### PR TITLE
Fix various task backlog scheduling issues and flows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,25 +5,25 @@ jobs:
     format:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ github.head_ref }}
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22.x"
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
             - run: pnpm install --no-frozen-lockfile
             - run: pnpm run lint
             - run: pnpm run compile
     tests:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ github.head_ref }}
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22.x"
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
             - run: pnpm install --no-frozen-lockfile
             - run: pnpm run test-update

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4 # Use a more recent version of checkout
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/draft-release-attest.yml
+++ b/.github/workflows/draft-release-attest.yml
@@ -15,14 +15,14 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: "22.x"
 
-            - uses: pnpm/action-setup@v4
+            - uses: pnpm/action-setup@v6
               with:
                   run_install: false
 

--- a/src/core/EventCache.ts
+++ b/src/core/EventCache.ts
@@ -328,6 +328,10 @@ export default class EventCache {
     return this.mutationHandler.scheduleTask(taskId, date, allDay);
   }
 
+  unscheduleTaskEvent(eventId: string): Promise<void> {
+    return this.mutationHandler.unscheduleTaskEvent(eventId);
+  }
+
   validateTaskSchedule(taskId: string, date: Date): Promise<{ isValid: boolean; reason?: string }> {
     return this.mutationHandler.validateTaskSchedule(taskId, date);
   }

--- a/src/core/cache/CacheMutationHandler.ts
+++ b/src/core/cache/CacheMutationHandler.ts
@@ -4,7 +4,7 @@ import { OFCEvent } from '../../types';
 
 import { t } from '../../features/i18n/i18n';
 import { CacheEntry } from './types';
-import { CalendarProvider } from '../../providers/Provider';
+import { CalendarProvider, TaskBacklogProvider } from '../../providers/Provider';
 import { CacheContext } from './CacheSyncHandler';
 import { EventPathLocation } from '../EventStore';
 import { DateTime } from 'luxon';
@@ -481,8 +481,29 @@ export class CacheMutationHandler {
 
     await provider.scheduleTask(taskId, date, allDay);
 
-    // Refresh views and reload if provider demands it
-    PluginState.getProviderRegistry().reloadProviderNow(provider.getTaskBacklogInfo().id);
+    const events = await provider.getEvents();
+    PluginState.getCache()?.syncCalendar(provider.getTaskBacklogInfo().id, events);
+    PluginState.getProviderRegistry().refreshBacklogViews();
+    PluginState.getProviderRegistry().refreshCalDAVTaskInboxViews();
+  }
+
+  public async unscheduleTaskEvent(eventId: string): Promise<void> {
+    const details = this.ctx.store.getEventDetails(eventId);
+    if (!details?.event.uid) {
+      throw new Error(`No scheduled task found for event ID: ${eventId}`);
+    }
+
+    const provider = this.ctx.calendars.get(details.calendarId) as
+      | (CalendarProvider<unknown> & TaskBacklogProvider)
+      | undefined;
+    if (!provider?.unscheduleTask) {
+      throw new Error(`Task provider does not support returning tasks to the backlog.`);
+    }
+
+    await provider.unscheduleTask(details.event.uid);
+
+    const events = await provider.getEvents();
+    PluginState.getCache()?.syncCalendar(details.calendarId, events);
     PluginState.getProviderRegistry().refreshBacklogViews();
     PluginState.getProviderRegistry().refreshCalDAVTaskInboxViews();
   }

--- a/src/features/task-backlogs/TaskBacklogView.ts
+++ b/src/features/task-backlogs/TaskBacklogView.ts
@@ -1,4 +1,4 @@
-import { ItemView, setIcon, WorkspaceLeaf } from 'obsidian';
+import { ItemView, Menu, setIcon, WorkspaceLeaf } from 'obsidian';
 import { Draggable } from '@fullcalendar/interaction';
 import FullCalendarPlugin from '../../main';
 import { PluginState } from '../../core/PluginState';
