### PR TITLE
Add backlog query

### DIFF
--- a/docs/architecture/calendars/tasks-integration.md
+++ b/docs/architecture/calendars/tasks-integration.md
@@ -74,12 +74,36 @@ The provider enforces a strict mapping policy to maintain data integrity:
 Backlog filtering is split by responsibility:
 
 - **Provider-level filter** (`TasksPluginProvider.getUndatedTasks()`): decides which tasks are backlog candidates using `backlogDateTarget` and completion state.
+- **Backlog Query Filter** (proposed): applies a Full Calendar-owned query string from `settings.tasksIntegration.backlogQuery` to backlog candidates before they are exposed to the backlog view.
 - **Global Query Filter** (`TasksQueryFilter`): If the setting `includeGlobalQueryInBacklog` is enabled, the provider fetches the global query string defined in Obsidian Tasks (`app.plugins.plugins['obsidian-tasks-plugin']?.settings?.globalQuery`) and filters backlog tasks accordingly.
 - **View-level filter** (`TasksBacklogView`): applies client-side fuzzy filtering over candidate tasks by title and file path.
 
 View-layer boundary reference: [Views Architecture](../views/architecture.md).
 
 The view-level fuzzy filter is intentionally non-destructive: it does not mutate provider state and only narrows visible rows in the panel.
+
+### Proposed Dedicated Backlog Query
+
+The dedicated backlog query should be a persisted Full Calendar setting rather than an Obsidian Tasks plugin setting:
+
+```ts
+interface TasksIntegrationSettings {
+  backlogQuery?: string;
+}
+```
+
+Suggested evaluation order in `TasksPluginProvider.getUndatedTasks()`:
+
+1. Select incomplete tasks missing the configured `backlogDateTarget`.
+2. If `tasksIntegration.backlogQuery` is non-empty, filter tasks with `new TasksQueryFilter(backlogQuery)`.
+3. If `includeGlobalQueryInBacklog` is enabled, filter the remaining tasks with the Tasks plugin `globalQuery`.
+4. Map the final tasks to `ParsedUndatedTask` for the backlog view.
+
+The backlog query and global query are combined with logical AND semantics. Each query line is already evaluated with AND semantics by `TasksQueryFilter`, so applying both filters sequentially preserves a simple mental model: a backlog task must satisfy every supported backlog rule and every supported global rule.
+
+The settings UI should expose this as a multiline text box in **Integrations → Tasks Plugin Integration**, near the existing **Include global query in the backlog** toggle. Saving the field should call `PluginState.saveSettings()` and `PluginState.getProviderRegistry().refreshBacklogViews()` so the sidebar updates immediately.
+
+The feature should reuse `TasksQueryFilter` instead of introducing another parser. This keeps supported syntax identical between the global query fallback and the dedicated backlog query, including ignored display/layout lines and unsupported lines.
 
 ### Global Query Filtering Architecture (`TasksQueryFilter`)
 

