### PR TITLE
Fixed TaskNotes duration token title parsing. 

### DIFF
--- a/src/providers/tasknotes/TaskNotesProvider.ts
+++ b/src/providers/tasknotes/TaskNotesProvider.ts
@@ -340,7 +340,7 @@ export class TaskNotesProvider
     if (normalizedEnd) {
       const minutes = this.computeMinutes(normalizedStart, normalizedEnd);
       if (minutes && minutes > 0) {
-        durationToken = ` for ${minutes}m`;
+        durationToken = ` ${minutes}m`;
       }
     }
 


### PR DESCRIPTION
The previous use of the word 'for' is no longer required and causes malformed titles to be created. Removing the 'for' word creates properly named titles if created through the calendar view.

<img width="741" height="783" alt="image" src="https://github.com/user-attachments/assets/a6e7faf6-b8ad-46d0-9849-d535fd61935a" />