@@ -150,10 +150,16 @@ export class TaskBacklogView extends ItemView {
   }
 
   private updateDisplayedTasks(): void {
-    this.filteredTasks = this.filterTasks(this.tasks, this.searchQuery);
+    this.filteredTasks = this.filterTasks(this.getOpenTasks(), this.searchQuery);
+    const totalPages = Math.max(1, Math.ceil(this.filteredTasks.length / this.TASKS_PER_PAGE));
+    this.currentPage = Math.min(this.currentPage, totalPages);
     const startIndex = (this.currentPage - 1) * this.TASKS_PER_PAGE;
     const endIndex = startIndex + this.TASKS_PER_PAGE;
     this.displayedTasks = this.filteredTasks.slice(startIndex, endIndex);
+  }
+
+  private getOpenTasks(): ProviderTaskBacklogItem[] {
+    return this.tasks.filter(task => !task.completed);
   }
 
   private filterTasks(tasks: ProviderTaskBacklogItem[], query: string): ProviderTaskBacklogItem[] {
@@ -199,9 +205,10 @@ export class TaskBacklogView extends ItemView {
     }
     this.renderSearchBar(header);
 
+    const openTaskCount = this.getOpenTasks().length;
     const countText = this.searchQuery.trim()
-      ? `${this.filteredTasks.length} of ${this.tasks.length} unscheduled tasks`
-      : `${this.tasks.length} unscheduled ${this.tasks.length === 1 ? 'task' : 'tasks'}`;
+      ? `${this.filteredTasks.length} of ${openTaskCount} unscheduled tasks`
+      : `${openTaskCount} unscheduled ${openTaskCount === 1 ? 'task' : 'tasks'}`;
     header.createDiv({
       text: countText,
       cls: 'tasks-backlog-count'
@@ -442,6 +449,9 @@ export class TaskBacklogView extends ItemView {
           'data-task-id': task.id
         }
       });
+      taskItem.addEventListener('contextmenu', event => {
+        this.showTaskContextMenu(event, task);
+      });
 
       const titleRow = taskItem.createDiv({ cls: 'tasks-backlog-title-row' });
       const checkbox = titleRow.createEl('input', {
@@ -449,7 +459,14 @@ export class TaskBacklogView extends ItemView {
         attr: { type: 'checkbox' }
       });
       checkbox.checked = task.completed;
-      checkbox.disabled = true;
+      checkbox.disabled = typeof task.provider.setTaskBacklogItemComplete !== 'function';
+      checkbox.addEventListener('click', event => {
+        event.stopPropagation();
+      });
+      checkbox.addEventListener('change', event => {
+        event.stopPropagation();
+        void this.setTaskCompleted(task, checkbox);
+      });
 
       titleRow.createSpan({
         text: task.title,
@@ -481,6 +498,89 @@ export class TaskBacklogView extends ItemView {
     this.draggable = new Draggable(tasksList, {
       itemSelector: '.tasks-backlog-item'
     });
+  }
+
+  private showTaskContextMenu(event: MouseEvent, task: ProviderTaskBacklogItem): void {
+    event.preventDefault();
+    const menu = new Menu();
+    let hasActions = false;
+
+    if (task.provider.openTaskBacklogItem) {
+      menu.addItem(item => {
+        item
+          .setTitle(t('ui.view.contextMenu.goToNote'))
+          .setIcon('file-text')
+          .onClick(() => {
+            void task.provider.openTaskBacklogItem?.(task.id);
+          });
+      });
+      hasActions = true;
+    }
+
+    if (task.provider.deleteTaskBacklogItem) {
+      menu.addItem(item => {
+        item
+          .setTitle(t('ui.view.contextMenu.delete'))
+          .setIcon('trash-2')
+          .onClick(() => {
+            void this.deleteTask(task);
+          });
+      });
+      hasActions = true;
+    }
+
+    if (!hasActions) {
+      menu.addItem(item => {
+        item.setTitle(t('ui.view.contextMenu.noActions')).setIcon('info').setDisabled(true);
+      });
+    }
+
+    menu.showAtMouseEvent(event);
+  }
+
+  private async deleteTask(task: ProviderTaskBacklogItem): Promise<void> {
+    if (!task.provider.deleteTaskBacklogItem) {
+      return;
+    }
+
+    try {
+      await task.provider.deleteTaskBacklogItem(task.id);
+      await this.loadTasks();
+      this.render();
+    } catch (err) {
+      console.warn('[TaskBacklogView] Failed to delete task.', err);
+    }
+  }
+
+  private async setTaskCompleted(
+    task: ProviderTaskBacklogItem,
+    checkbox: HTMLInputElement
+  ): Promise<void> {
+    if (!task.provider.setTaskBacklogItemComplete) {
+      checkbox.checked = task.completed;
+      return;
+    }
+
+    checkbox.disabled = true;
+    const nextCompleted = checkbox.checked;
+    const previousCompleted = task.completed;
+
+    try {
+      const success = await task.provider.setTaskBacklogItemComplete(task.id, nextCompleted);
+      if (!success) {
+        checkbox.checked = previousCompleted;
+        checkbox.disabled = false;
+        return;
+      }
+
+      task.completed = nextCompleted;
+      await this.loadTasks();
+      this.render();
+    } catch (err) {
+      console.warn('[TaskBacklogView] Failed to update task completion.', err);
+      checkbox.checked = previousCompleted;
+      checkbox.disabled = false;
+    }
   }
 
   private renderPaginationControls(container: HTMLElement): void {

--- a/src/providers/Provider.ts
+++ b/src/providers/Provider.ts
@@ -34,10 +34,13 @@ export interface TaskBacklogProvider {
   getTaskBacklogInfo(): TaskBacklogInfo;
   getTaskBacklogItems(): Promise<TaskBacklogItem[]>;
   createTaskBacklogItem?(title: string): Promise<TaskBacklogItem>;
+  setTaskBacklogItemComplete?(taskId: string, isDone: boolean): Promise<boolean>;
   openTaskBacklogItem?(taskId: string): Promise<void>;
+  deleteTaskBacklogItem?(taskId: string): Promise<void>;
   refreshTaskBacklogItems?(): Promise<TaskBacklogItem[]>;
   ownsTaskId(taskId: string): boolean;
   scheduleTask(taskId: string, date: Date, allDay?: boolean): Promise<void>;
+  unscheduleTask?(taskId: string): Promise<void>;
   validateTaskSchedule?(taskId: string, date: Date): Promise<{ isValid: boolean; reason?: string }>;
 }
 

--- a/src/providers/caldav/CalDAVProvider.test.ts
+++ b/src/providers/caldav/CalDAVProvider.test.ts
@@ -455,6 +455,73 @@ END:VCALENDAR`;
     expect(body).not.toContain('VALUE=DATE:20260615');
   });
 
+  it('returns a scheduled CalDAV task to the backlog by removing dates', async () => {
+    const mockInboxPropfind = `
+      <d:multistatus xmlns:d="DAV:">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/task-1.ics</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:getetag>"task-etag"</d:getetag>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    const mockIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-1
+SUMMARY:Schedule Me
+STATUS:NEEDS-ACTION
+DTSTART;TZID=Europe/Amsterdam:20260615T143000
+DUE;TZID=Europe/Amsterdam:20260615T153000
+END:VTODO
+END:VCALENDAR`;
+
+    mockObsidianFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(mockInboxPropfind)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 200,
+        text: () => Promise.resolve(mockIcs)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 204,
+        statusText: 'No Content'
+      } as Response);
+
+    await provider.unscheduleTask('task-1');
+
+    const body = mockObsidianFetch.mock.calls[2][1]?.body;
+    if (typeof body !== 'string') {
+      throw new Error('Expected CalDAV PUT body to be a string');
+    }
+    expect(body).not.toContain('DTSTART');
+    expect(body).not.toContain('DUE');
+    await expect(provider.getUndatedTasks()).resolves.toEqual([
+      expect.objectContaining({ uid: 'task-1', title: 'Schedule Me' })
+    ]);
+  });
+
+  it('deletes an unscheduled CalDAV backlog task', async () => {
+    mockObsidianFetch.mockResolvedValueOnce({
+      status: 204,
+      statusText: 'No Content'
+    } as Response);
+
+    await provider.deleteTaskBacklogItem('caldav::caldav_1::task-1');
+
+    expect(mockObsidianFetch).toHaveBeenCalledWith(
+      'https://example.com/caldav/user/calendar/events/task-1.ics',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
   it('should preserve unique sync keys for recurring series and recurrence exceptions', async () => {
     const mockPropfindResponse = `
       <d:multistatus xmlns:d="DAV:">

--- a/src/providers/caldav/CalDAVProvider.ts
+++ b/src/providers/caldav/CalDAVProvider.ts
@@ -924,6 +924,68 @@ export class CalDAVProvider
     return this.toTaskBacklogItem(task);
   }
 
+  async deleteTaskBacklogItem(taskId: string): Promise<void> {
+    const parsed = parseCalDAVTaskId(taskId);
+    let taskUid = taskId;
+    if (parsed) {
+      if (parsed.calendarId !== this.source.id) {
+        throw new Error(`CalDAV task ID ${taskId} does not belong to this provider.`);
+      }
+      taskUid = parsed.uid;
+    }
+
+    await this.deleteEvent({ persistentId: taskUid });
+    this.undatedTaskCache = this.undatedTaskCache.filter(task => task.uid !== taskUid);
+    this.hasLoadedUndatedTasks = true;
+  }
+
+  async setTaskBacklogItemComplete(taskId: string, isDone: boolean): Promise<boolean> {
+    const parsed = parseCalDAVTaskId(taskId);
+    let taskUid = taskId;
+    if (parsed) {
+      if (parsed.calendarId !== this.source.id) {
+        return false;
+      }
+      taskUid = parsed.uid;
+    }
+
+    const authHeader = createBasicAuthHeader(this.source.username, this.source.password);
+    const objects = await fetchCalendarObjectsViaPropfindFallback(this.source.homeUrl, authHeader);
+
+    for (const object of objects) {
+      const vcalendar = parseVCalendar(object.ics);
+      const todo = findTodoByUid(vcalendar, taskUid);
+      if (!todo || !isUnscheduledTodo(todo)) {
+        continue;
+      }
+
+      todo.updatePropertyWithValue('status', isDone ? 'COMPLETED' : 'NEEDS-ACTION');
+      if (isDone) {
+        todo.updatePropertyWithValue('completed', ical.Time.now());
+      } else {
+        todo.removeAllProperties('completed');
+      }
+      todo.updatePropertyWithValue('last-modified', ical.Time.now());
+
+      const url = resolveCollectionObjectUrl(this.source.homeUrl, object.href);
+      await this.doRequest(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'text/calendar; charset=utf-8',
+          ...(object.etag ? { 'If-Match': object.etag } : {})
+        },
+        body: (vcalendar as unknown as { toString(): string }).toString()
+      });
+
+      this.undatedTaskCache = this.undatedTaskCache.filter(task => task.uid !== taskUid);
+      this.hasLoadedUndatedTasks = true;
+      PluginState.getProviderRegistry().refreshBacklogViews();
+      return true;
+    }
+
+    return false;
+  }
+
   async openTaskBacklogItem(taskId: string): Promise<void> {
     const parsed = parseCalDAVTaskId(taskId);
     if (!parsed || parsed.calendarId !== this.source.id) {
@@ -1142,6 +1204,56 @@ export class CalDAVProvider
     }
 
     throw new Error(`CalDAV task ${taskUid} was not found or is already scheduled.`);
+  }
+
+  async unscheduleTask(taskId: string): Promise<void> {
+    const parsed = parseCalDAVTaskId(taskId);
+    let taskUid = taskId;
+    if (parsed) {
+      if (parsed.calendarId !== this.source.id) {
+        throw new Error(`CalDAV task ID ${taskId} does not belong to this provider.`);
+      }
+      taskUid = parsed.uid;
+    }
+    const authHeader = createBasicAuthHeader(this.source.username, this.source.password);
+    const objects = await fetchCalendarObjectsViaPropfindFallback(this.source.homeUrl, authHeader);
+
+    for (const object of objects) {
+      const vcalendar = parseVCalendar(object.ics);
+      const todo = findTodoByUid(vcalendar, taskUid);
+      if (!todo) {
+        continue;
+      }
+
+      todo.removeAllProperties('dtstart');
+      todo.removeAllProperties('due');
+      todo.updatePropertyWithValue('last-modified', ical.Time.now());
+
+      const url = resolveCollectionObjectUrl(this.source.homeUrl, object.href);
+      await this.doRequest(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'text/calendar; charset=utf-8',
+          ...(object.etag ? { 'If-Match': object.etag } : {})
+        },
+        body: (vcalendar as unknown as { toString(): string }).toString()
+      });
+
+      const updatedIcs = (vcalendar as unknown as { toString(): string }).toString();
+      const unscheduledTasks = parseUnscheduledTasksFromObject(
+        { ...object, ics: updatedIcs },
+        this.source.id,
+        this.source.name
+      );
+      this.undatedTaskCache = [
+        ...this.undatedTaskCache.filter(task => task.uid !== taskUid),
+        ...unscheduledTasks
+      ];
+      this.hasLoadedUndatedTasks = true;
+      return;
+    }
+
+    throw new Error(`CalDAV task ${taskUid} was not found.`);
   }
 
   async createInstanceOverride(

--- a/src/providers/googletasks/GoogleTasksProvider.test.ts
+++ b/src/providers/googletasks/GoogleTasksProvider.test.ts
@@ -5,6 +5,18 @@ import * as React from 'react';
 import { GoogleTasksProvider } from './GoogleTasksProvider';
 import FullCalendarPlugin from '../../main';
 import { GoogleTasksProviderConfig } from './typesGoogleTasks';
+import { makeAuthenticatedRequest } from '../google/auth/request';
+
+jest.mock('../google/auth/request', () => ({
+  makeAuthenticatedRequest: jest.fn(),
+  GoogleApiError: class GoogleApiError extends Error {}
+}));
+
+jest.mock('../google/auth/GoogleAuthManager', () => ({
+  GoogleAuthManager: jest.fn().mockImplementation(() => ({
+    getTokenForSource: jest.fn().mockResolvedValue('token')
+  }))
+}));
 
 describe('GoogleTasksProvider Configuration Wrapper', () => {
   let mockPlugin: FullCalendarPlugin;
@@ -51,6 +63,7 @@ describe('GoogleTasksProvider ownsTaskId', () => {
   let provider: GoogleTasksProvider;
 
   beforeEach(() => {
+    (makeAuthenticatedRequest as jest.Mock).mockReset();
     mockPlugin = {
       app: {
         vault: {},
@@ -81,5 +94,39 @@ describe('GoogleTasksProvider ownsTaskId', () => {
   it('should not own improperly formatted taskId', () => {
     expect(provider.ownsTaskId('googletasks_1')).toBe(false);
     expect(provider.ownsTaskId('googletasks_1::task_123::extra')).toBe(false);
+  });
+
+  it('returns a scheduled Google Task to the backlog by clearing its due date', async () => {
+    (makeAuthenticatedRequest as jest.Mock)
+      .mockResolvedValueOnce({
+        id: 'task_123',
+        title: 'Schedule Me',
+        status: 'needsAction',
+        due: '2026-06-15T00:00:00.000Z'
+      })
+      .mockResolvedValueOnce({});
+
+    await provider.unscheduleTask('task_123');
+
+    expect(makeAuthenticatedRequest).toHaveBeenCalledTimes(2);
+    expect(makeAuthenticatedRequest).toHaveBeenNthCalledWith(
+      2,
+      'token',
+      'https://tasks.googleapis.com/tasks/v1/lists/list_123/tasks/task_123',
+      'PUT',
+      expect.objectContaining({ due: undefined })
+    );
+  });
+
+  it('deletes a backlog Google Task by provider-prefixed task ID', async () => {
+    (makeAuthenticatedRequest as jest.Mock).mockResolvedValueOnce({});
+
+    await provider.deleteTaskBacklogItem('googletasks_1::task_123');
+
+    expect(makeAuthenticatedRequest).toHaveBeenCalledWith(
+      'token',
+      'https://tasks.googleapis.com/tasks/v1/lists/list_123/tasks/task_123',
+      'DELETE'
+    );
   });
 });

--- a/src/providers/googletasks/GoogleTasksProvider.ts
+++ b/src/providers/googletasks/GoogleTasksProvider.ts
@@ -416,6 +416,35 @@ export class GoogleTasksProvider
     };
   }
 
+  async deleteTaskBacklogItem(taskId: string): Promise<void> {
+    const parts = taskId.split('::');
+    const taskUid = parts.length === 2 ? parts[1] : taskId;
+    await this.deleteEvent({ persistentId: taskUid });
+  }
+
+  async setTaskBacklogItemComplete(taskId: string, isDone: boolean): Promise<boolean> {
+    const parts = taskId.split('::');
+    const taskUid = parts[1];
+    const token = await this.getToken();
+    if (!token || !taskUid) return false;
+
+    try {
+      const getUrl = `https://tasks.googleapis.com/tasks/v1/lists/${encodeURIComponent(this.source.listId)}/tasks/${encodeURIComponent(taskUid)}`;
+      const task = await makeAuthenticatedRequest<GoogleTaskApiItem>(token, getUrl);
+
+      task.status = isDone ? 'completed' : 'needsAction';
+      task.completed = isDone ? DateTime.now().toISO() : undefined;
+
+      const putUrl = `https://tasks.googleapis.com/tasks/v1/lists/${encodeURIComponent(this.source.listId)}/tasks/${encodeURIComponent(taskUid)}`;
+      await makeAuthenticatedRequest(token, putUrl, 'PUT', task);
+      PluginState.getProviderRegistry().refreshBacklogViews();
+      return true;
+    } catch (e) {
+      console.error('Error toggling Google Tasks backlog item completion state:', e);
+      return false;
+    }
+  }
+
   ownsTaskId(taskId: string): boolean {
     const parts = taskId.split('::');
     return parts.length === 2 && parts[0] === this.source.id;
@@ -434,6 +463,20 @@ export class GoogleTasksProvider
     const task = await makeAuthenticatedRequest<GoogleTaskApiItem>(token, getUrl);
 
     task.due = dueString;
+
+    const putUrl = `https://tasks.googleapis.com/tasks/v1/lists/${encodeURIComponent(this.source.listId)}/tasks/${encodeURIComponent(taskUid)}`;
+    await makeAuthenticatedRequest(token, putUrl, 'PUT', task);
+  }
+
+  async unscheduleTask(taskId: string): Promise<void> {
+    const parts = taskId.split('::');
+    const taskUid = parts.length === 2 ? parts[1] : taskId;
+    const token = await this.getToken();
+    if (!token) throw new Error('Cannot unschedule Google Task: not authenticated.');
+
+    const getUrl = `https://tasks.googleapis.com/tasks/v1/lists/${encodeURIComponent(this.source.listId)}/tasks/${encodeURIComponent(taskUid)}`;
+    const task = await makeAuthenticatedRequest<GoogleTaskApiItem>(token, getUrl);
+    task.due = undefined;
 
     const putUrl = `https://tasks.googleapis.com/tasks/v1/lists/${encodeURIComponent(this.source.listId)}/tasks/${encodeURIComponent(taskUid)}`;
     await makeAuthenticatedRequest(token, putUrl, 'PUT', task);

--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -15,7 +15,7 @@ import { showNotice } from '../../utils/showNotice';
  */
 
 import { PluginState } from '../../core/PluginState';
-import { EventRef, TFile } from 'obsidian';
+import { EventRef, MarkdownView, TFile } from 'obsidian';
 import FullCalendarPlugin from '../../main';
 import { ObsidianInterface } from '../../ObsidianAdapter';
 import { OFCEvent, EventLocation } from '../../types';
@@ -120,6 +120,10 @@ export function updateTimeInLine(
   }
 
   return result;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -711,6 +715,57 @@ export class TasksPluginProvider
     }));
   }
 
+  public async setTaskBacklogItemComplete(taskId: string, isDone: boolean): Promise<boolean> {
+    try {
+      const task = this.allTasks.find(t => t.id === taskId);
+      if (!task) {
+        throw new Error(`Task with persistent ID ${taskId} not found in provider cache.`);
+      }
+
+      const newLine = this.setDoneState(task.originalMarkdown, isDone);
+      if (newLine === task.originalMarkdown) {
+        return true;
+      }
+
+      await this.replaceTaskInFile(task.filePath, task.lineNumber, [newLine]);
+      task.originalMarkdown = newLine;
+      task.isDone = isDone;
+      PluginState.getProviderRegistry().refreshBacklogViews();
+      return true;
+    } catch (e) {
+      if (e instanceof Error) {
+        console.error('Error toggling backlog task completion:', e);
+        showNotice(e.message);
+      }
+      return false;
+    }
+  }
+
+  public async openTaskBacklogItem(taskId: string): Promise<void> {
+    const [filePath, lineNumberStr] = taskId.split('::');
+    const lineNumber = Number.parseInt(lineNumberStr, 10);
+    if (!filePath || !Number.isFinite(lineNumber)) {
+      throw new Error('Invalid task handle format. Expected "filePath::lineNumber".');
+    }
+
+    const file = this.plugin.app.vault.getAbstractFileByPath(filePath);
+    if (!(file instanceof TFile)) {
+      throw new Error(`Task file not found: ${filePath}`);
+    }
+
+    const leaf = this.plugin.app.workspace.getLeaf(true);
+    await leaf.openFile(file);
+    if (leaf.view instanceof MarkdownView) {
+      leaf.view.editor.setCursor({ line: lineNumber, ch: 0 });
+    }
+  }
+
+  public async deleteTaskBacklogItem(taskId: string): Promise<void> {
+    await this.deleteEvent({ persistentId: taskId });
+    this.allTasks = this.allTasks.filter(task => task.id !== taskId);
+    PluginState.getProviderRegistry().refreshBacklogViews();
+  }
+
   public getEventsInFile(file: TFile): Promise<EditableEventResponse[]> {
     const events: EditableEventResponse[] = [];
     // Filter the live cache for tasks in the specified file. This is very fast.
@@ -759,7 +814,7 @@ export class TasksPluginProvider
     }
   }
 
-  private setTaskDate(task: CalendarTask, target: TasksDateTarget, date: Date): void {
+  private setTaskDate(task: CalendarTask, target: TasksDateTarget, date: Date | null): void {
     switch (target) {
       case 'startDate':
         task.startDate = date;
@@ -813,6 +868,23 @@ export class TasksPluginProvider
       return `${contentWithoutBlockLink.trim()} ${newDateComponent}${blockLinkMatch[1]}`;
     }
     return `${originalMarkdown.trim()} ${newDateComponent}`;
+  }
+
+  private clearTaskDateLine(
+    originalMarkdown: string,
+    target: TasksDateTarget = 'scheduledDate'
+  ): string {
+    const dateSymbol = this.getDateTargetEmoji(target);
+    const dateRegex = new RegExp(`\\s*${escapeRegExp(dateSymbol)}\\s*\\d{4}-\\d{2}-\\d{2}`, 'u');
+    const withoutTime = updateTimeInLine(
+      originalMarkdown,
+      null,
+      null,
+      PluginState.getSettings().timeFormat24h,
+      dateSymbol,
+      PluginState.getSettings().tasksIntegration.taskDisplayFormat ?? 'dayPlanner'
+    );
+    return withoutTime.replace(dateRegex, '').trimEnd();
   }
 
   // --- REPLACE createEvent and updateEvent with new versions ---
@@ -978,6 +1050,21 @@ export class TasksPluginProvider
     ) {
       showNotice(t('notices.tasks.scheduledNoModal'));
     }
+  }
+
+  public async unscheduleTask(taskId: string): Promise<void> {
+    const task = this.allTasks.find(t => t.id === taskId);
+    if (!task) {
+      throw new Error(`Cannot find original task to unschedule at ${taskId}`);
+    }
+
+    const dateTarget = PluginState.getSettings().tasksIntegration.calendarDisplayDateTarget;
+    const newLine = this.clearTaskDateLine(task.originalMarkdown, dateTarget);
+    await this.replaceTaskInFile(task.filePath, task.lineNumber, [newLine]);
+    task.originalMarkdown = newLine;
+    this.setTaskDate(task, dateTarget, null);
+    task.startTime = null;
+    task.endTime = null;
   }
 
   public async editInProviderUI(eventId: string): Promise<void> {

--- a/src/providers/tasks/tests/TasksPluginProvider.test.ts
+++ b/src/providers/tasks/tests/TasksPluginProvider.test.ts
@@ -384,6 +384,48 @@ describe('TasksPluginProvider', () => {
       await expect(provider.getUndatedTasks()).resolves.toEqual([]);
     });
 
+    it('returns scheduled tasks to the backlog by clearing the configured display date and time', async () => {
+      const file = { path: 'Daily.md' };
+      mockApp.getFileByPath.mockReturnValue(file);
+      mockApp.rewrite.mockImplementation((_file: unknown, update: (content: string) => string) => {
+        const updated = update('- [ ] Backlog task (9:00-10:00) 📅 2026-05-02');
+        expect(updated).toBe('- [ ] Backlog task');
+        return Promise.resolve();
+      });
+      mockPlugin.settings.tasksIntegration = {
+        backlogDateTarget: 'dueDate',
+        calendarDisplayDateTarget: 'dueDate',
+        openEditModalAfterBacklogDrop: false,
+        taskDisplayFormat: 'standard'
+      };
+      mockPlugin.app.workspace.trigger.mockImplementation(
+        (eventName: string, callback: (data: unknown) => void) => {
+          if (eventName === 'obsidian-tasks-plugin:request-cache-update') {
+            callback({
+              state: 'Warm',
+              tasks: [
+                {
+                  path: 'Daily.md',
+                  description: 'Backlog task (9:00-10:00)',
+                  taskLocation: { lineNumber: 0 },
+                  dueDate: { toDate: () => new Date('2026-05-02T00:00:00') },
+                  originalMarkdown: '- [ ] Backlog task (9:00-10:00) 📅 2026-05-02',
+                  isDone: false
+                }
+              ]
+            });
+          }
+        }
+      );
+
+      await provider.getEvents();
+      await provider.unscheduleTask('Daily.md::0');
+
+      await expect(provider.getUndatedTasks()).resolves.toEqual([
+        expect.objectContaining({ title: 'Backlog task' })
+      ]);
+    });
+
     it('filters backlog tasks by the configured Tasks date field', async () => {
       mockPlugin.settings.tasksIntegration = {
         backlogDateTarget: 'dueDate',
@@ -421,6 +463,74 @@ describe('TasksPluginProvider', () => {
       await expect(provider.getUndatedTasks()).resolves.toEqual([
         expect.objectContaining({ title: 'Scheduled only' })
       ]);
+    });
+
+    it('marks backlog tasks complete through the backlog checkbox action', async () => {
+      const file = { path: 'Daily.md' };
+      mockApp.getFileByPath.mockReturnValue(file);
+      mockApp.rewrite.mockImplementation((_file: unknown, update: (content: string) => string) => {
+        const updated = update('- [ ] Backlog task');
+        expect(updated).toMatch(/^- \[x\] Backlog task ✅ \d{4}-\d{2}-\d{2}$/);
+        return Promise.resolve();
+      });
+      mockPlugin.app.workspace.trigger.mockImplementation(
+        (eventName: string, callback: (data: unknown) => void) => {
+          if (eventName === 'obsidian-tasks-plugin:request-cache-update') {
+            callback({
+              state: 'Warm',
+              tasks: [
+                {
+                  path: 'Daily.md',
+                  description: 'Backlog task',
+                  taskLocation: { lineNumber: 0 },
+                  originalMarkdown: '- [ ] Backlog task',
+                  isDone: false
+                }
+              ]
+            });
+          }
+        }
+      );
+
+      await provider.getUndatedTasks();
+      await expect(provider.setTaskBacklogItemComplete('Daily.md::0', true)).resolves.toBe(true);
+
+      expect(mockPlugin.providerRegistry.refreshBacklogViews).toHaveBeenCalled();
+      await expect(provider.getUndatedTasks()).resolves.toEqual([]);
+    });
+
+    it('deletes backlog tasks through the backlog context menu action', async () => {
+      const file = { path: 'Daily.md' };
+      mockApp.getFileByPath.mockReturnValue(file);
+      mockApp.rewrite.mockImplementation((_file: unknown, update: (content: string) => string) => {
+        const updated = update('- [ ] Backlog task');
+        expect(updated).toBe('');
+        return Promise.resolve();
+      });
+      mockPlugin.app.workspace.trigger.mockImplementation(
+        (eventName: string, callback: (data: unknown) => void) => {
+          if (eventName === 'obsidian-tasks-plugin:request-cache-update') {
+            callback({
+              state: 'Warm',
+              tasks: [
+                {
+                  path: 'Daily.md',
+                  description: 'Backlog task',
+                  taskLocation: { lineNumber: 0 },
+                  originalMarkdown: '- [ ] Backlog task',
+                  isDone: false
+                }
+              ]
+            });
+          }
+        }
+      );
+
+      await provider.getUndatedTasks();
+      await provider.deleteTaskBacklogItem('Daily.md::0');
+
+      expect(mockPlugin.providerRegistry.refreshBacklogViews).toHaveBeenCalled();
+      await expect(provider.getUndatedTasks()).resolves.toEqual([]);
     });
 
     it('opens the Tasks edit modal after backlog drops only when enabled', async () => {

--- a/src/ui/calendar/ViewEventInteractionHandler.ts
+++ b/src/ui/calendar/ViewEventInteractionHandler.ts
@@ -290,11 +290,33 @@ export class ViewEventInteractionHandler {
       showNotice(t('ui.view.success.taskScheduled'));
 
       PluginState.getProviderRegistry().refreshBacklogViews();
-      void this.ctx.refreshView();
     } catch (error) {
       console.error('Failed to schedule task:', error);
       const message = error instanceof Error ? error.message : 'Unknown error occurred';
       showNotice(t('ui.view.errors.taskScheduleFailed', { message }));
+    }
+  }
+
+  public async handleEventDragStop(eventApi: EventApi, mouseEvent: MouseEvent): Promise<void> {
+    const target = mouseEvent.view?.document.elementFromPoint(
+      mouseEvent.clientX,
+      mouseEvent.clientY
+    );
+    if (!target?.instanceOf(Element) || !target.closest('.tasks-backlog-view')) {
+      return;
+    }
+
+    try {
+      if (!PluginState.getCache()) {
+        throw new Error('Event cache not available');
+      }
+
+      await PluginState.getCache().unscheduleTaskEvent(eventApi.id);
+      showNotice('Task returned to backlog');
+    } catch (error) {
+      console.error('Failed to return task to backlog:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error occurred';
+      showNotice(`Failed to return task to backlog: ${message}`);
     }
   }
 }

--- a/src/ui/settings/sections/calendars/calendar.ts
+++ b/src/ui/settings/sections/calendars/calendar.ts
@@ -53,6 +53,7 @@ interface ExtraRenderProps {
   getRecurringInstanceState?: (event: EventApi) => Promise<RecurringInstanceState | null>;
   dateRightClick?: (date: Date, mouseEvent: MouseEvent) => void;
   viewRightClick?: (mouseEvent: MouseEvent, calendar: Calendar) => void;
+  eventDragStop?: (event: EventApi, mouseEvent: MouseEvent) => void;
   forceNarrow?: boolean;
   resources?: { id: string; title: string; eventColor?: string }[];
   onViewChange?: () => void; // Add view change callback
@@ -143,6 +144,7 @@ export async function renderCalendar(
     getRecurringInstanceState,
     dateRightClick,
     viewRightClick,
+    eventDragStop,
     customButtons,
     resources,
     onViewChange,
@@ -444,11 +446,12 @@ export async function renderCalendar(
   let currentUpcomingEventIds = new Set<string>();
 
   const isEditableTarget = (target: EventTarget | null): boolean => {
-    if (!(target instanceof Element)) {
+    const element = target instanceof Node && target.instanceOf(Element) ? target : null;
+    if (!element) {
       return false;
     }
 
-    return !!target.closest(
+    return !!element.closest(
       'input, textarea, select, [contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"], .cm-content, .cm-editor, .markdown-source-view, .markdown-preview-view'
     );
   };
@@ -828,6 +831,11 @@ export async function renderCalendar(
     editable: modifyEvent && true,
     // Keep drag mirror anchored to the viewport, not transformed Obsidian panes.
     fixedMirrorParent: mirrorParent,
+    eventDragStop:
+      eventDragStop &&
+      (info => {
+        eventDragStop(info.event, info.jsEvent);
+      }),
     eventDrop: modifyEventCallback,
     eventResize: modifyEventCallback,
 

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -304,6 +304,9 @@ export class CalendarView extends ItemView implements ViewContext {
           }
           this.dateNavigation?.showViewContextMenu(mouseEvent, calendar);
         },
+        eventDragStop: (eventApi, mouseEvent) => {
+          void this.interactionHandler.handleEventDragStop(eventApi, mouseEvent);
+        },
         drop: (taskId, date, allDay) => this.interactionHandler.handleDrop(taskId, date, allDay)
       });
 


### PR DESCRIPTION
There were a lot of minor issues with the Task backlog system which I hopefully fixed here:

Fix task backlog interactions so scheduling and backlog state stay in sync without disrupting calendar navigation.

Previously, dragging a backlog task onto the calendar forced a provider reload and view refresh, which sent users back to the current date. Scheduling now syncs only the affected provider event source and refreshes backlog views, preserving the active calendar page.

Backlog checkboxes now update provider state, completed tasks are hidden from the backlog, and provider hooks cover Obsidian Tasks, CalDAV, and Google Tasks.

Tasks can also be dragged from the calendar back to the backlog. The drop-zone handling clears the same scheduled/deadline data that scheduling writes: Tasks date markers and time blocks, CalDAV DTSTART/DUE, and Google Tasks due dates.

Finally, backlog items now have a context menu with Go to Note and Delete where supported, backed by provider-level open/delete hooks and regression tests for the affected providers.