### PR TITLE
Fix task backlog linked note resolution

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,29 +5,25 @@ jobs:
     format:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                   ref: ${{ github.head_ref }}
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               with:
                   node-version: "22.x"
-            - uses: pnpm/action-setup@v2
-              with:
-                  version: 11
+            - uses: pnpm/action-setup@v4
             - run: pnpm install --no-frozen-lockfile
             - run: pnpm run lint
             - run: pnpm run compile
     tests:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                   ref: ${{ github.head_ref }}
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v4
               with:
                   node-version: "22.x"
-            - uses: pnpm/action-setup@v2
-              with:
-                  version: 11
+            - uses: pnpm/action-setup@v4
             - run: pnpm install --no-frozen-lockfile
             - run: pnpm run test-update

--- a/.github/workflows/draft-release-attest.yml
+++ b/.github/workflows/draft-release-attest.yml
@@ -22,9 +22,8 @@ jobs:
               with:
                   node-version: "22.x"
 
-            - uses: pnpm/action-setup@v2
+            - uses: pnpm/action-setup@v4
               with:
-                  version: 11
                   run_install: false
 
             - name: Install dependencies

--- a/src/features/linked-notes/linkedNotes.ts
+++ b/src/features/linked-notes/linkedNotes.ts
@@ -14,6 +14,12 @@ import {
 import { replaceFrontmatter } from '../../providers/fullnote/frontmatter';
 import FullCalendarPlugin from '../../main';
 
+const linkedNoteCreationPromises = new Map<string, Promise<TFile | null>>();
+
+function linkedNoteCreationKey(calendarId: string, event: OFCEvent, instanceDate?: string): string {
+  return `${calendarId}::${event.uid || ''}::${instanceDate || ''}`;
+}
+
 /**
  * Centrally creates a linked note for a remote event, ensuring absolute DRY behavior and zero hardcoded English strings.
  */
@@ -32,11 +38,46 @@ export async function createLinkedNoteForProvider({
   linkedNoteIndex: LinkedNoteIndex;
   instanceDate?: string;
 }): Promise<TFile | null> {
-  const existingFile = linkedNoteIndex.getFileForEvent(event.uid || '', instanceDate);
+  const existingFile = await linkedNoteIndex.getFileForEventAfterHydration(
+    event.uid || '',
+    instanceDate
+  );
   if (existingFile) {
     return existingFile;
   }
 
+  const creationKey = linkedNoteCreationKey(calendarId, event, instanceDate);
+  const inFlightCreation = linkedNoteCreationPromises.get(creationKey);
+  if (inFlightCreation) {
+    return inFlightCreation;
+  }
+
+  const creationPromise = createLinkedNoteFile({
+    app,
+    event,
+    calendarId,
+    calendarName,
+    instanceDate
+  }).finally(() => {
+    linkedNoteCreationPromises.delete(creationKey);
+  });
+  linkedNoteCreationPromises.set(creationKey, creationPromise);
+  return creationPromise;
+}
+
+async function createLinkedNoteFile({
+  app,
+  event,
+  calendarId,
+  calendarName,
+  instanceDate
+}: {
+  app: App;
+  event: OFCEvent;
+  calendarId: string;
+  calendarName: string;
+  instanceDate?: string;
+}): Promise<TFile | null> {
   const settings = PluginState.getSettings();
   const directory = settings.linkedNotesDirectory;
   if (!directory) {
@@ -99,7 +140,7 @@ export async function openOrCreateLinkedNote(
 
   // 2. Check if note already exists
   if (linkedNoteProvider.linkedNoteIndex) {
-    const existingFile = linkedNoteProvider.linkedNoteIndex.getFileForEvent(
+    const existingFile = await linkedNoteProvider.linkedNoteIndex.getFileForEventAfterHydration(
       event.uid || '',
       instanceDate
     );

--- a/src/providers/caldav/CalDAVProvider.test.ts
+++ b/src/providers/caldav/CalDAVProvider.test.ts
@@ -881,7 +881,7 @@ END:VCALENDAR
       expect(file!.path).toBe('Calendar/Notes/CalDAV Linked Note Event.md');
       expect(file!.content).toContain('# CalDAV Linked Note Event');
       expect(file!.content).toContain('**Calendar**: Test Calendar');
-      expect(file!.content).toContain('fc-event-uid: caldav-uid-999');
+      expect(file!.content).toContain('fc-event-uid: "caldav-uid-999"');
     });
 
     it('should use custom template when linkedNoteTemplate setting is provided', async () => {

--- a/src/providers/caldav/CalDAVProvider.ts
+++ b/src/providers/caldav/CalDAVProvider.ts
@@ -19,7 +19,10 @@ import { obsidianFetch } from './obsidian-fetch_caldav';
 import { createBasicAuthHeader } from './auth_caldav';
 import { LinkedNoteIndex } from '../utils/LinkedNoteIndex';
 import { TFile } from 'obsidian';
-import { createLinkedNoteForProvider } from '../../features/linked-notes/linkedNotes';
+import {
+  createLinkedNoteForProvider,
+  openOrCreateLinkedNote
+} from '../../features/linked-notes/linkedNotes';
 import { parseTimezoneAwareString } from '../../features/timezone/Timezone';
 import { PluginState } from '../../core/PluginState';
 
@@ -932,13 +935,7 @@ export class CalDAVProvider
       return;
     }
 
-    const file = await this.createLinkedNoteForTask(task);
-    if (!file) {
-      return;
-    }
-
-    const leaf = this.plugin.app.workspace.getLeaf(false);
-    await leaf.openFile(file);
+    await openOrCreateLinkedNote(this.plugin, this.source.id, taskToLinkedNoteEvent(task), false);
   }
 
   private toTaskBacklogItem(task: CalDAVTaskInboxItem): TaskBacklogItem {

--- a/src/providers/google/GoogleProvider.test.ts
+++ b/src/providers/google/GoogleProvider.test.ts
@@ -128,7 +128,7 @@ describe('GoogleProvider createLinkedNote', () => {
     expect(file!.path).toBe('Calendar/Notes/Test Dynamic Note Event.md');
     expect(file!.content).toContain('# Test Dynamic Note Event');
     expect(file!.content).toContain('**Calendar**: My Google Calendar');
-    expect(file!.content).toContain('fc-event-uid: google-uid-123');
+    expect(file!.content).toContain('fc-event-uid: "google-uid-123"');
   });
 
   it('should use custom template when linkedNoteTemplate setting is provided', async () => {

--- a/src/providers/ics/ICSProvider.test.ts
+++ b/src/providers/ics/ICSProvider.test.ts
@@ -87,7 +87,7 @@ describe('ICSProvider createLinkedNote', () => {
     expect(file!.path).toBe('Calendar/Notes/ICS Linked Note Event.md');
     expect(file!.content).toContain('# ICS Linked Note Event');
     expect(file!.content).toContain('**Calendar**: Remote Calendar (ICS)');
-    expect(file!.content).toContain('fc-event-uid: ics-uid-123');
+    expect(file!.content).toContain('fc-event-uid: "ics-uid-123"');
   });
 
   it('should use custom template when linkedNoteTemplate setting is provided', async () => {

--- a/src/providers/outlook/OutlookProvider.test.ts
+++ b/src/providers/outlook/OutlookProvider.test.ts
@@ -130,7 +130,7 @@ describe('OutlookProvider createLinkedNote', () => {
     expect(file!.path).toBe('Calendar/Notes/Outlook Linked Note Event.md');
     expect(file!.content).toContain('# Outlook Linked Note Event');
     expect(file!.content).toContain('**Calendar**: My Outlook Calendar');
-    expect(file!.content).toContain('fc-event-uid: outlook-uid-123');
+    expect(file!.content).toContain('fc-event-uid: "outlook-uid-123"');
   });
 
   it('should use custom template when linkedNoteTemplate setting is provided', async () => {

--- a/src/providers/utils/LinkedNoteIndex.test.ts
+++ b/src/providers/utils/LinkedNoteIndex.test.ts
@@ -225,6 +225,93 @@ describe('LinkedNoteIndex', () => {
     expect(index.getFileForEvent('uid-resolved')).toBe(file);
   });
 
+  it('waits for startup hydration before resolving a linked note file', async () => {
+    const file = createMockFile('events/async-resolved-note.md');
+    let metadataReady = false;
+
+    mockWorkspace.onLayoutReady.mockImplementation(() => undefined);
+    mockWaitForMetadata.mockImplementation(() => new Promise(() => undefined));
+    mockVault.getMarkdownFiles.mockReturnValue([file]);
+
+    mockMetadataCache.getFileCache.mockImplementation(() => {
+      if (!metadataReady) {
+        return null;
+      }
+      return {
+        frontmatter: {
+          'fc-calendar-id': calendarId,
+          'fc-event-uid': 'uid-async-resolved'
+        }
+      };
+    });
+
+    const index = new LinkedNoteIndex(mockApp, calendarId);
+    index.initialize();
+
+    let resolved = false;
+    const filePromise = index.getFileForEventAfterHydration('uid-async-resolved').then(result => {
+      resolved = true;
+      return result;
+    });
+    await Promise.resolve();
+
+    expect(resolved).toBe(false);
+
+    metadataReady = true;
+    triggerEvent('resolved');
+
+    await expect(filePromise).resolves.toBe(file);
+    expect(resolved).toBe(true);
+  });
+
+  it('does not treat the index as hydrated while any linked-note files are unresolved', async () => {
+    const indexedFile = createMockFile('events/indexed-note.md');
+    const delayedFile = createMockFile('events/delayed-note.md');
+    let delayedMetadataReady = false;
+
+    mockWorkspace.onLayoutReady.mockImplementation(() => undefined);
+    mockWaitForMetadata.mockImplementation(() => new Promise(() => undefined));
+    mockVault.getMarkdownFiles.mockReturnValue([indexedFile, delayedFile]);
+    mockMetadataCache.getFileCache.mockImplementation((file: TFile) => {
+      if (file.path === indexedFile.path) {
+        return {
+          frontmatter: {
+            'fc-calendar-id': calendarId,
+            'fc-event-uid': 'uid-indexed'
+          }
+        };
+      }
+      if (file.path === delayedFile.path && delayedMetadataReady) {
+        return {
+          frontmatter: {
+            'fc-calendar-id': calendarId,
+            'fc-event-uid': 'uid-delayed'
+          }
+        };
+      }
+      return null;
+    });
+
+    const index = new LinkedNoteIndex(mockApp, calendarId);
+    index.initialize();
+
+    let resolved = false;
+    const filePromise = index.getFileForEventAfterHydration('uid-delayed').then(result => {
+      resolved = true;
+      return result;
+    });
+    await Promise.resolve();
+
+    expect(index.getFileForEvent('uid-indexed')).toBe(indexedFile);
+    expect(resolved).toBe(false);
+
+    delayedMetadataReady = true;
+    triggerEvent('resolved');
+
+    await expect(filePromise).resolves.toBe(delayedFile);
+    expect(resolved).toBe(true);
+  });
+
   it('indexes linked-note files created in the watched directory', () => {
     const index = new LinkedNoteIndex(mockApp, calendarId);
     index.initialize();
@@ -326,6 +413,23 @@ describe('LinkedNoteIndex', () => {
     expect(index.getFileForEvent('uid-recur', '2026-05-21')).toBe(fileMaster);
     // query with no instance should match the master note
     expect(index.getFileForEvent('uid-recur')).toBe(fileMaster);
+  });
+
+  it('indexes existing linked notes whose UID frontmatter was parsed as a number', () => {
+    const file = createMockFile('events/numeric-uid.md');
+
+    mockVault.getMarkdownFiles.mockReturnValue([file]);
+    mockMetadataCache.getFileCache.mockReturnValue({
+      frontmatter: {
+        'fc-calendar-id': calendarId,
+        'fc-event-uid': 1234567890
+      }
+    });
+
+    const index = new LinkedNoteIndex(mockApp, calendarId);
+    index.initialize();
+
+    expect(index.getFileForEvent('1234567890')).toBe(file);
   });
 
   it('should scrub stale mappings pointing to the same path but a different key during reactive updates', () => {

--- a/src/providers/utils/LinkedNoteIndex.ts
+++ b/src/providers/utils/LinkedNoteIndex.ts
@@ -6,6 +6,7 @@ export class LinkedNoteIndex {
   private calendarId: string;
   private index = new Map<string, TFile>(); // uid -> TFile
   private eventRefs: EventRef[] = [];
+  private hydrationWaiters: (() => void)[] = [];
   private revision = 0;
   private startupHydrationPending = false;
 
@@ -54,15 +55,12 @@ export class LinkedNoteIndex {
     }
 
     const unresolvedFiles = this.scanDirectory();
-    if (this.index.size > 0) {
-      this.completeStartupHydration(revision);
-      return;
-    }
-
     if (unresolvedFiles.length > 0) {
       void this.backfillUnresolvedFiles(unresolvedFiles, revision);
       return;
     }
+
+    this.completeStartupHydration(revision);
   }
 
   private completeStartupHydration(revision: number): void {
@@ -71,6 +69,7 @@ export class LinkedNoteIndex {
     }
 
     this.startupHydrationPending = false;
+    this.resolveHydrationWaiters();
   }
 
   private scheduleLayoutReadyRescan(revision: number): void {
@@ -94,8 +93,57 @@ export class LinkedNoteIndex {
     return this.index.get(eventUid) || null;
   }
 
+  public async getFileForEventAfterHydration(
+    eventUid: string,
+    recurrenceId?: string
+  ): Promise<TFile | null> {
+    const existingFile = this.getFileForEvent(eventUid, recurrenceId);
+    if (existingFile) {
+      return existingFile;
+    }
+
+    await this.waitForStartupHydration();
+    return this.getFileForEvent(eventUid, recurrenceId);
+  }
+
+  public async waitForStartupHydration(timeoutMs = 1500): Promise<void> {
+    if (!this.startupHydrationPending) {
+      return;
+    }
+
+    const revision = this.revision;
+    this.reconcileStartupHydration(revision);
+    if (!this.startupHydrationPending || revision !== this.revision) {
+      return;
+    }
+
+    await new Promise<void>(resolve => {
+      const resolveOnce = () => {
+        window.clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = window.setTimeout(() => {
+        this.hydrationWaiters = this.hydrationWaiters.filter(waiter => waiter !== resolveOnce);
+        resolve();
+      }, timeoutMs);
+
+      this.hydrationWaiters.push(resolveOnce);
+    });
+  }
+
   private getDirectory(): string {
     return PluginState.getSettings().linkedNotesDirectory || '';
+  }
+
+  private frontmatterString(value: unknown): string | null {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed ? trimmed : null;
+    }
+    if (typeof value === 'number' || typeof value === 'bigint') {
+      return value.toString();
+    }
+    return null;
   }
 
   private isFileInDirectory(file: TFile): boolean {
@@ -169,15 +217,12 @@ export class LinkedNoteIndex {
       return this.removePathFromIndex(file.path, triggerReload);
     }
 
-    const calId = frontmatter['fc-calendar-id'] as unknown;
-    const eventUid = frontmatter['fc-event-uid'] as unknown;
-    const recurrenceId = frontmatter['fc-event-recurrence-id'] as unknown;
+    const calId = this.frontmatterString(frontmatter['fc-calendar-id']);
+    const eventUid = this.frontmatterString(frontmatter['fc-event-uid']);
+    const recurrenceId = this.frontmatterString(frontmatter['fc-event-recurrence-id']);
 
-    if (calId === this.calendarId && typeof eventUid === 'string' && eventUid.trim() !== '') {
-      const recurrenceSuffix =
-        typeof recurrenceId === 'string' && recurrenceId.trim() !== ''
-          ? `::${recurrenceId.trim()}`
-          : '';
+    if (calId === this.calendarId && eventUid) {
+      const recurrenceSuffix = recurrenceId ? `::${recurrenceId}` : '';
       const key = `${eventUid}${recurrenceSuffix}`;
 
       // Clean up any stale mappings in the index map that point to the same file path but have a different key
@@ -275,6 +320,7 @@ export class LinkedNoteIndex {
   public destroy(): void {
     this.revision += 1;
     this.startupHydrationPending = false;
+    this.resolveHydrationWaiters();
     for (const ref of this.eventRefs) {
       // metadataCache and vault can offref their listeners
       this.app.metadataCache.offref(ref);
@@ -282,5 +328,13 @@ export class LinkedNoteIndex {
     }
     this.eventRefs = [];
     this.index.clear();
+  }
+
+  private resolveHydrationWaiters(): void {
+    const waiters = this.hydrationWaiters;
+    this.hydrationWaiters = [];
+    for (const resolve of waiters) {
+      resolve();
+    }
   }
 }

--- a/src/providers/utils/noteUtils.test.ts
+++ b/src/providers/utils/noteUtils.test.ts
@@ -106,7 +106,19 @@ describe('noteUtils', () => {
         active: true
       };
       const yaml = serializeFrontmatter(fields);
-      expect(yaml).toBe('fc-event-uid: 12345\nfc-calendar-id: cal-1\nactive: true');
+      expect(yaml).toBe('fc-event-uid: "12345"\nfc-calendar-id: "cal-1"\nactive: true');
+    });
+
+    it('should quote and escape string values so identifiers stay strings', () => {
+      const yaml = serializeFrontmatter({
+        'fc-event-uid': '12345',
+        title: 'Quote "heavy" task',
+        path: 'Folder\\Note'
+      });
+
+      expect(yaml).toBe(
+        'fc-event-uid: "12345"\ntitle: "Quote \\"heavy\\" task"\npath: "Folder\\\\Note"'
+      );
     });
   });
 

--- a/src/providers/utils/noteUtils.ts
+++ b/src/providers/utils/noteUtils.ts
@@ -120,10 +120,15 @@ type PrintableAtom =
   | boolean
   | null;
 
+function escapeYamlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function stringifyYamlLine(k: string, v: PrintableAtom): string {
   if (v === null) return `${k}:`;
   if (Array.isArray(v)) return `${k}: [${v.join(',')}]`;
   if (typeof v === 'object') return `${k}: ${JSON.stringify(v)}`;
+  if (typeof v === 'string') return `${k}: ${escapeYamlString(v)}`;
   return `${k}: ${v}`;
 }
 


### PR DESCRIPTION
Task backlog CalDAV note opens used a provider-specific path that called createLinkedNoteForTask directly. That bypassed the same open-or-create helper used by calendar events, so it did not consistently wait for linked-note index hydration before deciding whether an existing note was missing.

The linked-note index also had two independent false-negative cases. First, startup hydration could complete as soon as any linked note was indexed, even while other note files in the linked-notes directory still had unresolved Obsidian metadata. If the requested task note was one of those delayed files, the lookup returned null and created a duplicate with the -_-_-1 suffix. Second, unquoted numeric-looking UIDs in YAML frontmatter could be parsed as numbers, while the index only accepted string UIDs.

Route CalDAV backlog opens through openOrCreateLinkedNote, add an index API that waits for startup hydration before returning a miss, keep hydration pending until no linked-note files remain unresolved, normalize frontmatter identifiers to strings for backward compatibility, and quote string values when writing new frontmatter so numeric UIDs stay strings.

Add regression coverage for delayed metadata hydration, mixed indexed/unresolved linked-note files, numeric UID frontmatter, quoted YAML serialization, and updated remote provider linked-note output.

This should finally solve the -_-_-1 nonsense.