--- a/docs/user/calendars/tasks-plugin-integration.md
+++ b/docs/user/calendars/tasks-plugin-integration.md
@@ -24,8 +24,34 @@ The integration revolves around two surfaces: the **Backlog** (where unscheduled
 The Tasks Backlog supports multiple filters that work together seamlessly to help you manage even the largest backlogs:
 
 - **Missing Date** dropdown: selects which missing Tasks date marker defines backlog membership (`⏳`, `🛫`, or `📅`).
+- **Backlog Query** setting: defines a Full Calendar-specific Tasks query that is applied only to the sidebar backlog.
 - **Fuzzy Search** input: filters visible backlog rows by task title, file name, or full file path.
 - **Global Query Filter** (Toggle): When **"Include global query in the backlog"** is enabled in settings, Full Calendar will retrieve the global query string defined in your Obsidian Tasks plugin settings and apply all its filter rules to the backlog in real-time. This is extremely powerful for excluding archive files, private areas, templates, or only matching specific folders/tags automatically.
+
+### Proposed Backlog Query Setting
+
+The dedicated backlog query would let you filter the Full Calendar backlog without changing the global query used by the Tasks plugin itself.
+
+Example setting value:
+
+```tasks
+path does not include Templates
+folder includes Projects
+tags do not include someday
+priority is not lowest
+```
+
+With this query configured, a task appears in the backlog only when all of these are true:
+
+- It is missing the configured **Backlog Filter Date**.
+- It is not completed.
+- It matches every supported line in the **Backlog Query**.
+- If **Include global query in the backlog** is also enabled, it also matches every supported line in the Tasks plugin global query.
+- It matches the current fuzzy search text, if any.
+
+This keeps the global Tasks query as a broad vault-wide default while allowing Full Calendar to maintain a narrower scheduling queue. For example, the global query might hide archived notes everywhere, while the backlog query shows only actionable project tasks that are ready to schedule.
+
+Unsupported Tasks query lines should be ignored in the same way they are ignored for global query filtering. Display and layout instructions such as `sort by`, `group by`, `limit`, `hide`, and `show` do not affect the backlog query.
 
 ### Supported Global Query Syntax
 

--- a/src/features/i18n/locales/de.json
+++ b/src/features/i18n/locales/de.json
@@ -859,6 +859,11 @@
         "label": "Globale Abfrage im Backlog berücksichtigen",
         "description": "Wenden Sie die Filter der globalen Abfrage von Obsidian Tasks auf die Backlog-Ansicht an."
       },
+      "backlogQuery": {
+        "label": "Backlog-Abfrage",
+        "description": "Wendet diese Tasks-Abfrage nur auf das Full Calendar-Backlog an. Jede unterstützte Zeile muss übereinstimmen, damit eine Aufgabe angezeigt wird.",
+        "placeholder": "path does not include Templates\nfolder includes Projects\ntags do not include someday"
+      },
       "calendarDisplayDateTarget": {
         "label": "Kalender-Anzeigedatum-Feld",
         "description": "Wählen Sie, welchen Tasks-Datumsmarker Full Calendar zur Anzeige von Tasks-Ereignissen verwendet. Es gibt kein Fallback auf andere Datumsmarker. Starten Sie Obsidian neu oder laden Sie das Plugin neu, damit diese Änderung vollständig wirksam wird."

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -877,6 +877,11 @@
         "label": "Include global query in the backlog",
         "description": "Apply the Obsidian Tasks global query filters to the backlog view."
       },
+      "backlogQuery": {
+        "label": "Backlog query",
+        "description": "Apply this Tasks query only to the Full Calendar backlog. Each supported line must match for a task to appear.",
+        "placeholder": "path does not include Templates\nfolder includes Projects\ntags do not include someday"
+      },
       "taskDisplayFormat": {
         "label": "Task time format",
         "description": "Choose how Full Calendar writes time into Tasks lines.",

--- a/src/features/i18n/locales/es.json
+++ b/src/features/i18n/locales/es.json
@@ -859,6 +859,11 @@
         "label": "Incluir consulta global en el backlog",
         "description": "Aplicar los filtros de la consulta global de Obsidian Tasks a la vista de backlog."
       },
+      "backlogQuery": {
+        "label": "Consulta de backlog",
+        "description": "Aplica esta consulta de Tasks solo al backlog de Full Calendar. Cada línea compatible debe coincidir para que se muestre una tarea.",
+        "placeholder": "path does not include Templates\nfolder includes Projects\ntags do not include someday"
+      },
       "calendarDisplayDateTarget": {
         "label": "Campo de fecha de visualización del calendario",
         "description": "Elige qué marcador de fecha de Tasks utiliza Full Calendar para mostrar los eventos de Tasks. No hay alternativa a otros marcadores de fecha. Reinicia Obsidian o recarga el plugin para que este cambio surta efecto."

--- a/src/features/i18n/locales/fr.json
+++ b/src/features/i18n/locales/fr.json
@@ -859,6 +859,11 @@
         "label": "Inclure la requête globale dans le backlog",
         "description": "Appliquer les filtres de la requête globale d'Obsidian Tasks à la vue backlog."
       },
