### PR TITLE
feat: add a very simple fallback in case the query filter is not present in the tasks plugin setting

### DIFF
--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -641,14 +641,22 @@ export class TasksPluginProvider
       .filter((e): e is [OFCEvent, EventLocation | null] => e !== null);
   }
 
-  public filterTasksByGlobalQuery(tasks: CalendarTask[]): CalendarTask[] {
-    const globalQuery = (
+  public async filterTasksByGlobalQuery(tasks: CalendarTask[]): Promise<CalendarTask[]> {
+    const tasksPlugin = (
       this.plugin.app as unknown as {
         plugins?: {
-          plugins?: Record<string, { settings?: { globalQuery?: string } }>;
+          plugins?: Record<
+            string,
+            {
+              settings?: { globalQuery?: string };
+              loadData?: () => Promise<{ globalQuery?: string } | null>;
+            }
+          >;
         };
       }
-    ).plugins?.plugins?.['obsidian-tasks-plugin']?.settings?.globalQuery;
+    ).plugins?.plugins?.['obsidian-tasks-plugin'];
+    const persistedData = tasksPlugin?.settings?.globalQuery ? null : await tasksPlugin?.loadData?.();
+    const globalQuery = tasksPlugin?.settings?.globalQuery ?? persistedData?.globalQuery;
 
     if (!globalQuery) {
       return tasks;
@@ -663,7 +671,7 @@ export class TasksPluginProvider
 
     const settings = PluginState.getSettings();
     if (settings.tasksIntegration.includeGlobalQueryInBacklog) {
-      tasks = this.filterTasksByGlobalQuery(tasks);
+      tasks = await this.filterTasksByGlobalQuery(tasks);
     }
 
     return tasks.map(t => ({


### PR DESCRIPTION
## Description
As mentioned in the #263, there is an issue while picking up the global query filter. I added a fallback to load the plugin settings in case the global query filter is present but it is not exposed in the plugin.settings object.

The fix adds a fallback:

```ts
const persistedData = tasksPlugin?.settings?.globalQuery
  ? null
  : await tasksPlugin?.loadData?.();
const globalQuery = tasksPlugin?.settings?.globalQuery ?? persistedData?.globalQuery;
```

Meaning:
1. Try the old runtime location first: tasksPlugin.settings.globalQuery.
2. If that is missing, call the Tasks plugin’s Obsidian loadData() method.
3. Read globalQuery from the persisted plugin data instead.

The core issue was not the toggle. It was that Full Calendar assumed the Tasks plugin exposed globalQuery in memory, but the Tasks plugin only reliably had it in persisted data. (At least in my version!)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance

## Related Issues

- Closes #263 
- Related to #264 

## Code Quality Checklist (MANDATORY)
- **SOLID & DRY**:
  - [x] Designed polymorphically where appropriate.
  - [ ] Kept classes and UI views decoupled (e.g., separating layout/filtering scroll sections from persistent creation footers).
  - [x] Shared reusable helpers instead of copying/pasting logic.
- **Internationalization (i18n)**:
  - [x] Declared all new UI headers, text, labels, and placeholders inside `src/features/i18n/locales/en.json` and retrieved them using `t()`; **no** user-facing strings are hardcoded in the codebase.
- **Documentation Sync**:
  - [ ] Updated corresponding architectural documentation (under `docs/architecture/`).
  - [ ] Updated corresponding user-facing documentation (under `docs/user/`).
  - [ ] Adhered to the hyperlinked, compact, table-based concise formatting style.
- **Code Integrity & Type Safety**:
  - [x] Ran `pnpm run ra` locally and confirmed that compilation, ESLint (`lint_report.txt` and `css_report.txt`), i18n checks, and Jest unit tests pass with **0 errors**.
- **Test Integrity**:
  - [x] Kept all existing `.test` files completely untouched.
  - [ ] Added new unit/integration tests for new features.

Unchecked items in this case don't apply to this PR, they are not pending chores.