### PR TITLE
Fix CalDAV ICS serialization of timed event timezones

### DIFF
--- a/src/providers/ics/formatter.ts
+++ b/src/providers/ics/formatter.ts
@@ -3,31 +3,66 @@ import ical from 'ical.js';
 import { DateTime } from 'luxon';
 
 /**
- * Formats a Luxon DateTime into an iCal DATE-TIME string (YYYYMMDDTHHMMSSZ or local).
- * @param dt The DateTime to format
- * @param isAllDay Whether this is an all-day event
+ * Formats a Luxon DateTime into an iCal Time value.
+ *
+ * Important:
+ * - All-day events are DATE values.
+ * - UTC events are represented with a trailing Z.
+ * - Non-UTC timed events need TZID on the iCalendar property itself,
+ *   which is handled by addDateTimeProperty().
  */
 function formatDateTime(dt: DateTime, isAllDay: boolean): ical.Time {
-  const time = new ical.Time({
+  const data: {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+    isDate: boolean;
+    timezone?: string;
+  } = {
     year: dt.year,
     month: dt.month,
     day: dt.day,
-    hour: dt.hour,
-    minute: dt.minute,
-    second: dt.second,
-    isDate: isAllDay
-  });
+    hour: isAllDay ? 0 : dt.hour,
+    minute: isAllDay ? 0 : dt.minute,
+    second: isAllDay ? 0 : dt.second,
+    isDate: isAllDay,
+  };
 
-  if (!isAllDay) {
-    if (dt.zoneName === 'UTC') {
-      time.timezone = 'Z';
-    } else {
-      // ical.js Time handles timezones via the `zone` property (string identifier) or `timezone` (object).
-      // We use `zone` for the string identifier.
-      time.timezone = dt.zoneName || 'Z';
-    }
+  if (!isAllDay && dt.zoneName === 'UTC') {
+    data.timezone = 'Z';
   }
-  return time;
+
+  return new ical.Time(data);
+}
+
+/**
+ * Adds a DATE / DATE-TIME property to an iCalendar component.
+ *
+ * This explicitly sets TZID for non-UTC timed events, preventing CalDAV
+ * servers from treating the value as floating time.
+ */
+function addDateTimeProperty(
+  component: ical.Component,
+  name: string,
+  dt: DateTime,
+  isAllDay: boolean
+) {
+  const prop = new ical.Property(name);
+  const time = formatDateTime(dt, isAllDay);
+
+  if (isAllDay) {
+    prop.setParameter('VALUE', 'DATE');
+  } else if (dt.zoneName === 'UTC') {
+    // UTC is represented by the trailing Z on the value.
+  } else if (dt.zoneName) {
+    prop.setParameter('TZID', dt.zoneName);
+  }
+
+  prop.setValue(time);
+  component.addProperty(prop);
 }
 
 /**
@@ -66,6 +101,7 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
 
   if (event.allDay) {
     startDt = DateTime.fromISO(datePart);
+
     if (event.type === 'single' && event.endDate) {
       endDt = DateTime.fromISO(event.endDate).plus({ days: 1 });
     } else {
@@ -73,7 +109,6 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
       endDt = startDt.plus({ days: 1 });
     }
   } else {
-    // Not all day
     const startTime = (event as unknown as { startTime?: string }).startTime || '00:00';
     const endTime = (event as unknown as { endTime?: string }).endTime || '00:00';
     const opts = event.timezone ? { zone: event.timezone } : {};
@@ -84,14 +119,15 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
       endDt = DateTime.fromISO(`${event.endDate}T${endTime}`, opts);
     } else {
       endDt = DateTime.fromISO(`${datePart}T${endTime}`, opts);
+
       if (endDt < startDt) {
         endDt = endDt.plus({ days: 1 });
       }
     }
   }
 
-  vevent.addPropertyWithValue('dtstart', formatDateTime(startDt, event.allDay));
-  vevent.addPropertyWithValue('dtend', formatDateTime(endDt, event.allDay));
+  addDateTimeProperty(vevent, 'dtstart', startDt, event.allDay);
+  addDateTimeProperty(vevent, 'dtend', endDt, event.allDay);
 
   // Description
   if (event.description) {
@@ -105,6 +141,7 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
       const recur = (ical.Recur as unknown as { fromString?: (s: string) => unknown }).fromString
         ? (ical.Recur as unknown as { fromString: (s: string) => unknown }).fromString(ruleStr)
         : null;
+
       if (recur) {
         vevent.addPropertyWithValue('rrule', recur);
       } else {
@@ -125,17 +162,16 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
     event.skipDates.length > 0
   ) {
     for (const skipDate of event.skipDates) {
-      let exTime: ical.Time;
       if (event.allDay) {
         const dt = DateTime.fromISO(skipDate);
-        exTime = new ical.Time({ year: dt.year, month: dt.month, day: dt.day, isDate: true });
+        addDateTimeProperty(vevent, 'exdate', dt, true);
       } else {
         const startTime = (event as unknown as { startTime?: string }).startTime || '00:00';
         const opts = event.timezone ? { zone: event.timezone } : {};
         const dt = DateTime.fromISO(`${skipDate}T${startTime}`, opts);
-        exTime = formatDateTime(dt, false);
+
+        addDateTimeProperty(vevent, 'exdate', dt, false);
       }
-      vevent.addPropertyWithValue('exdate', exTime);
     }
   }
 
@@ -147,6 +183,7 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
  */
 export function eventToIcs(event: OFCEvent): string {
   const component = new ical.Component('vcalendar');
+
   component.addPropertyWithValue('version', '2.0');
   component.addPropertyWithValue('prodid', '-//Obsidian Full Calendar Plugin//NONSGML v1.0//EN');
 
@@ -158,44 +195,25 @@ export function eventToIcs(event: OFCEvent): string {
 
 /**
  * Creates a VEVENT component for an instance override.
+ *
  * @param event The new event data for the specific instance.
- * @param originalDate The original start date/time of the instance being modified (ISO string).
+ * @param originalDate The original start date/time of the instance being modified.
  */
 export function createOverrideVEvent(event: OFCEvent, originalDate: string): ical.Component {
-  // 1. Create the base VEVENT with new data
   const vevent = createVEventComponent(event, true);
 
-  // 2. Add RECURRENCE-ID
-  // The originalDate argument should be ISO. We need to parse it to ical.Time.
-  // Assuming originalDate came from the event's original start time.
-
-  // We need to know if the original was all-day or not to format RECURRENCE-ID correctly.
-  // Usually overrides match the type of the original, but can change.
-  // RECURRENCE-ID should match the PATTERN of the master event's DTSTART (Date or DateTime).
-  // For now, let's infer from the passed date string or event.allDay.
-
-  // If originalDate is just YYYY-MM-DD, treat as Date.
+  // If originalDate is just YYYY-MM-DD, treat it as DATE.
   const isDate = originalDate.length === 10;
-  let recurIdTime: ical.Time;
 
   if (isDate) {
     const dt = DateTime.fromISO(originalDate);
-    recurIdTime = new ical.Time({ year: dt.year, month: dt.month, day: dt.day, isDate: true });
+    addDateTimeProperty(vevent, 'recurrence-id', dt, true);
   } else {
-    // Assume DateTime string
-    const dt = DateTime.fromISO(originalDate);
-    recurIdTime = formatDateTime(dt, false);
-    // Important: RECURRENCE-ID must match the timezone of the original DTSTART if it wasn't UTC.
-    // If we don't have that info easily, we might struggle.
-    // But usually standard is to use the same zone or UTC.
-    // Let's hope basic formatting works.
+    const opts = event.timezone ? { zone: event.timezone } : {};
+    const dt = DateTime.fromISO(originalDate, opts);
+
+    addDateTimeProperty(vevent, 'recurrence-id', dt, false);
   }
-
-  vevent.addPropertyWithValue('recurrence-id', recurIdTime);
-
-  // 3. Ensure SEQUENCE is incremented?
-  // Usually the server handles sequence or client should increment.
-  // We'll leave it for now.
 
   return vevent;
 }


### PR DESCRIPTION
CalDAV write-back could serialize timed events as local DATE-TIME values without either a TZID parameter or a UTC `Z` suffix. For example, an event created with the plugin display timezone set to Europe/Amsterdam could be written as:

    DTSTART:20260520T100000
    DTEND:20260520T110000

That value is floating time in iCalendar terms. In practice, Nextcloud can store/show the event as floating, and after FCR reloads or resyncs the calendar the event can be interpreted with the wrong offset and shift by two hours.

This changes the ICS formatter to create date/time properties explicitly instead of relying on addPropertyWithValue() for timezone-aware values. The new helper writes:

- all-day events as DATE values
- UTC timed events as DATE-TIME values with the trailing `Z`
- non-UTC timed events with a property-level TZID parameter, e.g. `DTSTART;TZID=Europe/Amsterdam:20260520T100000`

The helper is now used consistently for DTSTART, DTEND, EXDATE, and RECURRENCE-ID so normal events, recurring exclusions, and recurrence overrides use the same timezone serialization behavior.

Fixes [#265](https://github.com/obsidian-full-calendar-remastered/plugin-full-calendar/issues/265).