+      "backlogQuery": {
+        "label": "Requête du backlog",
+        "description": "Applique cette requête Tasks uniquement au backlog Full Calendar. Chaque ligne prise en charge doit correspondre pour afficher une tâche.",
+        "placeholder": "path does not include Templates\nfolder includes Projects\ntags do not include someday"
+      },
       "calendarDisplayDateTarget": {
         "label": "Champ de date d'affichage du calendrier",
         "description": "Choisissez quel marqueur de date Tasks Full Calendar utilise pour afficher les événements Tasks. Aucun recours à d'autres marqueurs de date. Redémarrez Obsidian ou rechargez le plugin pour que ce changement prenne pleinement effet."

--- a/src/features/i18n/locales/it.json
+++ b/src/features/i18n/locales/it.json
@@ -859,6 +859,11 @@
         "label": "Includi query globale nel backlog",
         "description": "Applica i filtri della query globale di Obsidian Tasks alla vista backlog."
       },
+      "backlogQuery": {
+        "label": "Query backlog",
+        "description": "Applica questa query Tasks solo al backlog di Full Calendar. Ogni riga supportata deve corrispondere affinché un'attività venga mostrata.",
+        "placeholder": "path does not include Templates\nfolder includes Projects\ntags do not include someday"
+      },
       "calendarDisplayDateTarget": {
         "label": "Campo data di visualizzazione calendario",
         "description": "Scegli quale marcatore di data di Tasks Full Calendar utilizza per visualizzare gli eventi Tasks. Nessun fallback su altri marcatori di data. Riavvia Obsidian o ricarica il plugin affinché questa modifica abbia effetto."

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -855,6 +855,11 @@
         "label": "在待办事项中包含全局查询",
         "description": "将 Obsidian Tasks 全局查询过滤器应用于待办事项视图。"
       },
+      "backlogQuery": {
+        "label": "待办列表查询",
+        "description": "仅将此 Tasks 查询应用于 Full Calendar 待办列表。任务必须匹配每个受支持的行才会显示。",
+        "placeholder": "path does not include Templates\nfolder includes Projects\ntags do not include someday"
+      },
       "calendarDisplayDateTarget": {
         "label": "日历显示日期字段",
         "description": "选择日历用于显示 Tasks 事件的 Tasks 日期标记。没有回退到其他日期标记的选项。重启 Obsidian 或重新加载插件以使此更改完全生效。"

--- a/src/providers/tasks/TasksIntegrationSettingsModal.ts
+++ b/src/providers/tasks/TasksIntegrationSettingsModal.ts
@@ -75,6 +75,24 @@ export class TasksIntegrationSettingsModal extends Modal {
       });
 
     new Setting(this.contentEl)
