### PR TITLE
Tasks times feature

### DIFF
--- a/docs/calendars/tasks-plugin-integration.md
+++ b/docs/calendars/tasks-plugin-integration.md
@@ -47,6 +47,33 @@ You can manage your tasks without ever leaving the calendar interface.
 
 All changes are synced back to the Tasks plugin in real-time.
 
+### Time Blocks
+
+You can schedule a task to a specific time—or a time range—by embedding a time block directly in the task's title. Full Calendar reads this block to position the task on the timed calendar view.
+
+In the calendar view, you can also drag and drop tasks between the "all day" area and the timed calendar view.
+
+**Supported formats:**
+
+| Format | Example | Result |
+|---|---|---|
+| Single time (24h) | `(14:30)` | Event starts at 2:30 PM |
+| Time range (24h) | `(9:00-10:30)` | Event from 9:00 AM to 10:30 AM |
+| Single time (12h) | `(2:30 PM)` | Event starts at 2:30 PM |
+| Time range (12h) | `(9:00 AM-10:30 AM)` | Event from 9:00 AM to 10:30 AM |
+
+A complete task line with a time block looks like this:
+
+```
+- [ ] Review meeting notes (14:00-15:00) ⏳ 2025-03-28
+```
+
+The time block is placed **before** the scheduled emoji (`⏳`) in the task description. When you drag a task to a time slot on the calendar, the time block is written back automatically. Editing the event start/end time from the calendar view will update the embedded time block in the markdown file in real time.
+
+!!! tip "Time Format Setting"
+    Full Calendar reads time blocks in both 12-hour and 24-hour format. It writes time blocks in
+    the format specified under **Settings → Appearance**.
+
 ### Advanced Parsing and Settings
 
 The integration is built with flexibility in mind.

