### PR TITLE
Fix duplicate linked notes for remote calendar events

### DIFF
--- a/src/core/TimeEngine.test.ts
+++ b/src/core/TimeEngine.test.ts
@@ -1,0 +1,75 @@
+import { DateTime, Settings } from 'luxon';
+import { TimeEngine } from './TimeEngine';
+import type EventCache from './EventCache';
+import type { OFCEvent } from '../types';
+
+function createTimeEngine(events: { id: string; event: OFCEvent }[]): TimeEngine {
+  const cache = {
+    store: {
+      getAllEvents: () => events.map(({ id, event }) => ({ id, event, location: null }))
+    },
+    broadcastTimeTick: jest.fn()
+  } as unknown as EventCache;
+
+  return new TimeEngine(cache);
+}
+
+describe('TimeEngine', () => {
+  afterEach(() => {
+    Settings.now = () => Date.now();
+  });
+
+  it('builds timed single event occurrences in the event source timezone', async () => {
+    Settings.now = () => Date.parse('2026-06-15T11:00:00.000Z');
+
+    const event = {
+      type: 'single',
+      title: 'New York meeting',
+      date: '2026-06-15',
+      startTime: '10:00',
+      endTime: '11:00',
+      timezone: 'America/New_York',
+      allDay: false,
+      endDate: null
+    } as OFCEvent;
+
+    const engine = createTimeEngine([{ id: 'evt-1', event }]);
+    const rebuildOccurrenceCache = (
+      engine as unknown as { rebuildOccurrenceCache: () => Promise<void> }
+    ).rebuildOccurrenceCache.bind(engine);
+    await rebuildOccurrenceCache();
+
+    const occurrence = engine.getOccurrenceCache()[0];
+    expect(occurrence).toBeDefined();
+    expect(occurrence.start.toUTC().toISO()).toBe('2026-06-15T14:00:00.000Z');
+    expect(occurrence.end.toUTC().toISO()).toBe('2026-06-15T15:00:00.000Z');
+  });
+
+  it('builds timed rrule event occurrences from the timed source timezone start', async () => {
+    Settings.now = () => Date.parse('2026-06-15T11:00:00.000Z');
+
+    const event = {
+      type: 'rrule',
+      title: 'Recurring New York meeting',
+      startDate: '2026-06-15',
+      startTime: '10:00',
+      endTime: '11:00',
+      timezone: 'America/New_York',
+      allDay: false,
+      endDate: null,
+      rrule: 'RRULE:FREQ=DAILY;COUNT=1',
+      skipDates: []
+    } as OFCEvent;
+
+    const engine = createTimeEngine([{ id: 'evt-rrule-1', event }]);
+    const rebuildOccurrenceCache = (
+      engine as unknown as { rebuildOccurrenceCache: () => Promise<void> }
+    ).rebuildOccurrenceCache.bind(engine);
+    await rebuildOccurrenceCache();
+
+    const occurrence = engine.getOccurrenceCache()[0];
+    expect(occurrence).toBeDefined();
+    expect(occurrence.start.toUTC().toISO()).toBe('2026-06-15T14:00:00.000Z');
+    expect(occurrence.end.toUTC().toISO()).toBe('2026-06-15T15:00:00.000Z');
+  });
+});

--- a/src/core/TimeEngine.ts
+++ b/src/core/TimeEngine.ts
@@ -39,6 +39,29 @@ const CHECK_INTERVAL_MS = 60 * 1000; // Check every minute
 const OCCURRENCE_CACHE_LOOKAHEAD = { days: 7 }; // Pre-calculate occurrences for the next 7 days.
 const MAX_OCCURRENCES = 100; // Max number of occurrences to cache to prevent performance issues.
 
