### PR TITLE
Fix status bar all-day task handling

### DIFF
--- a/src/core/TimeEngine.test.ts
+++ b/src/core/TimeEngine.test.ts
@@ -1,6 +1,7 @@
-import { Settings } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 import { TimeEngine } from './TimeEngine';
 import type EventCache from './EventCache';
+import type { TimeState } from './TimeEngine';
 import type { OFCEvent } from '../types';
 
 function createTimeEngine(events: { id: string; event: OFCEvent }[]): TimeEngine {
@@ -12,6 +13,20 @@ function createTimeEngine(events: { id: string; event: OFCEvent }[]): TimeEngine
   } as unknown as EventCache;
 
   return new TimeEngine(cache);
+}
+
+async function buildState(
+  events: { id: string; event: OFCEvent }[],
+  nowIso: string
+): Promise<TimeState> {
+  const engine = createTimeEngine(events);
+  const internals = engine as unknown as {
+    rebuildOccurrenceCache: () => Promise<void>;
+    calculateCurrentState: (now: DateTime) => TimeState;
+  };
+
+  await internals.rebuildOccurrenceCache();
+  return internals.calculateCurrentState(DateTime.fromISO(nowIso));
 }
 
 describe('TimeEngine', () => {
@@ -71,5 +86,68 @@ describe('TimeEngine', () => {
     expect(occurrence).toBeDefined();
     expect(occurrence.start.toUTC().toISO()).toBe('2026-06-15T14:00:00.000Z');
     expect(occurrence.end.toUTC().toISO()).toBe('2026-06-15T15:00:00.000Z');
+  });
+
+  it('does not include all-day task events in current or upcoming time state', async () => {
+    Settings.now = () => Date.parse('2026-06-15T10:00:00.000Z');
+
+    const allDayTask = {
+      type: 'single',
+      title: 'All-day task',
+      date: '2026-06-15',
+      endDate: null,
+      allDay: true,
+      completed: false
+    } as OFCEvent;
+    const upcomingAllDayTask = {
+      type: 'single',
+      title: 'Tomorrow all-day task',
+      date: '2026-06-16',
+      endDate: null,
+      allDay: true,
+      completed: false
+    } as OFCEvent;
+
+    const state = await buildState(
+      [
+        { id: 'task-current', event: allDayTask },
+        { id: 'task-upcoming', event: upcomingAllDayTask }
+      ],
+      '2026-06-15T12:00:00.000'
+    );
+
+    expect(state.current).toBeNull();
+    expect(state.upcoming).toEqual([]);
+  });
+
+  it('prefers a timed current event over an all-day current event', async () => {
+    Settings.now = () => Date.parse('2026-06-15T10:00:00.000Z');
+
+    const allDayEvent = {
+      type: 'single',
+      title: 'All-day event',
+      date: '2026-06-15',
+      endDate: null,
+      allDay: true
+    } as OFCEvent;
+    const timedEvent = {
+      type: 'single',
+      title: 'Scheduled event',
+      date: '2026-06-15',
+      startTime: '11:00',
+      endTime: '12:30',
+      allDay: false,
+      endDate: null
+    } as OFCEvent;
+
+    const state = await buildState(
+      [
+        { id: 'all-day', event: allDayEvent },
+        { id: 'timed', event: timedEvent }
+      ],
+      '2026-06-15T12:00:00.000'
+    );
+
+    expect(state.current?.id).toBe('timed');
   });
 });

--- a/src/core/TimeEngine.ts
+++ b/src/core/TimeEngine.ts
@@ -62,6 +62,36 @@ const parseRecurringStart = (event: Extract<OFCEvent, { type: 'rrule' }>): DateT
   );
 };
 
+const isTaskEvent = (event: OFCEvent): boolean => {
+  return (
+    ('completed' in event && event.completed !== undefined) ||
+    ('isTask' in event && Boolean(event.isTask))
+  );
+};
+
+const shouldExcludeFromTimeState = (event: OFCEvent): boolean => {
+  return event.allDay && isTaskEvent(event);
+};
+
+const compareCurrentEventPriority = (
+  candidate: EnrichedOFCEvent,
+  current: EnrichedOFCEvent | null
+): number => {
+  if (!current) return -1;
+
+  if (candidate.event.allDay !== current.event.allDay) {
+    return candidate.event.allDay ? 1 : -1;
+  }
+
+  const candidateEnd = candidate.end.toMillis();
+  const currentEnd = current.end.toMillis();
+  if (candidateEnd !== currentEnd) {
+    return candidateEnd - currentEnd;
+  }
+
+  return candidate.start.toMillis() - current.start.toMillis();
+};
+
 // ============== CLASS DEFINITION ==============
 
 export class TimeEngine {
@@ -141,8 +171,14 @@ export class TimeEngine {
     const upcoming: EnrichedOFCEvent[] = [];
 
     for (const occurrence of this.occurrenceCache) {
+      if (shouldExcludeFromTimeState(occurrence.event)) {
+        continue;
+      }
+
       if (occurrence.start <= now && now < occurrence.end) {
-        current = occurrence;
+        if (compareCurrentEventPriority(occurrence, current) < 0) {
+          current = occurrence;
+        }
       } else if (occurrence.start > now) {
         upcoming.push(occurrence);
       }


### PR DESCRIPTION
## Description

Fixes current event status bar selection so all-day task events are excluded from the time state used by the status bar. Timed current events now take precedence over all-day current events.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance

## Related Issues

- Closes #
- Related to #

## Code Quality Checklist (MANDATORY)

*Please read and verify you have adhered to all guidelines outlined in [CONTRIBUTING.md](../CONTRIBUTING.md).*

- **SOLID & DRY**:
  - [x] Designed polymorphically where appropriate.
  - [x] Kept classes and UI views decoupled (e.g., separating layout/filtering scroll sections from persistent creation footers).
  - [x] Shared reusable helpers instead of copying/pasting logic.

- **Internationalization (i18n)**:
  - [ ] Declared all new UI headers, text, labels, and placeholders inside `src/features/i18n/locales/en.json` and retrieved them using `t()`; **no** user-facing strings are hardcoded in the codebase.

- **Documentation Sync**:
  - [ ] Updated corresponding architectural documentation (under `docs/architecture/`).
  - [ ] Updated corresponding user-facing documentation (under `docs/user/`).
  - [ ] Adhered to the hyperlinked, compact, table-based concise formatting style.

- **Code Integrity & Type Safety**:
  - [ ] Ran `pnpm run ra` locally and confirmed that compilation, ESLint (`lint_report.txt` and `css_report.txt`), i18n checks, and Jest unit tests pass with **0 errors**.

- **Test Integrity**:
  - [ ] Kept all existing `.test` files completely untouched.
  - [x] Added new unit/integration tests for new features.

## Notes

- No new user-facing UI strings were added.
- No documentation files were changed.
- `src/core/TimeEngine.test.ts` was changed.
- Added regression tests for all-day task exclusion and timed-event precedence.
- Ran `pnpm jest src/core/TimeEngine.test.ts --runInBand`.
- Ran `pnpm run compile`.
- Did not run `pnpm run ra`.