+      .setName(t('settings.tasksIntegration.backlogQuery.label'))
+      .setDesc(t('settings.tasksIntegration.backlogQuery.description'))
+      .addTextArea(text => {
+        text
+          .setPlaceholder(t('settings.tasksIntegration.backlogQuery.placeholder'))
+          .setValue(settings.backlogQuery ?? '')
+          .onChange(async value => {
+            settings.backlogQuery = value;
+            await PluginState.saveSettings();
+            PluginState.getProviderRegistry().refreshBacklogViews();
+            this.onChange();
+          });
+        text.inputEl.rows = 6;
+        text.inputEl.cols = 50;
+        text.inputEl.setCssProps({ width: '100%' });
+      });
+
+    new Setting(this.contentEl)
       .setName(t('settings.tasksIntegration.taskDisplayFormat.label'))
       .setDesc(t('settings.tasksIntegration.taskDisplayFormat.description'))
       .addDropdown(dropdown => {

--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -641,14 +641,22 @@ export class TasksPluginProvider
       .filter((e): e is [OFCEvent, EventLocation | null] => e !== null);
   }
 
-  public filterTasksByGlobalQuery(tasks: CalendarTask[]): CalendarTask[] {
-    const globalQuery = (
+  public async filterTasksByGlobalQuery(tasks: CalendarTask[]): Promise<CalendarTask[]> {
+    const tasksPlugin = (
       this.plugin.app as unknown as {
         plugins?: {
-          plugins?: Record<string, { settings?: { globalQuery?: string } }>;
+          plugins?: Record<
+            string,
+            {
+              settings?: { globalQuery?: string };
+              loadData?: () => Promise<{ globalQuery?: string } | null>;
+            }
+          >;
         };
       }
-    ).plugins?.plugins?.['obsidian-tasks-plugin']?.settings?.globalQuery;
+    ).plugins?.plugins?.['obsidian-tasks-plugin'];
+    const persistedData = tasksPlugin?.settings?.globalQuery ? null : await tasksPlugin?.loadData?.();
+    const globalQuery = tasksPlugin?.settings?.globalQuery ?? persistedData?.globalQuery;
 
     if (!globalQuery) {
       return tasks;
@@ -663,7 +671,7 @@ export class TasksPluginProvider
 
     const settings = PluginState.getSettings();
     if (settings.tasksIntegration.includeGlobalQueryInBacklog) {
-      tasks = this.filterTasksByGlobalQuery(tasks);
+      tasks = await this.filterTasksByGlobalQuery(tasks);
     }
 
     return tasks.map(t => ({

--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -670,6 +670,11 @@ export class TasksPluginProvider
     let tasks = this.allTasks.filter(t => !this.hasBacklogTargetDate(t) && !t.isDone);
 
     const settings = PluginState.getSettings();
+    const backlogQuery = settings.tasksIntegration.backlogQuery?.trim();
+    if (backlogQuery) {
+      tasks = new TasksQueryFilter(backlogQuery).filter(tasks);
+    }
+
     if (settings.tasksIntegration.includeGlobalQueryInBacklog) {
       tasks = await this.filterTasksByGlobalQuery(tasks);
     }

--- a/src/providers/tasks/tests/TasksPluginProvider.test.ts
+++ b/src/providers/tasks/tests/TasksPluginProvider.test.ts
@@ -866,5 +866,91 @@ describe('TasksPluginProvider', () => {
       const tasks = await provider.getUndatedTasks();
       expect(tasks).toHaveLength(1);
     });
+
+    it('filters backlog tasks by the dedicated backlog query without enabling the global query', async () => {
+      mockPlugin.settings.tasksIntegration.includeGlobalQueryInBacklog = false;
+      mockPlugin.settings.tasksIntegration.backlogQuery = 'folder includes Projects\ntags do not include someday';
+      tasksPluginSettings.globalQuery = 'path does not include Projects';
+
+      mockPlugin.app.workspace.trigger.mockImplementation(
+        (eventName: string, callback: (data: unknown) => void) => {
+          if (eventName === 'obsidian-tasks-plugin:request-cache-update') {
+            callback({
+              state: 'Warm',
+              tasks: [
+                {
+                  path: 'Projects/Active.md',
+                  description: 'Task 1 #next',
+                  taskLocation: { lineNumber: 0 },
+                  originalMarkdown: '- [ ] Task 1 #next',
+                  isDone: false
+                },
+                {
+                  path: 'Projects/Someday.md',
+                  description: 'Task 2 #someday',
+                  taskLocation: { lineNumber: 1 },
+                  originalMarkdown: '- [ ] Task 2 #someday',
+                  isDone: false
+                },
+                {
+                  path: 'Inbox.md',
+                  description: 'Task 3 #next',
+                  taskLocation: { lineNumber: 2 },
+                  originalMarkdown: '- [ ] Task 3 #next',
+                  isDone: false
+                }
+              ]
+            });
+          }
+        }
+      );
+
+      const tasks = await provider.getUndatedTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].title).toBe('Task 1 #next');
+    });
+
+    it('combines the dedicated backlog query with the global query using AND semantics', async () => {
+      mockPlugin.settings.tasksIntegration.includeGlobalQueryInBacklog = true;
+      mockPlugin.settings.tasksIntegration.backlogQuery = 'folder includes Projects';
+      tasksPluginSettings.globalQuery = 'tags include next';
+
+      mockPlugin.app.workspace.trigger.mockImplementation(
+        (eventName: string, callback: (data: unknown) => void) => {
+          if (eventName === 'obsidian-tasks-plugin:request-cache-update') {
+            callback({
+              state: 'Warm',
+              tasks: [
+                {
+                  path: 'Projects/Active.md',
+                  description: 'Task 1 #next',
+                  taskLocation: { lineNumber: 0 },
+                  originalMarkdown: '- [ ] Task 1 #next',
+                  isDone: false
+                },
+                {
+                  path: 'Projects/Waiting.md',
+                  description: 'Task 2 #waiting',
+                  taskLocation: { lineNumber: 1 },
+                  originalMarkdown: '- [ ] Task 2 #waiting',
+                  isDone: false
+                },
+                {
+                  path: 'Inbox.md',
+                  description: 'Task 3 #next',
+                  taskLocation: { lineNumber: 2 },
+                  originalMarkdown: '- [ ] Task 3 #next',
+                  isDone: false
+                }
+              ]
+            });
+          }
+        }
+      );
+
+      const tasks = await provider.getUndatedTasks();
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].title).toBe('Task 1 #next');
+    });
   });
 });

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -48,6 +48,7 @@ export interface TasksIntegrationSettings {
   openEditModalAfterBacklogDrop: boolean;
   taskDisplayFormat?: TasksDisplayFormat;
   includeGlobalQueryInBacklog?: boolean;
+  backlogQuery?: string;
 }
 
 export interface MilestonesSettings {
@@ -255,7 +256,8 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
     calendarDisplayDateTarget: 'scheduledDate',
     openEditModalAfterBacklogDrop: false,
     taskDisplayFormat: 'dayPlanner',
-    includeGlobalQueryInBacklog: false
+    includeGlobalQueryInBacklog: false,
+    backlogQuery: ''
   },
   milestones: {
     counters: {},


### PR DESCRIPTION
## Description
This PR adds the possibility for users to add a backlog specific query that will get applied to the tasks in the obsidian tasks backlog. This is important because we might want to make the query filter applied to the backlog more restrictive than the global query filter without affecting the rest of the vault.

The PR builds on top of #286 and adds a new setting under the Tasks Integration modal

<img width="691" height="187" alt="image" src="https://github.com/user-attachments/assets/c233648c-48cf-437d-8090-20dd641ef226" />

The query reuses the TasksQueryFilter:

```ts
const backlogQuery = settings.tasksIntegration.backlogQuery?.trim();
if (backlogQuery) {
  tasks = new TasksQueryFilter(backlogQuery).filter(tasks);
}
```

The code changes are as minimal as possible and the feature is necessary.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance

## Related Issues

- Closes #
- Related to #263 #264 

## Code Quality Checklist (MANDATORY)
*Please read and verify you have adhered to all guidelines outlined in [CONTRIBUTING.md](../CONTRIBUTING.md).*

- **SOLID & DRY**:
  - [x] Designed polymorphically where appropriate.
  - [x] Kept classes and UI views decoupled (e.g., separating layout/filtering scroll sections from persistent creation footers).
  - [x] Shared reusable helpers instead of copying/pasting logic.
- **Internationalization (i18n)**:
  - [x] Declared all new UI headers, text, labels, and placeholders inside `src/features/i18n/locales/en.json` and retrieved them using `t()`; **no** user-facing strings are hardcoded in the codebase.
- **Documentation Sync**:
  - [x] Updated corresponding architectural documentation (under `docs/architecture/`).
  - [x] Updated corresponding user-facing documentation (under `docs/user/`).
  - [x] Adhered to the hyperlinked, compact, table-based concise formatting style.
- **Code Integrity & Type Safety**:
  - [x] Ran `pnpm run ra` locally and confirmed that compilation, ESLint (`lint_report.txt` and `css_report.txt`), i18n checks, and Jest unit tests pass with **0 errors**.
- **Test Integrity**:
  - [x] Kept all existing `.test` files completely untouched.
  - [x] Added new unit/integration tests for new features.