+const parseEventDateTime = (date: string, time?: string, timezone?: string): DateTime => {
+  const dateTimeString = time ? `${date}T${time}` : date;
+  if (!timezone) {
+    return DateTime.fromISO(dateTimeString);
+  }
+
+  const zone = timezone === 'Z' || timezone.toLowerCase() === 'utc' ? 'utc' : timezone;
+  const zoned = DateTime.fromISO(dateTimeString, { zone });
+  return zoned.isValid ? zoned : DateTime.fromISO(dateTimeString);
+};
+
+const parseRecurringStart = (event: Extract<OFCEvent, { type: 'rrule' }>): DateTime => {
+  if (event.startDate.includes('T')) {
+    return parseEventDateTime(event.startDate, undefined, event.timezone);
+  }
+
+  return parseEventDateTime(
+    event.startDate,
+    event.allDay ? undefined : event.startTime,
+    event.allDay ? undefined : event.timezone
+  );
+};
+
 // ============== CLASS DEFINITION ==============
 
 export class TimeEngine {
@@ -142,12 +165,6 @@ export class TimeEngine {
       const now = DateTime.now();
       const lookaheadEnd = now.plus(OCCURRENCE_CACHE_LOOKAHEAD);
 
-      // Helper moved here so it is in scope for all usages below.
-      const fromISO = (date: string, time?: string) => {
-        const dateTimeString = time ? `${date}T${time}` : date;
-        return DateTime.fromISO(dateTimeString);
-      };
-
       for (const storedEvent of allStoredEvents) {
         const { id, event, location: pathLocation } = storedEvent; // RENAMED
         // TRANSFORM to EventLocation shape expected by subscribers
@@ -160,16 +177,16 @@ export class TimeEngine {
 
         if (event.type === 'single') {
           if (event.allDay) {
-            const start = fromISO(event.date).startOf('day');
-            const end = fromISO(event.endDate || event.date).endOf('day');
+            const start = parseEventDateTime(event.date).startOf('day');
+            const end = parseEventDateTime(event.endDate || event.date).endOf('day');
             if (end >= now) {
               newOccurrences.push({ id, event, location, start, end });
             }
           } else {
-            const start = fromISO(event.date, event.startTime);
+            const start = parseEventDateTime(event.date, event.startTime, event.timezone);
             if (!start.isValid) continue;
             const end = event.endTime
-              ? fromISO(event.endDate || event.date, event.endTime)
+              ? parseEventDateTime(event.endDate || event.date, event.endTime, event.timezone)
               : start.plus({ hours: 1 });
             if (end >= now) {
               newOccurrences.push({ id, event, location, start, end });
@@ -180,14 +197,13 @@ export class TimeEngine {
           try {
             let dtstart: Date;
             if (event.type === 'rrule') {
-              // startDate may already contain time+offset (from timezone conversion),
-              // so parse it directly without appending startTime.
-              const dt = DateTime.fromISO(event.startDate);
+              const dt = parseRecurringStart(event);
               dtstart = dt.isValid ? dt.toJSDate() : new Date(event.startDate);
             } else {
-              dtstart = fromISO(
+              dtstart = parseEventDateTime(
                 event.startRecur || '1970-01-01',
-                event.allDay ? undefined : event.startTime
+                event.allDay ? undefined : event.startTime,
+                event.allDay ? undefined : event.timezone
               ).toJSDate();
             }
 
@@ -214,7 +230,7 @@ export class TimeEngine {
                 }
               }
               if (event.endRecur) {
-                ruleOptions.until = fromISO(event.endRecur).endOf('day').toJSDate();
+                ruleOptions.until = parseEventDateTime(event.endRecur).endOf('day').toJSDate();
               }
             } else {
               const parsed = rrulestr(event.rrule);

--- a/src/features/linked-notes/linkedNotes.ts
+++ b/src/features/linked-notes/linkedNotes.ts
@@ -15,7 +15,55 @@ import { replaceFrontmatter } from '../../providers/fullnote/frontmatter';
 import FullCalendarPlugin from '../../main';
 
 /**
- * Centrally creates a linked note for a remote event, ensuring absolute DRY behavior and zero hardcoded English strings.
+ * Return stable linked-note lookup keys for an event.
+ *
+ * Prefer uid because this is the existing linked-note frontmatter contract
+ * and because current providers already query LinkedNoteIndex by uid.
+ *
+ * Fall back to id for providers/events that expose a more specific internal id,
+ * such as parsed ICS/CalDAV recurring events.
+ */
+function getLinkedNoteKeys(event: OFCEvent): string[] {
+  const candidates = [event.uid, event.id];
+
+  return candidates
+    .filter((value): value is string => typeof value === 'string' && value.trim() !== '')
+    .map(value => value.trim())
+    .filter((value, index, arr) => arr.indexOf(value) === index);
+}
+
+function getPrimaryLinkedNoteKey(event: OFCEvent): string | null {
+  return getLinkedNoteKeys(event)[0] || null;
+}
+
+function getExistingLinkedNote(
+  linkedNoteIndex: LinkedNoteIndex,
+  event: OFCEvent
+): TFile | null {
+  for (const key of getLinkedNoteKeys(event)) {
+    const existingFile = linkedNoteIndex.getFileForEvent(key);
+    if (existingFile) {
+      return existingFile;
+    }
+  }
+
+  return null;
+}
+
+function registerLinkedNoteKeys(
+  linkedNoteIndex: LinkedNoteIndex,
+  event: OFCEvent,
+  file: TFile
+): void {
+  const keys = getLinkedNoteKeys(event);
+
+  keys.forEach((key, index) => {
+    linkedNoteIndex.setFileForEvent(key, file, index === 0);
+  });
+}
+
+/**
+ * Centrally creates a linked note for a remote event.
  */
 export async function createLinkedNoteForProvider({
   app,
@@ -30,9 +78,16 @@ export async function createLinkedNoteForProvider({
   calendarName: string;
   linkedNoteIndex: LinkedNoteIndex;
 }): Promise<TFile | null> {
-  const existingFile = linkedNoteIndex.getFileForEvent(event.uid || '');
+  const existingFile = getExistingLinkedNote(linkedNoteIndex, event);
   if (existingFile) {
     return existingFile;
+  }
+
+  const primaryLinkedNoteKey = getPrimaryLinkedNoteKey(event);
+  if (!primaryLinkedNoteKey) {
+    console.warn('Full Calendar: Cannot create linked note for event without uid or id.', event);
+    showNotice(t('notices.failedToCreateLinkedNote'));
+    return null;
   }
 
   const settings = PluginState.getSettings();
@@ -46,12 +101,11 @@ export async function createLinkedNoteForProvider({
   const bodyContent = TemplateEngine.render(template, event, calendarName);
 
   const frontmatter = {
-    'fc-event-uid': event.uid,
+    'fc-event-uid': primaryLinkedNoteKey,
     'fc-calendar-id': calendarId
   };
 
   const yaml = serializeFrontmatter(frontmatter);
-  // Smart reuse of FullNote's replaceFrontmatter utility
   const fileContent = replaceFrontmatter(bodyContent, yaml);
 
   const baseFilename = sanitizeTitleForFilename(event.title || t('linkedNotes.untitledNote'));
@@ -59,6 +113,11 @@ export async function createLinkedNoteForProvider({
   const uniquePath = findUniquePath(appAdapter, directory, baseFilename);
 
   const file = await appAdapter.create(uniquePath, fileContent);
+
+  // Critical fix:
+  // Do not wait for metadataCache.on("changed") before the note can be found again.
+  registerLinkedNoteKeys(linkedNoteIndex, event, file);
+
   return file;
 }
 
@@ -76,21 +135,20 @@ export async function openOrCreateLinkedNote(
     linkedNoteIndex?: LinkedNoteIndex;
     createLinkedNote?: (event: OFCEvent) => Promise<TFile | null>;
   };
+
   if (!linkedNoteProvider) {
     showNotice(t('notices.cannotOpenRemote'));
     return;
   }
 
-  // 1. Check if a directory is set
   const settings = PluginState.getSettings();
   if (!settings.linkedNotesDirectory) {
     showNotice(t('notices.configureLinkedNotesDirFirst'));
     return;
   }
 
-  // 2. Check if note already exists
   if (linkedNoteProvider.linkedNoteIndex) {
-    const existingFile = linkedNoteProvider.linkedNoteIndex.getFileForEvent(event.uid || '');
+    const existingFile = getExistingLinkedNote(linkedNoteProvider.linkedNoteIndex, event);
     if (existingFile) {
       const leaf = plugin.app.workspace.getLeaf(openInNewLeaf);
       await leaf.openFile(existingFile);
@@ -98,7 +156,6 @@ export async function openOrCreateLinkedNote(
     }
   }
 
-  // 3. Otherwise create a new note
   if (typeof linkedNoteProvider.createLinkedNote === 'function') {
     try {
       const file = await linkedNoteProvider.createLinkedNote(event);

--- a/src/providers/ics/ics.test.ts
+++ b/src/providers/ics/ics.test.ts
@@ -322,6 +322,36 @@ END:VCALENDAR`;
     expect(task).toHaveProperty('endTime', '11:00');
   });
 
+  it('does not parse an unscheduled VTODO task as a calendar event', () => {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-unscheduled-1
+SUMMARY:Unscheduled Task
+DTSTAMP:20260520T100000Z
+CREATED:20260520T100000Z
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`;
+
+    const events = getEventsFromICS(ics);
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not default an undated VTODO task to the current date', () => {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-undated-1
+SUMMARY:Undated Task
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`;
+
+    const events = getEventsFromICS(ics);
+    expect(events).toHaveLength(0);
+  });
+
   it('parses recurring VTODO task', () => {
     const ics = `BEGIN:VCALENDAR
 VERSION:2.0

--- a/src/providers/ics/ics.ts
+++ b/src/providers/ics/ics.ts
@@ -215,52 +215,18 @@ function todoToOFC(todo: ical.Component): OFCEvent | null {
   const dueProp = todo.getFirstProperty('due');
   const due: ical.Time | null = dueProp ? dueProp.getFirstValue() : null;
 
-  // Find a baseline ical.Time for the date field
-  let baseTime: ical.Time | null = dtstart || due;
-  let hasValidBaseTime = false;
+  const dtstartDate = dtstart ? parseTimezoneAwareString(dtstart) : null;
+  const dueDate = due ? parseTimezoneAwareString(due) : null;
+  const hasValidDtstart = !!dtstartDate?.isValid;
+  const hasValidDue = !!dueDate?.isValid;
 
-  let startDate: DateTime | null = null;
-  if (baseTime) {
-    startDate = parseTimezoneAwareString(baseTime);
-    if (startDate.isValid) {
-      hasValidBaseTime = true;
-    }
-  }
+  // VTODO CREATED/DTSTAMP describe metadata, not scheduling. Without DTSTART or
+  // DUE, the task has no calendar placement and should not render as an event.
+  const baseTime: ical.Time | null = hasValidDtstart ? dtstart : hasValidDue ? due : null;
+  const startDate: DateTime | null = hasValidDtstart ? dtstartDate : hasValidDue ? dueDate : null;
 
-  if (!hasValidBaseTime) {
-    // Try dtstamp or created
-    const dtstampProp = todo.getFirstProperty('dtstamp');
-    const dtstamp: ical.Time | null = dtstampProp ? dtstampProp.getFirstValue() : null;
-    if (dtstamp) {
-      startDate = parseTimezoneAwareString(dtstamp);
-      if (startDate.isValid) {
-        baseTime = dtstamp;
-        hasValidBaseTime = true;
-      }
-    }
-  }
-
-  if (!hasValidBaseTime) {
-    const createdProp = todo.getFirstProperty('created');
-    const created: ical.Time | null = createdProp ? createdProp.getFirstValue() : null;
-    if (created) {
-      startDate = parseTimezoneAwareString(created);
-      if (startDate.isValid) {
-        baseTime = created;
-        hasValidBaseTime = true;
-      }
-    }
-  }
-
-  if (!hasValidBaseTime || !startDate) {
-    // Absolute fallback: current local date
-    startDate = DateTime.now();
-    baseTime = new ical.Time({
-      year: startDate.year,
-      month: startDate.month,
-      day: startDate.day,
-      isDate: true
-    });
+  if (!baseTime || !startDate) {
+    return null;
   }
 
   const isAllDay = baseTime ? baseTime.isDate : true;

--- a/src/providers/utils/LinkedNoteIndex.ts
+++ b/src/providers/utils/LinkedNoteIndex.ts
@@ -4,7 +4,7 @@ import { PluginState } from '../../core/PluginState';
 export class LinkedNoteIndex {
   private app: App;
   private calendarId: string;
-  private index = new Map<string, TFile>(); // uid -> TFile
+  private index = new Map<string, TFile>(); // linked note key -> TFile
   private eventRefs: EventRef[] = [];
 
   constructor(app: App, calendarId: string) {
@@ -13,7 +13,42 @@ export class LinkedNoteIndex {
   }
 
   public getFileForEvent(eventUid: string): TFile | null {
-    return this.index.get(eventUid) || null;
+    const key = this.normalizeKey(eventUid);
+    if (!key) return null;
+
+    return this.index.get(key) || null;
+  }
+
+  /**
+   * Immediately registers a linked note without waiting for Obsidian's metadata cache.
+   * This prevents duplicate note creation when the user presses "Open note" again
+   * before metadataCache.on("changed") has indexed the newly-created file.
+   */
+  public setFileForEvent(eventUid: string, file: TFile, triggerReload = true): boolean {
+    const key = this.normalizeKey(eventUid);
+    if (!key) return false;
+
+    const prevFile = this.index.get(key);
+    if (prevFile?.path === file.path) {
+      return false;
+    }
+
+    this.index.set(key, file);
+
+    if (triggerReload) {
+      this.triggerReload();
+    }
+
+    return true;
+  }
+
+  private normalizeKey(value: unknown): string | null {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      return null;
+    }
+
+    const key = String(value).trim();
+    return key.length > 0 ? key : null;
   }
 
   private getDirectory(): string {
@@ -23,13 +58,14 @@ export class LinkedNoteIndex {
   private isFileInDirectory(file: TFile): boolean {
     const dir = this.getDirectory().trim();
     if (!dir) return false;
-    // Normalize paths
+
     const normalizedDir = dir.replace(/\/$/, '');
     return file.path.startsWith(`${normalizedDir}/`);
   }
 
   public initialize(): void {
     this.destroy();
+
     const dir = this.getDirectory().trim();
     if (!dir) return;
 
@@ -48,20 +84,21 @@ export class LinkedNoteIndex {
     const frontmatter = cache?.frontmatter;
 
     if (!frontmatter) {
-      // Remove any existing mapping for this file
       return this.removePathFromIndex(file.path, triggerReload);
     }
 
-    const calId = frontmatter['fc-calendar-id'] as unknown;
-    const eventUid = frontmatter['fc-event-uid'] as unknown;
+    const calId = this.normalizeKey(frontmatter['fc-calendar-id']);
+    const eventUid = this.normalizeKey(frontmatter['fc-event-uid']);
 
-    if (calId === this.calendarId && typeof eventUid === 'string' && eventUid.trim() !== '') {
+    if (calId === this.calendarId && eventUid) {
       const prevFile = this.index.get(eventUid);
       if (prevFile?.path !== file.path) {
         this.index.set(eventUid, file);
+
         if (triggerReload) {
           this.triggerReload();
         }
+
         return true;
       }
     } else {
@@ -73,15 +110,18 @@ export class LinkedNoteIndex {
 
   private removePathFromIndex(path: string, triggerReload = true): boolean {
     let removed = false;
+
     for (const [uid, indexedFile] of this.index.entries()) {
       if (indexedFile.path === path) {
         this.index.delete(uid);
         removed = true;
       }
     }
+
     if (removed && triggerReload) {
       this.triggerReload();
     }
+
     return removed;
   }
 
@@ -102,7 +142,6 @@ export class LinkedNoteIndex {
         if (this.isFileInDirectory(file)) {
           this.processFile(file);
         } else {
-          // If the file was in our index but is now moved out of directory, remove it
           this.removePathFromIndex(file.path);
         }
       }
@@ -118,10 +157,8 @@ export class LinkedNoteIndex {
 
     const renameRef = this.app.vault.on('rename', (file, oldPath) => {
       if (file instanceof TFile) {
-        // Remove old mapping by treating it as a deleted file
         const removed = this.removePathFromIndex(oldPath, false);
 
-        // Process as new file if it's in the directory now
         if (this.isFileInDirectory(file)) {
           this.processFile(file);
         } else if (removed) {
@@ -134,10 +171,10 @@ export class LinkedNoteIndex {
 
   public destroy(): void {
     for (const ref of this.eventRefs) {
-      // metadataCache and vault can offref their listeners
       this.app.metadataCache.offref(ref);
       this.app.vault.offref(ref);
     }
+
     this.eventRefs = [];
     this.index.clear();
   }


### PR DESCRIPTION
Register newly created linked notes immediately so repeated Open note actions reuse the existing note instead of creating suffixed duplicates.

Also allow linked-note lookup to consider both event UID and event ID, improving compatibility with CalDAV/ICS-backed events such as Nextcloud calendars.

Feel free to remove comments of course.