--- a/src/core/interop.ts
+++ b/src/core/interop.ts
@@ -37,7 +37,13 @@ const parseTime = (time: string): Duration | null => {
     parsed = DateTime.fromFormat(time, 'HH:mm');
   }
   if (parsed.invalidReason) {
+    parsed = DateTime.fromFormat(time, 'H:mm');
+  }
+  if (parsed.invalidReason) {
     parsed = DateTime.fromFormat(time, 'HH:mm:ss');
+  }
+  if (parsed.invalidReason) {
+    parsed = DateTime.fromFormat(time, 'H:mm:ss');
   }
 
   if (parsed.invalidReason) {

--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -64,6 +64,56 @@ export function extractTimeFromTitle(title: string): {
   return { startTime: null, endTime: null, cleanTitle: title };
 }
 
+/**
+ * Updates or removes the time block `(H:MM)` or `(H:MM-H:MM)` embedded in a
+ * task's markdown line (i.e. inside the description, before metadata emojis).
+ *
+ * Pass `startTime = null` to strip the time block entirely (all-day).
+ * Pass `startTime` equal to `endTime` (or `endTime = null`) to write a
+ * single-time block `(H:MM)`.  Otherwise a range `(H:MM-H:MM)` is written.
+ *
+ * @param line      The full task markdown line (after date update).
+ * @param startTime New start time string (e.g. "9:00"), or null to remove.
+ * @param endTime   New end time string, or null for a single-time block.
+ * @returns The modified line.
+ */
+export function updateTimeInLine(
+  line: string,
+  startTime: string | null,
+  endTime: string | null
+): string {
+  // Strip any existing time block from the line
+  const timeBlockPattern = /\s*\(\d{1,2}:\d{2}(?:-\d{1,2}:\d{2})?\)/g;
+  let result = line.replace(timeBlockPattern, '');
+
+  if (startTime) {
+    const timeBlock =
+      endTime && endTime !== startTime
+        ? `(${startTime}-${endTime})`
+        : `(${startTime})`;
+
+    // Insert before the scheduled emoji ⏳ (guaranteed present after updateTaskLine).
+    const scheduledEmojiIdx = result.indexOf('⏳');
+    if (scheduledEmojiIdx !== -1) {
+      const before = result.slice(0, scheduledEmojiIdx).trimEnd();
+      const after = result.slice(scheduledEmojiIdx);
+      result = `${before} ${timeBlock} ${after}`;
+    } else {
+      // Fallback: insert before any block link, or append to end.
+      const blockLinkRegex = /(\s*\^[a-zA-Z0-9-]+)$/;
+      const blockLinkMatch = result.match(blockLinkRegex);
+      if (blockLinkMatch) {
+        const withoutBlockLink = result.replace(blockLinkRegex, '');
+        result = `${withoutBlockLink.trimEnd()} ${timeBlock}${blockLinkMatch[1]}`;
+      } else {
+        result = `${result.trimEnd()} ${timeBlock}`;
+      }
+    }
+  }
+
+  return result;
+}
+
 // This is our own internal, simplified interface for a task from the Tasks plugin's cache.
 // It prevents the need to import anything from the Tasks plugin itself.
 interface CalendarTask {
@@ -585,7 +635,12 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
     }
 
     const taskId = handle.persistentId;
-    await this._surgicallyUpdateTask(taskId, newDate);
+
+    // Extract time from the dropped event.  allDay → clear time block; timed → update it.
+    const startTime = newEvent.allDay ? null : newEvent.startTime;
+    const endTime = newEvent.allDay ? null : (newEvent.endTime ?? null);
+
+    await this._surgicallyUpdateTask(taskId, newDate, startTime, endTime);
     const [filePath, lineNumberStr] = taskId.split('::');
     return {
       file: { path: filePath },
@@ -606,15 +661,26 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
   /**
    * Centralized helper for surgically updating a task line in a file.
    * This is called by both updateEvent (for drags) and scheduleTask (for backlog drops).
-   * @param taskId The persistent ID of the task (filePath::lineNumber).
-   * @param newDate The new date to apply to the task.
+   * @param taskId    The persistent ID of the task (filePath::lineNumber).
+   * @param newDate   The new date to apply to the task.
+   * @param startTime New start time, null to clear, or undefined to leave unchanged.
+   * @param endTime   New end time, null to clear, or undefined to leave unchanged.
    */
-  private async _surgicallyUpdateTask(taskId: string, newDate: Date): Promise<void> {
+  private async _surgicallyUpdateTask(
+    taskId: string,
+    newDate: Date,
+    startTime?: string | null,
+    endTime?: string | null
+  ): Promise<void> {
     const task = this.allTasks.find(t => t.id === taskId);
     if (!task) {
       throw new Error(`Cannot find original task with ID ${taskId} to update.`);
     }
-    const newLine = this.updateTaskLine(task.originalMarkdown, newDate);
+    let newLine = this.updateTaskLine(task.originalMarkdown, newDate);
+    // Only update the time block when explicitly provided (undefined = no change).
+    if (startTime !== undefined) {
+      newLine = updateTimeInLine(newLine, startTime, endTime ?? null);
+    }
     await this.replaceTaskInFile(task.filePath, task.lineNumber, [newLine]);
   }
 

--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -39,9 +39,9 @@ export function extractTimeFromTitle(title: string): {
   endTime: string | null;
   cleanTitle: string;
 } {
-  // Match (HH:MM-HH:MM) or (HH:MM)
-  const timeRangePattern = /\((\d{2}:\d{2})-(\d{2}:\d{2})\)/;
-  const timePattern = /\((\d{2}:\d{2})\)/;
+  // Match (H:MM-H:MM) or (H:MM), allowing single or double-digit hours
+  const timeRangePattern = /\((\d{1,2}:\d{2})-(\d{1,2}:\d{2})\)/;
+  const timePattern = /\((\d{1,2}:\d{2})\)/;
 
   const rangeMatch = title.match(timeRangePattern);
   if (rangeMatch) {

--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -29,6 +29,41 @@ import { t } from '../../features/i18n/i18n';
 // CHANGE: Define Scheduled emoji instead of Due
 const getScheduledDateEmoji = (): string => '⏳';
 
+/**
+ * Extracts a time or time range from a task title.
+ * Matches patterns like (18:00) or (18:00-20:00) anywhere in the title.
+ * Returns { startTime, endTime, cleanTitle } where cleanTitle has the pattern removed.
+ */
+export function extractTimeFromTitle(title: string): {
+  startTime: string | null;
+  endTime: string | null;
+  cleanTitle: string;
+} {
+  // Match (HH:MM-HH:MM) or (HH:MM)
+  const timeRangePattern = /\((\d{2}:\d{2})-(\d{2}:\d{2})\)/;
+  const timePattern = /\((\d{2}:\d{2})\)/;
+
+  const rangeMatch = title.match(timeRangePattern);
+  if (rangeMatch) {
+    return {
+      startTime: rangeMatch[1],
+      endTime: rangeMatch[2],
+      cleanTitle: title.replace(rangeMatch[0], '').trim()
+    };
+  }
+
+  const singleMatch = title.match(timePattern);
+  if (singleMatch) {
+    return {
+      startTime: singleMatch[1],
+      endTime: null,
+      cleanTitle: title.replace(singleMatch[0], '').trim()
+    };
+  }
+
+  return { startTime: null, endTime: null, cleanTitle: title };
+}
+
 // This is our own internal, simplified interface for a task from the Tasks plugin's cache.
 // It prevents the need to import anything from the Tasks plugin itself.
 interface CalendarTask {
@@ -41,6 +76,8 @@ interface CalendarTask {
   filePath: string;
   lineNumber: number; // 1-based line number.
   isDone: boolean;
+  startTime: string | null; // HH:mm if a time pattern was found in the title
+  endTime: string | null; // HH:mm if a time range pattern was found in the title
 }
 
 interface TasksPluginTaskDate {
@@ -260,16 +297,27 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
       return null;
     }
 
-    const ofcEvent: OFCEvent = {
-      type: 'single',
-      title: task.title,
-      allDay: true,
-      date: DateTime.fromJSDate(primaryDate).toFormat('yyyy-MM-dd'), // MODIFIED
-      // FIX: Ensure tasks are never multi-day by setting endDate to null.
-      endDate: null,
-      completed: task.isDone ? DateTime.now().toISO() : false, // MODIFIED
-      uid: task.id // The UID is our persistent handle.
-    };
+    const ofcEvent: OFCEvent = task.startTime
+      ? {
+          type: 'single',
+          title: task.title,
+          allDay: false,
+          date: DateTime.fromJSDate(primaryDate).toFormat('yyyy-MM-dd'),
+          endDate: null,
+          startTime: task.startTime,
+          endTime: task.endTime ?? task.startTime,
+          completed: task.isDone ? DateTime.now().toISO() : false,
+          uid: task.id
+        }
+      : {
+          type: 'single',
+          title: task.title,
+          allDay: true,
+          date: DateTime.fromJSDate(primaryDate).toFormat('yyyy-MM-dd'),
+          endDate: null,
+          completed: task.isDone ? DateTime.now().toISO() : false,
+          uid: task.id
+        };
 
     const location: EventLocation = {
       file: { path: task.filePath },
@@ -397,10 +445,11 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
     // FIX: Use the stable, nested line number from taskLocation and convert to 1-based index.
     const calendarTasks = tasks.map((task, index) => {
       const oneBasedLineNumber = task.taskLocation.lineNumber + 1;
+      const { startTime, endTime, cleanTitle } = extractTimeFromTitle(task.description);
       return {
         // The ID must be based on the 0-indexed number to match the live-update diffing logic.
         id: `${task.path}::${task.taskLocation.lineNumber}`,
-        title: task.description,
+        title: cleanTitle,
         startDate: task.startDate ? task.startDate.toDate() : null,
         dueDate: task.dueDate ? task.dueDate.toDate() : null,
         scheduledDate: task.scheduledDate ? task.scheduledDate.toDate() : null,
@@ -408,7 +457,9 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
         filePath: task.path,
         // The internal lineNumber must be 1-based for surgical editing.
         lineNumber: oneBasedLineNumber,
-        isDone: task.isDone || !!task.doneDatez
+        isDone: task.isDone || !!task.doneDatez,
+        startTime,
+        endTime
       };
     });
 
@@ -421,28 +472,9 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
 
   async getEvents(range?: { start: Date; end: Date }): Promise<EditableEventResponse[]> {
     await this._ensureTasksCacheIsWarm();
-    const events: EditableEventResponse[] = [];
-    for (const task of this.allTasks) {
-      const primaryDate = task.scheduledDate;
-      if (primaryDate) {
-        const ofcEvent: OFCEvent = {
-          type: 'single',
-          title: task.title,
-          allDay: true,
-          date: DateTime.fromJSDate(primaryDate).toFormat('yyyy-MM-dd'), // MODIFIED
-          endDate: null,
-          completed: task.isDone ? DateTime.now().toISO() : false, // MODIFIED
-          uid: task.id
-        };
-
-        const location: EventLocation = {
-          file: { path: task.filePath },
-          lineNumber: task.lineNumber
-        };
-        events.push([ofcEvent, location]);
-      }
-    }
-    return events;
+    return this.allTasks
+      .map(task => this._taskToOFCEvent(task))
+      .filter((e): e is [OFCEvent, EventLocation | null] => e !== null);
   }
 
   // REPLACE getUndatedTasks with corrected logic
@@ -473,24 +505,8 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
 
     // REPLACE the for-loop with corrected date priority and single-day logic
     for (const task of tasksInFile) {
-      const primaryDate = task.scheduledDate || task.dueDate || task.startDate;
-      if (primaryDate) {
-        const ofcEvent: OFCEvent = {
-          type: 'single',
-          title: task.title,
-          allDay: true,
-          date: DateTime.fromJSDate(primaryDate).toFormat('yyyy-MM-dd'), // MODIFIED
-          endDate: null,
-          completed: task.isDone ? DateTime.now().toISO() : false, // MODIFIED
-          uid: task.id
-        };
-
-        const location: EventLocation = {
-          file: { path: task.filePath },
-          lineNumber: task.lineNumber
-        };
-        events.push([ofcEvent, location]);
-      }
+      const result = this._taskToOFCEvent(task);
+      if (result) events.push(result);
     }
     return Promise.resolve(events);
   }

--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -39,15 +39,21 @@ export function extractTimeFromTitle(title: string): {
   endTime: string | null;
   cleanTitle: string;
 } {
-  // Match (H:MM-H:MM) or (H:MM), allowing single or double-digit hours
-  const timeRangePattern = /\((\d{1,2}:\d{2})-(\d{1,2}:\d{2})\)/;
-  const timePattern = /\((\d{1,2}:\d{2})\)/;
+  // A single time token: H:MM or H:MM AM/PM (case-insensitive, optional space before meridiem).
+  const TIME_TOKEN = String.raw`\d{1,2}:\d{2}(?:\s*[AaPp][Mm])?`;
+  const timeRangePattern = new RegExp(`\\((${TIME_TOKEN})-(${TIME_TOKEN})\\)`);
+  const timePattern = new RegExp(`\\((${TIME_TOKEN})\\)`);
+
+  // Normalise a captured time token: ensure a single space + uppercase meridiem where present.
+  // e.g. "9:00am" → "9:00 AM", "14:30" → "14:30"
+  const normalise = (t: string) =>
+    t.replace(/\s*([AaPp][Mm])$/, (_, m: string) => ` ${m.toUpperCase()}`);
 
   const rangeMatch = title.match(timeRangePattern);
   if (rangeMatch) {
     return {
-      startTime: rangeMatch[1],
-      endTime: rangeMatch[2],
+      startTime: normalise(rangeMatch[1]),
+      endTime: normalise(rangeMatch[2]),
       cleanTitle: title.replace(rangeMatch[0], '').trim()
     };
   }
@@ -55,7 +61,7 @@ export function extractTimeFromTitle(title: string): {
   const singleMatch = title.match(timePattern);
   if (singleMatch) {
     return {
-      startTime: singleMatch[1],
+      startTime: normalise(singleMatch[1]),
       endTime: null,
       cleanTitle: title.replace(singleMatch[0], '').trim()
     };
@@ -65,32 +71,34 @@ export function extractTimeFromTitle(title: string): {
 }
 
 /**
- * Updates or removes the time block `(H:MM)` or `(H:MM-H:MM)` embedded in a
- * task's markdown line (i.e. inside the description, before metadata emojis).
+ * Updates or removes the time block `(H:MM)` / `(H:MM AM)` or their range forms
+ * embedded in a task's markdown line (i.e. inside the description, before metadata emojis).
  *
  * Pass `startTime = null` to strip the time block entirely (all-day).
  * Pass `startTime` equal to `endTime` (or `endTime = null`) to write a
- * single-time block `(H:MM)`.  Otherwise a range `(H:MM-H:MM)` is written.
+ * single-time block.  Otherwise a range is written.
  *
- * @param line      The full task markdown line (after date update).
- * @param startTime New start time string (e.g. "9:00"), or null to remove.
- * @param endTime   New end time string, or null for a single-time block.
+ * @param line          The full task markdown line (after date update).
+ * @param startTime     New start time in `HH:mm` (24h) format, or null to remove.
+ * @param endTime       New end time in `HH:mm` (24h) format, or null for a single-time block.
+ * @param timeFormat24h When true (default), write `H:MM`; when false write `H:MM AM/PM`.
  * @returns The modified line.
  */
 export function updateTimeInLine(
   line: string,
   startTime: string | null,
-  endTime: string | null
+  endTime: string | null,
+  timeFormat24h = true
 ): string {
-  // Strip any existing time block from the line
-  const timeBlockPattern = /\s*\(\d{1,2}:\d{2}(?:-\d{1,2}:\d{2})?\)/g;
+  // Strip any existing time block (24h or 12h) from the line.
+  const timeBlockPattern = /\s*\(\d{1,2}:\d{2}(?:\s*[AaPp][Mm])?(?:-\d{1,2}:\d{2}(?:\s*[AaPp][Mm])?)?\)/g;
   let result = line.replace(timeBlockPattern, '');
 
   if (startTime) {
-    const timeBlock =
-      endTime && endTime !== startTime
-        ? `(${startTime}-${endTime})`
-        : `(${startTime})`;
+    const fmt = (t: string) => formatTimeToken(t, timeFormat24h);
+    const fmtStart = fmt(startTime);
+    const fmtEnd = endTime && endTime !== startTime ? fmt(endTime) : null;
+    const timeBlock = fmtEnd ? `(${fmtStart}-${fmtEnd})` : `(${fmtStart})`;
 
     // Insert before the scheduled emoji ⏳ (guaranteed present after updateTaskLine).
     const scheduledEmojiIdx = result.indexOf('⏳');
@@ -112,6 +120,25 @@ export function updateTimeInLine(
   }
 
   return result;
+}
+
+/**
+ * Formats a time string token for embedding in a task title.
+ * Input is expected to be in `HH:mm` (24h) format as produced by `getTime()`.
+ * When `timeFormat24h` is false the output is formatted as `h:mm AM/PM`.
+ */
+function formatTimeToken(time: string, timeFormat24h: boolean): string {
+  if (timeFormat24h) {
+    // Normalise to H:MM (drop leading zero) for a clean, compact appearance.
+    const parsed = DateTime.fromFormat(time, 'HH:mm');
+    return parsed.isValid ? parsed.toFormat('H:mm') : time;
+  }
+  // 12h: "9:00 AM", "12:30 PM", etc.
+  const parsed =
+    DateTime.fromFormat(time, 'HH:mm').isValid
+      ? DateTime.fromFormat(time, 'HH:mm')
+      : DateTime.fromFormat(time, 'H:mm');
+  return parsed.isValid ? parsed.toFormat('h:mm a').toUpperCase() : time;
 }
 
 // This is our own internal, simplified interface for a task from the Tasks plugin's cache.
@@ -639,8 +666,9 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
     // Extract time from the dropped event.  allDay → clear time block; timed → update it.
     const startTime = newEvent.allDay ? null : newEvent.startTime;
     const endTime = newEvent.allDay ? null : (newEvent.endTime ?? null);
+    const timeFormat24h = this.plugin.settings.timeFormat24h;
 
-    await this._surgicallyUpdateTask(taskId, newDate, startTime, endTime);
+    await this._surgicallyUpdateTask(taskId, newDate, startTime, endTime, timeFormat24h);
     const [filePath, lineNumberStr] = taskId.split('::');
     return {
       file: { path: filePath },
@@ -661,16 +689,18 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
   /**
    * Centralized helper for surgically updating a task line in a file.
    * This is called by both updateEvent (for drags) and scheduleTask (for backlog drops).
-   * @param taskId    The persistent ID of the task (filePath::lineNumber).
-   * @param newDate   The new date to apply to the task.
-   * @param startTime New start time, null to clear, or undefined to leave unchanged.
-   * @param endTime   New end time, null to clear, or undefined to leave unchanged.
+   * @param taskId        The persistent ID of the task (filePath::lineNumber).
+   * @param newDate       The new date to apply to the task.
+   * @param startTime     New start time in HH:mm, null to clear, or undefined to leave unchanged.
+   * @param endTime       New end time in HH:mm, null to clear, or undefined to leave unchanged.
+   * @param timeFormat24h Whether to write times in 24h format (default true).
    */
   private async _surgicallyUpdateTask(
     taskId: string,
     newDate: Date,
     startTime?: string | null,
-    endTime?: string | null
+    endTime?: string | null,
+    timeFormat24h = true
   ): Promise<void> {
     const task = this.allTasks.find(t => t.id === taskId);
     if (!task) {
@@ -679,7 +709,7 @@ export class TasksPluginProvider implements CalendarProvider<TasksProviderConfig
     let newLine = this.updateTaskLine(task.originalMarkdown, newDate);
     // Only update the time block when explicitly provided (undefined = no change).
     if (startTime !== undefined) {
-      newLine = updateTimeInLine(newLine, startTime, endTime ?? null);
+      newLine = updateTimeInLine(newLine, startTime, endTime ?? null, timeFormat24h);
     }
     await this.replaceTaskInFile(task.filePath, task.lineNumber, [newLine]);
   }

--- a/src/providers/tasks/tests/TasksTimeExtraction.test.ts
+++ b/src/providers/tasks/tests/TasksTimeExtraction.test.ts
@@ -88,4 +88,43 @@ describe('extractTimeFromTitle', () => {
       cleanTitle: 'Meet at 18:00 for dinner'
     });
   });
+
+  // --- 12h AM/PM format ---
+
+  it('extracts a single 12h time with uppercase AM', () => {
+    expect(extractTimeFromTitle('Dentist (9:00 AM)')).toEqual({
+      startTime: '9:00 AM',
+      endTime: null,
+      cleanTitle: 'Dentist'
+    });
+  });
+
+  it('extracts a single 12h time with lowercase am (normalises to uppercase)', () => {
+    expect(extractTimeFromTitle('Yoga (7:30am)')).toEqual({
+      startTime: '7:30 AM',
+      endTime: null,
+      cleanTitle: 'Yoga'
+    });
+  });
+
+  it('extracts a 12h time range', () => {
+    expect(extractTimeFromTitle('Meeting (9:00 AM-5:00 PM)')).toEqual({
+      startTime: '9:00 AM',
+      endTime: '5:00 PM',
+      cleanTitle: 'Meeting'
+    });
+  });
+
+  it('normalises AM/PM to uppercase with a space even when no space was present', () => {
+    expect(extractTimeFromTitle('Standup (9:00AM-10:00AM)')).toEqual({
+      startTime: '9:00 AM',
+      endTime: '10:00 AM',
+      cleanTitle: 'Standup'
+    });
+  });
+
+  it('strips a 12h time pattern from the title', () => {
+    const { cleanTitle } = extractTimeFromTitle('Lunch (12:00 PM)');
+    expect(cleanTitle).toBe('Lunch');
+  });
 });

--- a/src/providers/tasks/tests/TasksTimeExtraction.test.ts
+++ b/src/providers/tasks/tests/TasksTimeExtraction.test.ts
@@ -57,6 +57,30 @@ describe('extractTimeFromTitle', () => {
     expect(cleanTitle).toBe('Dentist');
   });
 
+  it('extracts a single-digit hour time (H:MM)', () => {
+    expect(extractTimeFromTitle('Morning run (9:00)')).toEqual({
+      startTime: '9:00',
+      endTime: null,
+      cleanTitle: 'Morning run'
+    });
+  });
+
+  it('extracts a time range with single-digit hours (H:MM-H:MM)', () => {
+    expect(extractTimeFromTitle('Yoga class (8:00-9:30)')).toEqual({
+      startTime: '8:00',
+      endTime: '9:30',
+      cleanTitle: 'Yoga class'
+    });
+  });
+
+  it('extracts a mixed range with single and double-digit hours', () => {
+    expect(extractTimeFromTitle('Long meeting (9:00-10:30)')).toEqual({
+      startTime: '9:00',
+      endTime: '10:30',
+      cleanTitle: 'Long meeting'
+    });
+  });
+
   it('does not match partial time-like patterns without parentheses', () => {
     expect(extractTimeFromTitle('Meet at 18:00 for dinner')).toEqual({
       startTime: null,

--- a/src/providers/tasks/tests/TasksTimeExtraction.test.ts
+++ b/src/providers/tasks/tests/TasksTimeExtraction.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @file TasksTimeExtraction.test.ts
+ * @brief Tests for time pattern extraction from task titles.
+ */
+
+import { extractTimeFromTitle } from '../TasksPluginProvider';
+
+describe('extractTimeFromTitle', () => {
+  it('returns no time info for a plain title', () => {
+    expect(extractTimeFromTitle('Buy groceries')).toEqual({
+      startTime: null,
+      endTime: null,
+      cleanTitle: 'Buy groceries'
+    });
+  });
+
+  it('extracts a single time (HH:MM)', () => {
+    expect(extractTimeFromTitle('Team meeting (18:00)')).toEqual({
+      startTime: '18:00',
+      endTime: null,
+      cleanTitle: 'Team meeting'
+    });
+  });
+
+  it('extracts a time range (HH:MM-HH:MM)', () => {
+    expect(extractTimeFromTitle('Team meeting (18:00-20:00)')).toEqual({
+      startTime: '18:00',
+      endTime: '20:00',
+      cleanTitle: 'Team meeting'
+    });
+  });
+
+  it('handles time pattern at the start of title', () => {
+    expect(extractTimeFromTitle('(09:00-10:00) Morning standup')).toEqual({
+      startTime: '09:00',
+      endTime: '10:00',
+      cleanTitle: 'Morning standup'
+    });
+  });
+
+  it('handles time pattern in the middle of title', () => {
+    expect(extractTimeFromTitle('Call with (14:30-15:00) client')).toEqual({
+      startTime: '14:30',
+      endTime: '15:00',
+      cleanTitle: 'Call with client'
+    });
+  });
+
+  it('prefers the range pattern over single time when both formats could match', () => {
+    const result = extractTimeFromTitle('Event (10:00-11:00)');
+    expect(result.startTime).toBe('10:00');
+    expect(result.endTime).toBe('11:00');
+  });
+
+  it('strips the time pattern from the title', () => {
+    const { cleanTitle } = extractTimeFromTitle('Dentist (08:30)');
+    expect(cleanTitle).toBe('Dentist');
+  });
+
+  it('does not match partial time-like patterns without parentheses', () => {
+    expect(extractTimeFromTitle('Meet at 18:00 for dinner')).toEqual({
+      startTime: null,
+      endTime: null,
+      cleanTitle: 'Meet at 18:00 for dinner'
+    });
+  });
+});

--- a/src/providers/tasks/tests/TasksUpdateTimeInLine.test.ts
+++ b/src/providers/tasks/tests/TasksUpdateTimeInLine.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @file TasksUpdateTimeInLine.test.ts
+ * @brief Tests for updateTimeInLine — inserting, updating and removing time
+ *        blocks in task markdown lines.
+ */
+
+import { updateTimeInLine } from '../TasksPluginProvider';
+
+// A typical task line produced by updateTaskLine (⏳ is always present).
+const BASE = '- [ ] My task ⏳ 2024-06-15';
+const BASE_BLOCK = '- [ ] My task ⏳ 2024-06-15 ^abc123';
+const WITH_TIME = '- [ ] My task (9:00) ⏳ 2024-06-15';
+const WITH_RANGE = '- [ ] My task (9:00-10:30) ⏳ 2024-06-15';
+
+describe('updateTimeInLine', () => {
+  describe('inserting a time block', () => {
+    it('inserts a single time before ⏳ when no time was present', () => {
+      expect(updateTimeInLine(BASE, '9:00', null)).toBe(
+        '- [ ] My task (9:00) ⏳ 2024-06-15'
+      );
+    });
+
+    it('inserts a time range before ⏳ when no time was present', () => {
+      expect(updateTimeInLine(BASE, '9:00', '10:30')).toBe(
+        '- [ ] My task (9:00-10:30) ⏳ 2024-06-15'
+      );
+    });
+
+    it('preserves a block link when inserting time with no ⏳ fallback', () => {
+      // Simulate a line with no ⏳ but with a block link
+      const line = '- [ ] My task ^abc123';
+      expect(updateTimeInLine(line, '14:00', null)).toBe(
+        '- [ ] My task (14:00) ^abc123'
+      );
+    });
+  });
+
+  describe('updating an existing time block', () => {
+    it('replaces an existing single time with a new single time', () => {
+      expect(updateTimeInLine(WITH_TIME, '11:00', null)).toBe(
+        '- [ ] My task (11:00) ⏳ 2024-06-15'
+      );
+    });
+
+    it('replaces an existing single time with a new range', () => {
+      expect(updateTimeInLine(WITH_TIME, '11:00', '12:00')).toBe(
+        '- [ ] My task (11:00-12:00) ⏳ 2024-06-15'
+      );
+    });
+
+    it('replaces an existing range with a new range (resize)', () => {
+      expect(updateTimeInLine(WITH_RANGE, '9:00', '11:00')).toBe(
+        '- [ ] My task (9:00-11:00) ⏳ 2024-06-15'
+      );
+    });
+
+    it('replaces an existing range with a single time', () => {
+      expect(updateTimeInLine(WITH_RANGE, '9:00', '9:00')).toBe(
+        '- [ ] My task (9:00) ⏳ 2024-06-15'
+      );
+    });
+  });
+
+  describe('removing the time block (all-day drop)', () => {
+    it('removes a single time block when startTime is null', () => {
+      expect(updateTimeInLine(WITH_TIME, null, null)).toBe(
+        '- [ ] My task ⏳ 2024-06-15'
+      );
+    });
+
+    it('removes a time range when startTime is null', () => {
+      expect(updateTimeInLine(WITH_RANGE, null, null)).toBe(
+        '- [ ] My task ⏳ 2024-06-15'
+      );
+    });
+
+    it('is a no-op on a line that has no time block', () => {
+      expect(updateTimeInLine(BASE, null, null)).toBe(BASE);
+    });
+  });
+
+  describe('block link preservation', () => {
+    it('preserves a block link when adding a time', () => {
+      expect(updateTimeInLine(BASE_BLOCK, '8:00', '9:00')).toBe(
+        '- [ ] My task (8:00-9:00) ⏳ 2024-06-15 ^abc123'
+      );
+    });
+
+    it('preserves a block link when removing a time', () => {
+      const line = '- [ ] My task (9:00) ⏳ 2024-06-15 ^abc123';
+      expect(updateTimeInLine(line, null, null)).toBe(
+        '- [ ] My task ⏳ 2024-06-15 ^abc123'
+      );
+    });
+  });
+
+  describe('single-digit hour support', () => {
+    it('handles single-digit start and end hours', () => {
+      expect(updateTimeInLine(BASE, '8:00', '9:30')).toBe(
+        '- [ ] My task (8:00-9:30) ⏳ 2024-06-15'
+      );
+    });
+
+    it('replaces a single-digit hour time block', () => {
+      const line = '- [ ] My task (8:00) ⏳ 2024-06-15';
+      expect(updateTimeInLine(line, '9:00', null)).toBe(
+        '- [ ] My task (9:00) ⏳ 2024-06-15'
+      );
+    });
+  });
+});

--- a/src/providers/tasks/tests/TasksUpdateTimeInLine.test.ts
+++ b/src/providers/tasks/tests/TasksUpdateTimeInLine.test.ts
@@ -1,7 +1,7 @@
 /**
  * @file TasksUpdateTimeInLine.test.ts
  * @brief Tests for updateTimeInLine — inserting, updating and removing time
- *        blocks in task markdown lines.
+ *        blocks in task markdown lines, in both 24h and 12h modes.
  */
 
 import { updateTimeInLine } from '../TasksPluginProvider';
@@ -11,8 +11,10 @@ const BASE = '- [ ] My task ⏳ 2024-06-15';
 const BASE_BLOCK = '- [ ] My task ⏳ 2024-06-15 ^abc123';
 const WITH_TIME = '- [ ] My task (9:00) ⏳ 2024-06-15';
 const WITH_RANGE = '- [ ] My task (9:00-10:30) ⏳ 2024-06-15';
+const WITH_TIME_12H = '- [ ] My task (9:00 AM) ⏳ 2024-06-15';
+const WITH_RANGE_12H = '- [ ] My task (9:00 AM-5:00 PM) ⏳ 2024-06-15';
 
-describe('updateTimeInLine', () => {
+describe('updateTimeInLine (24h mode, default)', () => {
   describe('inserting a time block', () => {
     it('inserts a single time before ⏳ when no time was present', () => {
       expect(updateTimeInLine(BASE, '9:00', null)).toBe(
@@ -27,7 +29,6 @@ describe('updateTimeInLine', () => {
     });
 
     it('preserves a block link when inserting time with no ⏳ fallback', () => {
-      // Simulate a line with no ⏳ but with a block link
       const line = '- [ ] My task ^abc123';
       expect(updateTimeInLine(line, '14:00', null)).toBe(
         '- [ ] My task (14:00) ^abc123'
@@ -59,6 +60,18 @@ describe('updateTimeInLine', () => {
         '- [ ] My task (9:00) ⏳ 2024-06-15'
       );
     });
+
+    it('replaces a 12h time block with a 24h time block', () => {
+      expect(updateTimeInLine(WITH_TIME_12H, '09:00', null, true)).toBe(
+        '- [ ] My task (9:00) ⏳ 2024-06-15'
+      );
+    });
+
+    it('replaces a 12h range with a 24h range', () => {
+      expect(updateTimeInLine(WITH_RANGE_12H, '09:00', '17:00', true)).toBe(
+        '- [ ] My task (9:00-17:00) ⏳ 2024-06-15'
+      );
+    });
   });
 
   describe('removing the time block (all-day drop)', () => {
@@ -70,6 +83,18 @@ describe('updateTimeInLine', () => {
 
     it('removes a time range when startTime is null', () => {
       expect(updateTimeInLine(WITH_RANGE, null, null)).toBe(
+        '- [ ] My task ⏳ 2024-06-15'
+      );
+    });
+
+    it('removes a 12h time block when startTime is null', () => {
+      expect(updateTimeInLine(WITH_TIME_12H, null, null)).toBe(
+        '- [ ] My task ⏳ 2024-06-15'
+      );
+    });
+
+    it('removes a 12h range when startTime is null', () => {
+      expect(updateTimeInLine(WITH_RANGE_12H, null, null)).toBe(
         '- [ ] My task ⏳ 2024-06-15'
       );
     });
@@ -105,6 +130,64 @@ describe('updateTimeInLine', () => {
       const line = '- [ ] My task (8:00) ⏳ 2024-06-15';
       expect(updateTimeInLine(line, '9:00', null)).toBe(
         '- [ ] My task (9:00) ⏳ 2024-06-15'
+      );
+    });
+  });
+});
+
+describe('updateTimeInLine (12h mode)', () => {
+  const use12h = false; // timeFormat24h = false
+
+  describe('inserting a 12h time block', () => {
+    it('inserts a 12h single time before ⏳', () => {
+      expect(updateTimeInLine(BASE, '09:00', null, use12h)).toBe(
+        '- [ ] My task (9:00 AM) ⏳ 2024-06-15'
+      );
+    });
+
+    it('inserts a 12h range before ⏳', () => {
+      expect(updateTimeInLine(BASE, '09:00', '17:00', use12h)).toBe(
+        '- [ ] My task (9:00 AM-5:00 PM) ⏳ 2024-06-15'
+      );
+    });
+
+    it('formats noon correctly', () => {
+      expect(updateTimeInLine(BASE, '12:00', null, use12h)).toBe(
+        '- [ ] My task (12:00 PM) ⏳ 2024-06-15'
+      );
+    });
+
+    it('formats midnight correctly', () => {
+      expect(updateTimeInLine(BASE, '00:00', null, use12h)).toBe(
+        '- [ ] My task (12:00 AM) ⏳ 2024-06-15'
+      );
+    });
+  });
+
+  describe('replacing an existing time block with 12h output', () => {
+    it('replaces a 24h time block with a 12h block', () => {
+      expect(updateTimeInLine(WITH_TIME, '09:00', null, use12h)).toBe(
+        '- [ ] My task (9:00 AM) ⏳ 2024-06-15'
+      );
+    });
+
+    it('replaces a 12h time block with an updated 12h block', () => {
+      expect(updateTimeInLine(WITH_TIME_12H, '10:00', null, use12h)).toBe(
+        '- [ ] My task (10:00 AM) ⏳ 2024-06-15'
+      );
+    });
+  });
+
+  describe('removing a 12h time block', () => {
+    it('removes a 12h single time when startTime is null', () => {
+      expect(updateTimeInLine(WITH_TIME_12H, null, null)).toBe(
+        '- [ ] My task ⏳ 2024-06-15'
+      );
+    });
+
+    it('removes a 12h range when startTime is null', () => {
+      expect(updateTimeInLine(WITH_RANGE_12H, null, null)).toBe(
+        '- [ ] My task ⏳ 2024-06-15'
       );
     });
   });


### PR DESCRIPTION
This adds the option to add a time block to an Obsidian task, and drag-drop tasks in the calendar.

- The time block is formatted as `(H:MM)` (defaulting to 1 hour) or `(H:MM-H:MM)`. It reads both 12-hour (am/pm) and 24-hour formats, and writes back according to the user's preference.
- It is possible to drag and drop a task to a different time, and back and forth from the all-day section.
- It updates the documentation.