### PR TITLE
Fix CalDAV recurrence exceptions and provider reminders

### DIFF
--- a/docs/architecture/calendars/provider-blueprint.md
+++ b/docs/architecture/calendars/provider-blueprint.md
@@ -16,6 +16,9 @@ Implement the `CalendarProvider` interface with clear source capability boundari
 - `getEvents` is mandatory.
 - `createEvent` / `updateEvent` / `deleteEvent` should throw explicit read-only errors if unsupported.
 - `getEventHandle` must return stable persistent identity.
+- Set `CalendarProviderCapabilities.supportsAlarms` only when the provider can persist `OFCEvent.alarms`.
+- Set `CalendarProviderCapabilities.ownsRecurringInstanceOverrides` when single-instance recurrence edits are provider-native and shared recurrence code should not create local child notes or infer behavior from provider type strings.
+- Providers that serialize ICS must preserve recurrence semantics for both `type: rrule` and `type: recurring`; UI-created recurring events must leave the app as real provider recurrence rules, not as single events that only look recurring locally.
 - Optional hooks (`initialize`, `toggleComplete`, `canBeScheduledAt`) are allowed only when needed.
 
 If recurring instance complete/skip semantics are provider-owned, implement the normalized recurring-instance hooks described in [Provider Implementations and Patches](provider-implementations.md#provider-agnostic-recurring-instance-semantics).

--- a/docs/architecture/events/architecture.md
+++ b/docs/architecture/events/architecture.md
@@ -16,6 +16,11 @@ This page describes how event logic is organized.
 - Recurrence logic is delegated to dedicated feature managers.
 - Provider write operations are routed through provider registry.
 - Recurring instance completion/skip semantics are exposed through provider-agnostic contracts and implemented inside providers (no provider-specific recurrence branching in shared UI/core paths).
+- Provider-specific recurring overrides are declared through `CalendarProviderCapabilities.ownsRecurringInstanceOverrides`. Shared recurrence code checks that capability instead of hardcoding provider types.
+- CalDAV recurrence overrides are edited inside the shared server `.ics` object. Updating or deleting one override must replace or remove only the matching `VEVENT` with the same `UID` and `RECURRENCE-ID`; it must not PUT a one-event calendar over the whole resource or DELETE the resource URL.
+- Recurring deletes are centralized in `RecurringEventManager.handleDelete`. Any GUI path that calls `EventCache.deleteEvent()` for a recurring master or linked override must show the same recurring-delete modal unless the caller explicitly uses `force`.
+- Dragging or resizing a recurring occurrence opens `RescheduleRecurringModal`, allowing either an occurrence override or a whole-sequence update. Single events bypass this modal and use the normal update path.
+- ICS serialization treats both internal recurrence shapes as provider-recurring data: `type: rrule` is serialized from its raw `rrule`, and `type: recurring` is converted into an RFC 5545 `RRULE` before writing to CalDAV/ICS providers.
 
 ## Related User Docs
 

--- a/docs/architecture/system/features/reminders-architecture.md
+++ b/docs/architecture/system/features/reminders-architecture.md
@@ -33,6 +33,25 @@ If snooze was runtime-only, snoozing on a Desktop would not prevent a mobile dev
 
 ---
 
+## Provider Alarm Contract
+
+Full Calendar keeps two reminder concepts separate:
+
+*   `notify` is the Obsidian/local reminder value consumed by `NotificationManager`.
+*   `alarms` is provider-owned reminder data that syncs to remote calendar services.
+
+Providers that can persist provider alarms set `CalendarProviderCapabilities.supportsAlarms`. The edit modal reads that capability and shows the provider reminder control only for those calendars.
+
+Provider mappings:
+
+*   CalDAV serializes `alarms` as ICS `VALARM` components.
+*   Google serializes `alarms` as popup reminder overrides.
+*   Outlook serializes `alarms` as reminder minutes.
+
+Recurring instance overrides inherit `notify` and `alarms` from the master event unless the override explicitly supplies its own values. For CalDAV, override alarm edits are written by replacing the matching recurrence override component in the same `.ics` resource as the recurring master.
+
+---
+
 ## Startup Safety (Recency Cutoff)
 
 The manager implements a **5-minute recency cutoff**. If a reminder's trigger point was more than 5 minutes in the past (e.g., you open Obsidian at 14:05 for a 14:00 event with a 10-minute reminder), the notification is suppressed. This prevents a "spam" of missed notifications when starting the app after a long break.

--- a/docs/user/events/recurring.md
+++ b/docs/user/events/recurring.md
@@ -10,7 +10,9 @@ The recurring event system in Full Calendar is designed to be both powerful and 
     -   **Monthly:** The event will repeat on the same day of the month as the start date (e.g., the 15th).
     -   **Yearly:** The event will repeat on the same month and day as the start date (e.g., every January 15th).
 3.  Optionally, set a **Start Repeat** and **End Repeat** date to define the range of the recurrence.
-4.  Save the event. A single note will be created that represents the entire series.
+4.  Save the event. A single source item will be created that represents the entire series.
+
+For note-backed calendars this is stored as one recurring note event. For CalDAV calendars, Full Calendar writes a real calendar recurrence rule (`RRULE`) to the remote calendar, so the event is a proper provider-side sequence rather than several local-looking copies.
 
 <!-- TODO: Add GIF of new recurring modal with "Repeats" dropdown -->
 
@@ -31,6 +33,13 @@ The plugin will automatically:
 3.  Visually, it looks like you just moved one event, but the data is handled cleanly in the background.
 
 ![Creating an override by dragging a recurring event](../../assets/events/moving-event.gif)
+
+When you drag or resize an event that belongs to a recurring sequence, Full Calendar asks whether you want to:
+
+-   **Move only this instance:** create or update an override for the selected occurrence.
+-   **Move the entire sequence:** update the recurring event itself so every occurrence follows the new schedule.
+
+Single, non-recurring events move immediately without this prompt.
 
 ---
 
@@ -62,13 +71,14 @@ Note: Some fields on an override intentionally inherit from the parent rule and 
 
 ### Deleting a Recurring Event
 
-When you delete an event that is part of a recurring series, the plugin will ask you what you want to do.
+When you delete an event that is part of a recurring series, the plugin will ask you what you want to do. This happens consistently whether you delete from the event modal, a context menu, or another calendar UI action.
 
--   **Deleting an Override:** If you delete a single override you created, it will be removed and the original instance from the parent series will reappear in its place.
--   **Deleting a Master Event:** If you delete the main recurring event (the one that defines the series), you will be presented with a modal with two options:
-    1.  **Promote Children:** This deletes the master recurring rule but **converts all of its overrides into standalone events**. They will no longer be linked to the series.
-    2.  **Delete Everything:** This deletes the master recurring rule **and all of its child overrides**. This cannot be undone.
+-   **Delete only this instance:** If available for the selected occurrence, this removes just that occurrence or override and leaves the sequence intact.
+-   **Promote child events:** This deletes the recurring rule but converts its overrides into standalone events.
+-   **Delete sequence:** This deletes the recurring rule and every override associated with the sequence. This cannot be undone.
 
-Remote calendars (Google/ICS/CalDAV) respect cancellations and exceptions from the source and propagate them into the view.
+Remote calendars respect cancellations and exceptions from the source and propagate them into the view. Google, Outlook, and CalDAV own their recurring-instance overrides natively, so moving, editing, or deleting one instance is written back as a provider override instead of as a separate local note.
+
+For CalDAV, the master recurring event and its exceptions usually live together in one `.ics` resource on the server. Full Calendar updates that shared resource in place when you edit or delete a single override, so the rest of the recurring series remains intact.
 
 <!-- TODO: Add Screenshot of DeleteRecurringModal -->

--- a/docs/user/features/reminders.md
+++ b/docs/user/features/reminders.md
@@ -27,6 +27,16 @@ startTime: "14:00"
 notify: 15  # Trigger 15 minutes before start
 ```
 
+## Calendar Provider Reminders
+
+Some remote calendars also have their own reminder model. Full Calendar maps those provider reminders into `alarms` event data:
+
+*   CalDAV reminders are stored as ICS `VALARM` entries.
+*   Google popup reminders are stored as Google reminder overrides.
+*   Outlook reminders are stored as Outlook reminder minutes.
+
+When a calendar supports provider reminders, the event editor shows separate controls for the Obsidian reminder and the calendar-provider reminder. Recurring instance overrides inherit the parent reminder settings unless you explicitly change the override.
+
 ## The Reminder Modal
 
 When you click a system notification (or when a reminder triggers while Obsidian is focused), an interactive modal appears:

--- a/src/features/i18n/locales/de.json
+++ b/src/features/i18n/locales/de.json
@@ -1158,8 +1158,6 @@
         },
         "notification": {
           "label": "Benachrichtigen",
-          "select": "Auswählen...",
-          "mins": "Min.",
           "presets": {
             "30m": "30 Min.",
             "1h": "1 Stunde",
@@ -1434,6 +1432,22 @@
         "regex": "Regex",
         "btnAdd": "+ Regel hinzufügen"
       }
+    },
+    "rescheduleRecurring": {
+      "title": "Reschedule Recurring Event",
+      "description": "This is a recurring event. Choose whether to reschedule only this occurrence or the entire recurring sequence.",
+      "rescheduleInstance": {
+        "name": "Reschedule only this instance",
+        "description": "Move only the instance on {{date}}. The rest of the sequence will keep its current schedule.",
+        "descriptionNoDate": "Move only this instance. The rest of the sequence will keep its current schedule.",
+        "button": "Move This Instance"
+      },
+      "rescheduleSequence": {
+        "name": "Reschedule entire sequence",
+        "description": "Update the recurring event itself so every occurrence follows the new schedule.",
+        "button": "Move Sequence"
+      },
+      "cancel": "Cancel"
     }
   },
   "google": {
@@ -1499,12 +1513,9 @@
         "chronoAnalyserDesktopOnly": "Der Chrono-Analysator ist nur auf dem Desktop verfügbar.",
         "chronoAnalyserFailed": "Fehler beim Öffnen des Chrono-Analysators. Bitte überprüfen Sie die Konsole.",
         "modifyEventFailed": "Fehler beim Ändern des Ereignisses.",
-        "taskScheduleFailed": "Fehler beim Planen der Aufgabe: {{message}}",
-        "moveRecurringDayError": "Eine wiederkehrende Instanz kann nicht auf einen anderen Tag verschoben werden. Ändern Sie nur die Uhrzeit oder bearbeiten Sie das wiederkehrende Hauptereignis.",
-        "moveRecurringInstanceError": "Eine wiederkehrende Instanz kann nicht auf einen anderen Tag verschoben werden. Sie können nur die Uhrzeit ändern."
+        "taskScheduleFailed": "Fehler beim Planen der Aufgabe: {{message}}"
       },
       "success": {
-        "deletedEvent": "Ereignis \"{{title}}\" gelöscht.",
         "taskScheduled": "Aufgabe erfolgreich geplant"
       },
       "workspace": {

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -1169,8 +1169,6 @@
         },
         "notification": {
           "label": "Notify",
-          "select": "Select...",
-          "mins": "Mins",
           "presets": {
             "30m": "30 minutes",
             "1h": "1 hour",
@@ -1228,9 +1226,25 @@
         "button": "Promote Children"
       },
       "deleteAll": {
-        "name": "Delete child events",
-        "description": "Delete all future override events associated with this recurring series. This cannot be undone.",
-        "button": "Delete Everything"
+        "name": "Delete entire sequence",
+        "description": "Delete the recurring event and every override associated with this recurring series. This cannot be undone.",
+        "button": "Delete Sequence"
+      },
+      "cancel": "Cancel"
+    },
+    "rescheduleRecurring": {
+      "title": "Reschedule Recurring Event",
+      "description": "This is a recurring event. Choose whether to reschedule only this occurrence or the entire recurring sequence.",
+      "rescheduleInstance": {
+        "name": "Reschedule only this instance",
+        "description": "Move only the instance on {{date}}. The rest of the sequence will keep its current schedule.",
+        "descriptionNoDate": "Move only this instance. The rest of the sequence will keep its current schedule.",
+        "button": "Move This Instance"
+      },
+      "rescheduleSequence": {
+        "name": "Reschedule entire sequence",
+        "description": "Update the recurring event itself so every occurrence follows the new schedule.",
+        "button": "Move Sequence"
       },
       "cancel": "Cancel"
     },
@@ -1566,12 +1580,9 @@
         "chronoAnalyserDesktopOnly": "The ChronoAnalyser is only available on desktop.",
         "chronoAnalyserFailed": "Failed to open ChronoAnalyser. Please check the console.",
         "modifyEventFailed": "Failed to modify event.",
-        "taskScheduleFailed": "Failed to schedule task: {{message}}",
-        "moveRecurringDayError": "Cannot move a recurring instance to a different day. Modify the time only or edit the main recurring event.",
-        "moveRecurringInstanceError": "Cannot move a recurring instance to a different day. You can only change the time."
+        "taskScheduleFailed": "Failed to schedule task: {{message}}"
       },
       "success": {
-        "deletedEvent": "Deleted event \"{{title}}\".",
         "taskScheduled": "Task scheduled successfully"
       },
       "workspace": {

--- a/src/features/i18n/locales/es.json
+++ b/src/features/i18n/locales/es.json
@@ -1158,8 +1158,6 @@
         },
         "notification": {
           "label": "Notificar",
-          "select": "Seleccionar...",
-          "mins": "Min.",
           "presets": {
             "30m": "30 min",
             "1h": "1 hora",
@@ -1434,6 +1432,22 @@
         "regex": "Regex",
         "btnAdd": "+ Añadir Regla"
       }
+    },
+    "rescheduleRecurring": {
+      "title": "Reschedule Recurring Event",
+      "description": "This is a recurring event. Choose whether to reschedule only this occurrence or the entire recurring sequence.",
+      "rescheduleInstance": {
+        "name": "Reschedule only this instance",
+        "description": "Move only the instance on {{date}}. The rest of the sequence will keep its current schedule.",
+        "descriptionNoDate": "Move only this instance. The rest of the sequence will keep its current schedule.",
+        "button": "Move This Instance"
+      },
+      "rescheduleSequence": {
+        "name": "Reschedule entire sequence",
+        "description": "Update the recurring event itself so every occurrence follows the new schedule.",
+        "button": "Move Sequence"
+      },
+      "cancel": "Cancel"
     }
   },
   "google": {
@@ -1499,12 +1513,9 @@
         "chronoAnalyserDesktopOnly": "El Analizador Chrono solo está disponible en la versión de escritorio.",
         "chronoAnalyserFailed": "No se pudo abrir el Analizador Chrono. Revisa la consola.",
         "modifyEventFailed": "No se pudo modificar el evento.",
-        "taskScheduleFailed": "No se pudo programar la tarea: {{message}}",
-        "moveRecurringDayError": "No se puede mover una instancia recurrente a un día diferente. Modifica solo la hora o edita el evento recurrente principal.",
-        "moveRecurringInstanceError": "No se puede mover una instancia recurrente a un día diferente. Solo puedes cambiar la hora."
+        "taskScheduleFailed": "No se pudo programar la tarea: {{message}}"
       },
       "success": {
-        "deletedEvent": "Evento eliminado \"{{title}}\".",
         "taskScheduled": "Tarea programada con éxito"
       },
       "workspace": {

--- a/src/features/i18n/locales/fr.json
+++ b/src/features/i18n/locales/fr.json
@@ -1158,8 +1158,6 @@
         },
         "notification": {
           "label": "Notifier",
-          "select": "Sélectionner...",
-          "mins": "Min.",
           "presets": {
             "30m": "30 min",
             "1h": "1 heure",
@@ -1434,6 +1432,22 @@
         "regex": "Regex",
         "btnAdd": "+ Ajouter une Règle"
       }
+    },
+    "rescheduleRecurring": {
+      "title": "Reschedule Recurring Event",
+      "description": "This is a recurring event. Choose whether to reschedule only this occurrence or the entire recurring sequence.",
+      "rescheduleInstance": {
+        "name": "Reschedule only this instance",
+        "description": "Move only the instance on {{date}}. The rest of the sequence will keep its current schedule.",
+        "descriptionNoDate": "Move only this instance. The rest of the sequence will keep its current schedule.",
+        "button": "Move This Instance"
+      },
+      "rescheduleSequence": {
+        "name": "Reschedule entire sequence",
+        "description": "Update the recurring event itself so every occurrence follows the new schedule.",
+        "button": "Move Sequence"
+      },
+      "cancel": "Cancel"
     }
   },
   "google": {
@@ -1499,12 +1513,9 @@
         "chronoAnalyserDesktopOnly": "L'Analyseur Chrono n'est disponible que sur la version de bureau.",
         "chronoAnalyserFailed": "Échec de l'ouverture de l'Analyseur Chrono. Veuillez vérifier la console.",
         "modifyEventFailed": "Échec de la modification de l'événement.",
-        "taskScheduleFailed": "Échec de la planification de la tâche : {{message}}",
-        "moveRecurringDayError": "Impossible de déplacer une instance récurrente à un autre jour. Modifiez uniquement l'heure ou modifiez l'événement récurrent principal.",
-        "moveRecurringInstanceError": "Impossible de déplacer une instance récurrente à un autre jour. Vous ne pouvez modifier que l'heure."
+        "taskScheduleFailed": "Échec de la planification de la tâche : {{message}}"
       },
       "success": {
-        "deletedEvent": "Événement \"{{title}}\" supprimé.",
         "taskScheduled": "Tâche planifiée avec succès"
       },
       "workspace": {

--- a/src/features/i18n/locales/it.json
+++ b/src/features/i18n/locales/it.json
@@ -1158,8 +1158,6 @@
         },
         "notification": {
           "label": "Notifica",
-          "select": "Seleziona...",
-          "mins": "Min.",
           "presets": {
             "30m": "30 min",
             "1h": "1 ora",
@@ -1434,6 +1432,22 @@
         "regex": "Regex",
         "btnAdd": "+ Aggiungi Regola"
       }
+    },
+    "rescheduleRecurring": {
+      "title": "Reschedule Recurring Event",
+      "description": "This is a recurring event. Choose whether to reschedule only this occurrence or the entire recurring sequence.",
+      "rescheduleInstance": {
+        "name": "Reschedule only this instance",
+        "description": "Move only the instance on {{date}}. The rest of the sequence will keep its current schedule.",
+        "descriptionNoDate": "Move only this instance. The rest of the sequence will keep its current schedule.",
+        "button": "Move This Instance"
+      },
+      "rescheduleSequence": {
+        "name": "Reschedule entire sequence",
+        "description": "Update the recurring event itself so every occurrence follows the new schedule.",
+        "button": "Move Sequence"
+      },
+      "cancel": "Cancel"
     }
   },
   "google": {
@@ -1499,12 +1513,9 @@
         "chronoAnalyserDesktopOnly": "Il Chrono Analyser è disponibile solo sulla versione desktop.",
         "chronoAnalyserFailed": "Impossibile aprire il Chrono Analyser. Si prega di controllare la console.",
         "modifyEventFailed": "Impossibile modificare l'evento.",
-        "taskScheduleFailed": "Impossibile pianificare l'attività: {{message}}",
-        "moveRecurringDayError": "Impossibile spostare un'istanza ricorrente in un giorno diverso. Modifica solo l'orario o modifica l'evento ricorrente principale.",
-        "moveRecurringInstanceError": "Impossibile spostare un'istanza ricorrente in un giorno diverso. Puoi cambiare solo l'orario."
+        "taskScheduleFailed": "Impossibile pianificare l'attività: {{message}}"
       },
       "success": {
-        "deletedEvent": "Evento \"{{title}}\" eliminato.",
         "taskScheduled": "Attività pianificata con successo"
       },
       "workspace": {

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -1158,8 +1158,6 @@
         },
         "notification": {
           "label": "通知",
-          "select": "选择...",
-          "mins": "分钟",
           "presets": {
             "30m": "30 分钟",
             "1h": "1 小时",
@@ -1434,6 +1432,22 @@
         "save": "保存",
         "cancel": "取消"
       }
+    },
+    "rescheduleRecurring": {
+      "title": "Reschedule Recurring Event",
+      "description": "This is a recurring event. Choose whether to reschedule only this occurrence or the entire recurring sequence.",
+      "rescheduleInstance": {
+        "name": "Reschedule only this instance",
+        "description": "Move only the instance on {{date}}. The rest of the sequence will keep its current schedule.",
+        "descriptionNoDate": "Move only this instance. The rest of the sequence will keep its current schedule.",
+        "button": "Move This Instance"
+      },
+      "rescheduleSequence": {
+        "name": "Reschedule entire sequence",
+        "description": "Update the recurring event itself so every occurrence follows the new schedule.",
+        "button": "Move Sequence"
+      },
+      "cancel": "Cancel"
     }
   },
   "google": {
@@ -1499,12 +1513,9 @@
         "chronoAnalyserDesktopOnly": "数据分析器仅在桌面版可用。",
         "chronoAnalyserFailed": "打开数据分析器失败。请检查控制台。",
         "modifyEventFailed": "修改事件失败。",
-        "taskScheduleFailed": "安排任务失败：{{message}}",
-        "moveRecurringDayError": "无法将重复实例移动到不同日期。请仅修改时间或编辑主重复事件。",
-        "moveRecurringInstanceError": "无法将重复实例移动到不同日期。您只能修改时间。"
+        "taskScheduleFailed": "安排任务失败：{{message}}"
       },
       "success": {
-        "deletedEvent": "已删除事件 \"{{title}}\"。",
         "taskScheduled": "任务安排成功"
       },
       "workspace": {

--- a/src/features/recur_events/RecurringEventManager.test.ts
+++ b/src/features/recur_events/RecurringEventManager.test.ts
@@ -12,6 +12,9 @@ import { DEFAULT_SETTINGS, FullCalendarSettings } from '../../types/settings';
 import FullCalendarPlugin from '../../main';
 import type { ProviderRegistry } from '../../providers/ProviderRegistry';
 
+const mockOpenDeleteRecurringModal = jest.fn();
+const mockDeleteRecurringModalConstructor = jest.fn();
+
 // Mock Obsidian
 jest.mock(
   'obsidian',
@@ -29,6 +32,12 @@ jest.mock(
 
 // Mock dependencies
 jest.mock('../../core/EventCache');
+jest.mock('../../ui/modals/DeleteRecurringModal', () => ({
+  DeleteRecurringModal: jest.fn().mockImplementation((...args: unknown[]) => {
+    mockDeleteRecurringModalConstructor(...args);
+    return { open: mockOpenDeleteRecurringModal };
+  })
+}));
 
 describe('RecurringEventManager', () => {
   let manager: RecurringEventManager;
@@ -63,6 +72,11 @@ describe('RecurringEventManager', () => {
     mockProvider = {
       type: 'test',
       displayName: 'Test Provider',
+      getCapabilities: jest.fn(() => ({
+        canCreate: true,
+        canEdit: true,
+        canDelete: true
+      })),
       getEventHandle: jest.fn((event: OFCEvent) => ({ persistentId: event.title }))
     } as unknown as jest.Mocked<CalendarProvider<unknown>>;
 
@@ -97,6 +111,127 @@ describe('RecurringEventManager', () => {
     } as unknown as jest.Mocked<EventCache>;
 
     manager = new RecurringEventManager(mockCache, mockPlugin);
+    mockOpenDeleteRecurringModal.mockClear();
+    mockDeleteRecurringModalConstructor.mockClear();
+  });
+
+  describe('handleDelete', () => {
+    beforeEach(() => {
+      (PluginState.getProviderRegistry().getSource as jest.Mock).mockReturnValue({
+        type: 'local',
+        id: 'test-calendar',
+        directory: 'events'
+      });
+      (PluginState.getProviderRegistry().getInstance as jest.Mock).mockReturnValue(mockProvider);
+    });
+
+    it('does not show recurring delete options for single standalone events', async () => {
+      const event: OFCEvent = {
+        type: 'single',
+        title: 'One-off',
+        date: '2026-06-08',
+        endDate: null,
+        allDay: true
+      };
+      (mockCache.store.getEventDetails as jest.Mock).mockReturnValue({
+        id: 'event-id',
+        calendarId: 'test-calendar',
+        event,
+        location: null
+      });
+
+      await expect(manager.handleDelete('event-id', event)).resolves.toBe(false);
+      expect(mockOpenDeleteRecurringModal).not.toHaveBeenCalled();
+    });
+
+    it('shows recurring delete options for recurring masters even without child overrides', async () => {
+      const event: OFCEvent = {
+        type: 'recurring',
+        title: 'Daily standup',
+        daysOfWeek: ['M', 'T', 'W', 'R', 'F'],
+        endDate: null,
+        allDay: false,
+        startTime: '09:00',
+        endTime: '09:30',
+        skipDates: []
+      };
+      (mockCache.store.getEventDetails as jest.Mock).mockReturnValue({
+        id: 'master-id',
+        calendarId: 'test-calendar',
+        event,
+        location: null
+      });
+
+      await expect(manager.handleDelete('master-id', event)).resolves.toBe(true);
+      expect(mockOpenDeleteRecurringModal).toHaveBeenCalledTimes(1);
+      expect(mockDeleteRecurringModalConstructor).toHaveBeenCalledWith(
+        mockPlugin.app,
+        expect.any(Function),
+        expect.any(Function),
+        undefined,
+        undefined,
+        false
+      );
+    });
+
+    it('deletes CalDAV recurrence overrides through the provider when deleting only one instance', async () => {
+      const masterEvent: OFCEvent = {
+        type: 'rrule',
+        title: 'Daily standup',
+        uid: 'series-1',
+        startDate: '2026-06-01',
+        endDate: null,
+        rrule: 'FREQ=DAILY',
+        skipDates: [],
+        allDay: false,
+        startTime: '09:00',
+        endTime: '09:30'
+      };
+      const overrideEvent: OFCEvent = {
+        type: 'single',
+        title: 'Daily standup moved',
+        uid: 'series-1',
+        recurrenceId: '2026-06-08T09:00:00.000+02:00',
+        date: '2026-06-08',
+        endDate: null,
+        allDay: false,
+        startTime: '10:00',
+        endTime: '10:30'
+      };
+
+      (PluginState.getProviderRegistry().getSource as jest.Mock).mockReturnValue({
+        type: 'caldav',
+        id: 'test-calendar'
+      });
+      (mockCache.store.getEventDetails as jest.Mock).mockReturnValue({
+        id: 'override-id',
+        calendarId: 'test-calendar',
+        event: overrideEvent,
+        location: null
+      });
+      (mockCache.store.getAllEvents as jest.Mock).mockReturnValue([
+        {
+          id: 'master-id',
+          calendarId: 'test-calendar',
+          event: masterEvent,
+          location: null
+        }
+      ]);
+
+      await expect(manager.handleDelete('override-id', overrideEvent)).resolves.toBe(true);
+      const constructorCalls = mockDeleteRecurringModalConstructor.mock.calls as unknown as Array<
+        [unknown, unknown, unknown, () => void]
+      >;
+      const deleteInstance = constructorCalls[0][3];
+      deleteInstance();
+      await Promise.resolve();
+
+      const cacheMocks = mockCache as unknown as { deleteEvent: jest.Mock };
+      expect(cacheMocks.deleteEvent).toHaveBeenCalledWith('override-id', {
+        silent: true,
+        force: true
+      });
+    });
   });
 
   describe('modifyRecurringInstance', () => {
@@ -127,7 +262,12 @@ describe('RecurringEventManager', () => {
     };
 
     it('updates native provider masters in cache without rewriting the master event', async () => {
-      (mockProvider as unknown as { type: string }).type = 'caldav';
+      (mockProvider.getCapabilities as jest.Mock).mockReturnValue({
+        canCreate: true,
+        canEdit: true,
+        canDelete: true,
+        ownsRecurringInstanceOverrides: true
+      });
       (PluginState.getProviderRegistry().getSource as jest.Mock).mockReturnValue({
         type: 'caldav',
         id: 'test-calendar'
@@ -163,10 +303,18 @@ describe('RecurringEventManager', () => {
           alarms: [{ minutesBefore: 15, action: 'DISPLAY' }]
         })
       );
-      expect(mockCache.processEvent).not.toHaveBeenCalled();
-      expect(mockCache.flushUpdateQueue).not.toHaveBeenCalled();
-      expect(mockCache.store.delete).toHaveBeenCalledWith('master-session-id');
-      expect(mockCache.store.add).toHaveBeenCalledWith(
+      const cacheMocks = mockCache as unknown as {
+        processEvent: jest.Mock;
+        flushUpdateQueue: jest.Mock;
+        store: {
+          delete: jest.Mock;
+          add: jest.Mock;
+        };
+      };
+      expect(cacheMocks.processEvent).not.toHaveBeenCalled();
+      expect(cacheMocks.flushUpdateQueue).not.toHaveBeenCalled();
+      expect(cacheMocks.store.delete).toHaveBeenCalledWith('master-session-id');
+      expect(cacheMocks.store.add).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'master-session-id',
           calendarId: 'test-calendar',

--- a/src/features/recur_events/RecurringEventManager.test.ts
+++ b/src/features/recur_events/RecurringEventManager.test.ts
@@ -78,15 +78,107 @@ describe('RecurringEventManager', () => {
       getGlobalIdentifier: jest.fn(
         (event: OFCEvent, calendarId: string) => `${calendarId}::${event.title}`
       ),
+      updateQueue: {
+        toRemove: new Set<string>(),
+        toAdd: new Map()
+      },
+      generateId: jest.fn().mockReturnValue('override-session-id'),
+      enhancer: {
+        enhance: jest.fn((event: OFCEvent) => event)
+      },
       store: {
         getEventDetails: jest.fn(),
-        getAllEvents: jest.fn().mockReturnValue([])
+        getAllEvents: jest.fn().mockReturnValue([]),
+        add: jest.fn(),
+        delete: jest.fn()
       },
       calendars: new Map([['test-calendar', mockProvider]]),
       plugin: mockPlugin
     } as unknown as jest.Mocked<EventCache>;
 
     manager = new RecurringEventManager(mockCache, mockPlugin);
+  });
+
+  describe('modifyRecurringInstance', () => {
+    const masterEvent: OFCEvent = {
+      type: 'rrule',
+      title: 'Weekly Remote Meeting',
+      uid: 'remote-master',
+      startDate: '2026-06-01',
+      endDate: null,
+      rrule: 'FREQ=WEEKLY',
+      skipDates: [],
+      allDay: false,
+      startTime: '09:00',
+      endTime: '10:00',
+      notify: { value: 15 },
+      alarms: [{ minutesBefore: 15, action: 'DISPLAY' }]
+    };
+
+    const overrideEvent: OFCEvent = {
+      type: 'single',
+      title: 'Weekly Remote Meeting moved',
+      uid: 'remote-master',
+      date: '2026-06-08',
+      endDate: null,
+      allDay: false,
+      startTime: '11:00',
+      endTime: '12:00'
+    };
+
+    it('updates native provider masters in cache without rewriting the master event', async () => {
+      (mockProvider as unknown as { type: string }).type = 'caldav';
+      (PluginState.getProviderRegistry().getSource as jest.Mock).mockReturnValue({
+        type: 'caldav',
+        id: 'test-calendar'
+      });
+      (PluginState.getProviderRegistry().getInstance as jest.Mock).mockReturnValue(mockProvider);
+      (
+        PluginState.getProviderRegistry() as unknown as {
+          createInstanceOverrideInProvider: jest.Mock;
+        }
+      ).createInstanceOverrideInProvider = jest.fn().mockResolvedValue([overrideEvent, null]);
+
+      (mockCache.store.getEventDetails as jest.Mock).mockReturnValue({
+        id: 'master-session-id',
+        calendarId: 'test-calendar',
+        event: masterEvent,
+        location: null
+      });
+
+      await manager.modifyRecurringInstance('master-session-id', '2026-06-08', overrideEvent);
+
+      expect(
+        (
+          PluginState.getProviderRegistry() as unknown as {
+            createInstanceOverrideInProvider: jest.Mock;
+          }
+        ).createInstanceOverrideInProvider
+      ).toHaveBeenCalledWith(
+        'test-calendar',
+        masterEvent,
+        '2026-06-08',
+        expect.objectContaining({
+          notify: { value: 15 },
+          alarms: [{ minutesBefore: 15, action: 'DISPLAY' }]
+        })
+      );
+      expect(mockCache.processEvent).not.toHaveBeenCalled();
+      expect(mockCache.flushUpdateQueue).not.toHaveBeenCalled();
+      expect(mockCache.store.delete).toHaveBeenCalledWith('master-session-id');
+      expect(mockCache.store.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'master-session-id',
+          calendarId: 'test-calendar',
+          event: expect.objectContaining({ skipDates: ['2026-06-08'] }) as OFCEvent
+        })
+      );
+      expect(mockCache.updateQueue.toRemove.has('master-session-id')).toBe(true);
+      expect(mockCache.updateQueue.toAdd.get('override-session-id')).toMatchObject({
+        event: overrideEvent,
+        calendarId: 'test-calendar'
+      });
+    });
   });
 
   describe('toggleRecurringInstance - undoing completed task', () => {

--- a/src/features/recur_events/RecurringEventManager.ts
+++ b/src/features/recur_events/RecurringEventManager.ts
@@ -117,11 +117,140 @@ export class RecurringEventManager {
     const masterLocalIdentifier = globalId.split('::').pop()?.split('/').pop();
     if (!masterLocalIdentifier) return [];
 
-    return this.cache.store
-      .getAllEvents()
-      .filter(
-        e => e.calendarId === calendarId && e.event.recurringEventId === masterLocalIdentifier
-      );
+    return this.cache.store.getAllEvents().filter(e => {
+      if (e.calendarId !== calendarId || e.event.type !== 'single') {
+        return false;
+      }
+      if (e.event.recurringEventId === masterLocalIdentifier) {
+        return true;
+      }
+      if (masterEvent.uid && e.event.recurringEventId === masterEvent.uid) {
+        return true;
+      }
+      if (masterEvent.id && e.event.recurringEventId === masterEvent.id) {
+        return true;
+      }
+      return Boolean(masterEvent.uid && e.event.uid === masterEvent.uid && e.event.recurrenceId);
+    });
+  }
+
+  private findRecurringMasterId(eventId: string, event: OFCEvent, calendarId: string): string | null {
+    if (event.type === 'recurring' || event.type === 'rrule') {
+      return eventId;
+    }
+
+    if (event.type !== 'single' || (!event.recurringEventId && !event.recurrenceId)) {
+      return null;
+    }
+
+    const expectedParentIdentifier = event.recurringEventId || event.uid;
+    if (!expectedParentIdentifier) {
+      return null;
+    }
+
+    const expectedParentFilename = expectedParentIdentifier.split('/').pop();
+    const master = this.cache.store.getAllEvents().find(candidate => {
+      if (candidate.calendarId !== calendarId) {
+        return false;
+      }
+      if (candidate.event.type !== 'recurring' && candidate.event.type !== 'rrule') {
+        return false;
+      }
+      if (candidate.event.uid && candidate.event.uid === expectedParentIdentifier) {
+        return true;
+      }
+      if (candidate.event.id && candidate.event.id === expectedParentIdentifier) {
+        return true;
+      }
+
+      const candidateFilename = candidate.location?.path.split('/').pop();
+      return Boolean(candidateFilename && candidateFilename === expectedParentFilename);
+    });
+
+    return master?.id ?? null;
+  }
+
+  private async deleteSingleRecurringInstance(
+    eventId: string,
+    event: OFCEvent,
+    calendarId: string,
+    instanceDate?: string
+  ): Promise<void> {
+    if (event.type === 'single' && event.recurrenceId && !event.recurringEventId) {
+      await this.cache.deleteEvent(eventId, { silent: true, force: true });
+      this.cache.flushUpdateQueue([], []);
+      return;
+    }
+
+    if (event.type === 'single' && event.recurringEventId) {
+      const masterFilename = event.recurringEventId;
+      const providerResult = this.getProviderAndConfig(calendarId);
+      if (!providerResult) {
+        console.warn(
+          `Could not find provider for calendar ID ${calendarId}. Deleting orphan override.`
+        );
+        await this.cache.deleteEvent(eventId, { silent: true, force: true });
+        this.cache.flushUpdateQueue([], []);
+        return;
+      }
+      const { config } = providerResult;
+      if (config.type !== 'local') {
+        await this.cache.deleteEvent(eventId, { silent: true, force: true });
+        this.cache.flushUpdateQueue([], []);
+        return;
+      }
+      const masterPath = `${config.directory}/${masterFilename}`;
+      const globalMasterIdentifier = `${calendarId}::${masterPath}`;
+
+      const masterSessionId = await this.cache.getSessionId(globalMasterIdentifier);
+
+      if (masterSessionId) {
+        await this.cache.processEvent(
+          masterSessionId,
+          e => {
+            if (e.type !== 'recurring' && e.type !== 'rrule') return e;
+            const dateToUnskip = event.date;
+            return {
+              ...e,
+              skipDates: e.skipDates.filter((d: string) => d !== dateToUnskip)
+            };
+          },
+          { silent: true }
+        );
+      } else {
+        console.warn(
+          `Master recurring event with identifier "${globalMasterIdentifier}" not found. Deleting orphan override.`
+        );
+      }
+      await this.cache.deleteEvent(eventId, { silent: true, force: true });
+      this.cache.flushUpdateQueue([], []);
+      return;
+    }
+
+    if (event.type === 'recurring' || event.type === 'rrule') {
+      const dateToSkip = instanceDate;
+      if (!dateToSkip) {
+        return;
+      }
+
+      const updated = await this.cache.processEvent(eventId, e => {
+        if (e.type !== 'recurring' && e.type !== 'rrule') return e;
+        const skipDates = e.skipDates?.includes(dateToSkip)
+          ? e.skipDates
+          : [...(e.skipDates || []), dateToSkip];
+        return { ...e, skipDates };
+      });
+
+      if (updated) {
+        const details = this.cache.store.getEventDetails(eventId);
+        if (details) {
+          const calendarSource = this.cache.getAllEvents().find(s => s.id === details.calendarId);
+          if (calendarSource) {
+            this.cache.updateCalendar(calendarSource);
+          }
+        }
+      }
+    }
   }
 
   public async promoteRecurringChildren(masterEventId: string): Promise<void> {
@@ -174,118 +303,35 @@ export class RecurringEventManager {
     event: OFCEvent,
     options?: DeleteOptions
   ): Promise<boolean> {
-    // Check if we are "undoing" an override. This is now the full operation.
-    if (event.type === 'single' && event.recurringEventId) {
-      const eventDetails = this.cache.store.getEventDetails(eventId);
-      if (!eventDetails) return false;
-      const { calendarId } = eventDetails;
-
-      const masterFilename = event.recurringEventId;
-      const providerResult = this.getProviderAndConfig(calendarId);
-      if (!providerResult) {
-        // Cannot proceed if provider/config is not found.
-        console.warn(
-          `Could not find provider for calendar ID ${calendarId}. Deleting orphan override.`
-        );
-        await this.cache.deleteEvent(eventId, { silent: true, force: true });
-        this.cache.flushUpdateQueue([], []);
-        return true;
-      }
-      const { config } = providerResult;
-      // Reconstruct the master event's full path (only for local sources)
-      if (config.type !== 'local') {
-        console.warn('Expected local calendar for recurring override cleanup.');
-        await this.cache.deleteEvent(eventId, { silent: true, force: true });
-        this.cache.flushUpdateQueue([], []);
-        return true;
-      }
-      const masterPath = `${config.directory}/${masterFilename}`;
-      const globalMasterIdentifier = `${calendarId}::${masterPath}`;
-
-      const masterSessionId = await this.cache.getSessionId(globalMasterIdentifier);
-
-      if (masterSessionId) {
-        await this.cache.processEvent(
-          masterSessionId,
-          e => {
-            if (e.type !== 'recurring' && e.type !== 'rrule') return e;
-            const dateToUnskip = event.date;
-            return {
-              ...e,
-              skipDates: e.skipDates.filter((d: string) => d !== dateToUnskip)
-            };
-          },
-          { silent: true }
-        );
-      } else {
-        console.warn(
-          `Master recurring event with identifier "${globalMasterIdentifier}" not found. Deleting orphan override.`
-        );
-      }
-      await this.cache.deleteEvent(eventId, { silent: true, force: true });
-      this.cache.flushUpdateQueue([], []);
-      return true;
-    }
-
-    const isRecurringMaster = event.type === 'recurring' || event.type === 'rrule';
-    if (!isRecurringMaster) {
-      return false;
-    }
-
     const eventDetails = this.cache.store.getEventDetails(eventId);
     if (!eventDetails) return false;
     const { calendarId } = eventDetails;
+    const masterEventId = this.findRecurringMasterId(eventId, event, calendarId);
+    if (!masterEventId) {
+      return false;
+    }
 
     // REPLACE calendar lookup with provider lookup
     const providerResult = this.getProviderAndConfig(calendarId);
     if (!providerResult) return false;
     const isGoogle = providerResult.provider.type === 'google';
 
-    const children = this.findRecurringChildren(eventId);
-
-    if (children.length > 0 || options?.instanceDate) {
-      // LAZY LOAD MODAL
-      const { DeleteRecurringModal } = await import('../../ui/modals/DeleteRecurringModal');
-      new DeleteRecurringModal(
-        this.cache.plugin.app,
-        () => void this.promoteRecurringChildren(eventId),
-        () => void this.deleteAllRecurring(eventId),
-        options?.instanceDate
-          ? () => {
-              void (async () => {
-                const instanceDate = options.instanceDate;
-                if (!instanceDate) {
-                  return;
-                }
-                const updated = await this.cache.processEvent(eventId, e => {
-                  if (e.type !== 'recurring' && e.type !== 'rrule') return e;
-                  const skipDates = e.skipDates?.includes(instanceDate)
-                    ? e.skipDates
-                    : [...(e.skipDates || []), instanceDate];
-                  return { ...e, skipDates };
-                });
-
-                if (updated) {
-                  const details = this.cache.store.getEventDetails(eventId);
-                  if (details) {
-                    const calendarSource = this.cache
-                      .getAllEvents()
-                      .find(s => s.id === details.calendarId);
-                    if (calendarSource) {
-                      this.cache.updateCalendar(calendarSource);
-                    }
-                  }
-                }
-              })();
-            }
-          : undefined,
-        options?.instanceDate,
-        isGoogle
-      ).open();
-      return true;
-    }
-
-    return false;
+    const instanceDate =
+      options?.instanceDate || (event.type === 'single' ? event.recurrenceId || event.date : undefined);
+    const { DeleteRecurringModal } = await import('../../ui/modals/DeleteRecurringModal');
+    new DeleteRecurringModal(
+      this.cache.plugin.app,
+      () => void this.promoteRecurringChildren(masterEventId),
+      () => void this.deleteAllRecurring(masterEventId),
+      instanceDate
+        ? () => {
+            void this.deleteSingleRecurringInstance(eventId, event, calendarId, instanceDate);
+          }
+        : undefined,
+      instanceDate,
+      isGoogle
+    ).open();
+    return true;
   }
 
   /**
@@ -378,8 +424,10 @@ export class RecurringEventManager {
     });
   }
 
-  private providerOwnsRecurringInstanceOverrides(providerType: string): boolean {
-    return providerType === 'caldav' || providerType === 'google' || providerType === 'outlook';
+  private providerOwnsRecurringInstanceOverrides(
+    providerResult: ReturnType<RecurringEventManager['getProviderAndConfig']>
+  ): boolean {
+    return Boolean(providerResult?.provider.getCapabilities().ownsRecurringInstanceOverrides);
   }
 
   private inheritReminderFields(overrideEvent: OFCEvent, masterEvent: OFCEvent): OFCEvent {
@@ -447,7 +495,7 @@ export class RecurringEventManager {
     });
     this.cache.isBulkUpdating = true;
 
-    if (this.providerOwnsRecurringInstanceOverrides(providerResult.provider.type)) {
+    if (this.providerOwnsRecurringInstanceOverrides(providerResult)) {
       this.updateMasterSkipDateInCache(masterEventId, instanceDate);
     } else {
       await this.cache.processEvent(

--- a/src/features/recur_events/RecurringEventManager.ts
+++ b/src/features/recur_events/RecurringEventManager.ts
@@ -342,6 +342,54 @@ export class RecurringEventManager {
     );
   }
 
+  private updateMasterSkipDateInCache(masterEventId: string, instanceDate: string): void {
+    const details = this.cache.store.getEventDetails(masterEventId);
+    if (!details) {
+      throw new Error('Master event not found for cache update.');
+    }
+
+    const { calendarId, event: masterEvent, location } = details;
+    if (masterEvent.type !== 'recurring' && masterEvent.type !== 'rrule') {
+      return;
+    }
+
+    const updatedMasterEvent: OFCEvent = {
+      ...masterEvent,
+      skipDates: masterEvent.skipDates.includes(instanceDate)
+        ? masterEvent.skipDates
+        : [...masterEvent.skipDates, instanceDate]
+    };
+
+    this.cache.store.delete(masterEventId);
+    this.cache.store.add({
+      calendarId,
+      location: location
+        ? { file: { path: location.path }, lineNumber: location.lineNumber }
+        : null,
+      id: masterEventId,
+      event: updatedMasterEvent
+    });
+
+    this.cache.updateQueue.toRemove.add(masterEventId);
+    this.cache.updateQueue.toAdd.set(masterEventId, {
+      id: masterEventId,
+      calendarId,
+      event: updatedMasterEvent
+    });
+  }
+
+  private providerOwnsRecurringInstanceOverrides(providerType: string): boolean {
+    return providerType === 'caldav' || providerType === 'google' || providerType === 'outlook';
+  }
+
+  private inheritReminderFields(overrideEvent: OFCEvent, masterEvent: OFCEvent): OFCEvent {
+    return {
+      ...overrideEvent,
+      notify: overrideEvent.notify !== undefined ? overrideEvent.notify : masterEvent.notify,
+      alarms: overrideEvent.alarms !== undefined ? overrideEvent.alarms : masterEvent.alarms
+    };
+  }
+
   /**
    * Handles the modification of a single instance of a recurring event.
    * This is triggered when a user drags or resizes an instance in the calendar view.
@@ -364,6 +412,15 @@ export class RecurringEventManager {
       throw new Error('Master event not found for instance modification.');
     }
     const { calendarId, event: masterEvent } = details;
+    const providerResult = this.getProviderAndConfig(calendarId);
+    if (!providerResult) {
+      throw new Error(`Provider for calendar ${calendarId} not found.`);
+    }
+
+    const overrideEventWithInheritedReminders = this.inheritReminderFields(
+      newEventData,
+      masterEvent
+    );
 
     // CORRECTED: Delegate the entire provider operation to the registry.
     const [authoritativeOverrideEvent, overrideLocation] =
@@ -371,7 +428,7 @@ export class RecurringEventManager {
         calendarId,
         masterEvent,
         instanceDate,
-        newEventData
+        overrideEventWithInheritedReminders
       );
 
     const enhancedEvent = this.cache.enhancer.enhance(authoritativeOverrideEvent);
@@ -390,19 +447,21 @@ export class RecurringEventManager {
     });
     this.cache.isBulkUpdating = true;
 
-    await this.cache.processEvent(
-      masterEventId,
-      e => {
-        if (e.type !== 'recurring' && e.type !== 'rrule') return e;
-        const skipDates = e.skipDates.includes(instanceDate)
-          ? e.skipDates
-          : [...e.skipDates, instanceDate];
-        return { ...e, skipDates };
-      },
-      { silent: true }
-    );
-
-    this.cache.flushUpdateQueue([], []);
+    if (this.providerOwnsRecurringInstanceOverrides(providerResult.provider.type)) {
+      this.updateMasterSkipDateInCache(masterEventId, instanceDate);
+    } else {
+      await this.cache.processEvent(
+        masterEventId,
+        e => {
+          if (e.type !== 'recurring' && e.type !== 'rrule') return e;
+          const skipDates = e.skipDates.includes(instanceDate)
+            ? e.skipDates
+            : [...e.skipDates, instanceDate];
+          return { ...e, skipDates };
+        },
+        { silent: true }
+      );
+    }
   }
 
   /**

--- a/src/providers/Provider.ts
+++ b/src/providers/Provider.ts
@@ -8,6 +8,8 @@ export interface CalendarProviderCapabilities {
   canEdit: boolean;
   canDelete: boolean;
   hasCustomEditUI?: boolean; // This is the new capability
+  supportsAlarms?: boolean;
+  ownsRecurringInstanceOverrides?: boolean;
   contextMenu?: {
     allowGenericTaskActions?: boolean;
     allowDisplayActions?: boolean;

--- a/src/providers/caldav/CalDAVProvider.test.ts
+++ b/src/providers/caldav/CalDAVProvider.test.ts
@@ -593,7 +593,7 @@ END:VCALENDAR
     expect(syncKeys).toHaveLength(2);
     expect(new Set(syncKeys).size).toBe(2);
     expect(syncKeys).toContain('ics::series-1::2020-01-15::recurring');
-    expect(syncKeys).toContain('series-1');
+    expect(syncKeys).toContain('series-1::2024-01-15');
   });
 
   it('should keep valid fallback events when some fallback GET requests fail', async () => {

--- a/src/providers/caldav/CalDAVProvider.test.ts
+++ b/src/providers/caldav/CalDAVProvider.test.ts
@@ -833,7 +833,13 @@ END:VCALENDAR
       .mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response)
       .mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response);
 
-    expect(provider.getCapabilities()).toEqual({ canCreate: true, canEdit: true, canDelete: true });
+    expect(provider.getCapabilities()).toEqual({
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      supportsAlarms: true,
+      ownsRecurringInstanceOverrides: true
+    });
 
     const [createdEvent] = await provider.createEvent({ ...baseEvent });
     expect(createdEvent.uid).toBe('evt-workflow-1');

--- a/src/providers/caldav/CalDAVProvider.ts
+++ b/src/providers/caldav/CalDAVProvider.ts
@@ -784,12 +784,18 @@ export class CalDAVProvider
   }
 
   getEventHandle(event: OFCEvent): EventHandle | null {
+    if (event.caldavHref) {
+      return { persistentId: event.caldavHref };
+    }
     return event.uid ? { persistentId: event.uid } : null;
   }
 
   computeSyncKey(event: OFCEvent): string {
     if (event.type === 'rrule' && event.id) {
       return event.id;
+    }
+    if (event.uid && event.recurrenceId) {
+      return `${event.uid}::${event.recurrenceId}`;
     }
     return event.uid || JSON.stringify(event);
   }
@@ -832,10 +838,13 @@ export class CalDAVProvider
       const parsedEvents: OFCEvent[] = [];
       let parseFailures = 0;
 
-      for (const { ics, etag } of icsList) {
+      for (const { ics, etag, href } of icsList) {
         try {
           const events = getEventsFromICS(ics).map(ev => {
             if (etag) ev.etag = etag.replace(/"/g, ''); // standard ETag usually has quotes
+            if (href) {
+              ev.caldavHref = href;
+            }
             return ev;
           });
           parsedEvents.push(...events);
@@ -1083,15 +1092,15 @@ export class CalDAVProvider
     oldEvent: OFCEvent,
     newEvent: OFCEvent
   ): Promise<EventLocation | null> {
-    const uid = handle.persistentId;
+    const href = handle.persistentId;
     if (!newEvent.uid) {
-      newEvent.uid = uid;
+      newEvent.uid = oldEvent.uid || this.getUidFromHref(href);
     }
 
     // Convert to ICS
     const icsContent = eventToIcs(newEvent);
 
-    const url = `${canonCollection(this.source.homeUrl)}${uid}.ics`;
+    const url = this.resolveEventObjectUrl(href);
 
     // PUT to update
     await this.doRequest(url, {
@@ -1109,8 +1118,7 @@ export class CalDAVProvider
   }
 
   async deleteEvent(handle: EventHandle): Promise<void> {
-    const uid = handle.persistentId;
-    const url = `${canonCollection(this.source.homeUrl)}${uid}.ics`;
+    const url = this.resolveEventObjectUrl(handle.persistentId);
 
     await this.doRequest(url, {
       method: 'DELETE'
@@ -1265,8 +1273,11 @@ export class CalDAVProvider
     if (!masterEvent.uid) {
       throw new Error('Cannot create override: Master event has no UID.');
     }
-    const uid = masterEvent.uid;
-    const url = `${canonCollection(this.source.homeUrl)}${uid}.ics`;
+    const handle = this.getEventHandle(masterEvent);
+    if (!handle) {
+      throw new Error('Cannot create override: Master event has no CalDAV object reference.');
+    }
+    const url = this.resolveEventObjectUrl(handle.persistentId);
 
     // Fetch existing
     // We need to fetch the raw text of the ICS file.
@@ -1288,7 +1299,19 @@ export class CalDAVProvider
     const vcalendar = new ical.Component(jcal);
 
     // 3. Create the Override VEVENT
-    const overrideVEvent = createOverrideVEvent(newEventData, instanceDate);
+    const originalInstanceStart =
+      masterEvent.allDay || !('startTime' in masterEvent)
+        ? instanceDate
+        : `${instanceDate}T${masterEvent.startTime}`;
+    const overrideEventData: OFCEvent = {
+      ...newEventData,
+      uid: masterEvent.uid,
+      timezone: newEventData.timezone || masterEvent.timezone,
+      recurrenceId: originalInstanceStart,
+      notify: newEventData.notify !== undefined ? newEventData.notify : masterEvent.notify,
+      alarms: newEventData.alarms !== undefined ? newEventData.alarms : masterEvent.alarms
+    };
+    const overrideVEvent = createOverrideVEvent(overrideEventData, originalInstanceStart);
 
     // 4. Merge: Add the new VEVENT to the VCALENDAR
     vcalendar.addSubcomponent(overrideVEvent);
@@ -1307,7 +1330,7 @@ export class CalDAVProvider
       body: newIcsContent
     });
 
-    return [newEventData, null];
+    return [overrideEventData, null];
   }
 
   // Helper to attach auth and fetch
@@ -1324,6 +1347,25 @@ export class CalDAVProvider
       throw new Error(`CalDAV request failed: ${res.status} ${res.statusText}`);
     }
     return res;
+  }
+
+  private resolveEventObjectUrl(persistentId: string): string {
+    if (/^https?:\/\//i.test(persistentId)) {
+      return persistentId;
+    }
+    if (persistentId.endsWith('.ics') || persistentId.includes('/')) {
+      return resolveCollectionObjectUrl(this.source.homeUrl, persistentId);
+    }
+    return `${canonCollection(this.source.homeUrl)}${persistentId}.ics`;
+  }
+
+  private getUidFromHref(href: string): string {
+    return decodeURIComponent(
+      href
+        .split('/')
+        .pop()
+        ?.replace(/\.ics$/i, '') || href
+    );
   }
 
   // Boilerplate methods for the provider interface.

--- a/src/providers/caldav/CalDAVProvider.ts
+++ b/src/providers/caldav/CalDAVProvider.ts
@@ -25,6 +25,7 @@ import {
 } from '../../features/linked-notes/linkedNotes';
 import { parseTimezoneAwareString } from '../../features/timezone/Timezone';
 import { PluginState } from '../../core/PluginState';
+import { DateTime } from 'luxon';
 
 import { fetchCalendarInfo } from './helper_caldav';
 
@@ -241,6 +242,61 @@ function findTodoByUid(vcalendar: ical.Component, uid: string): ical.Component |
   const normalizedUid = uid.trim();
   return (
     vcalendar.getAllSubcomponents('vtodo').find(todo => getTaskUid(todo) === normalizedUid) ?? null
+  );
+}
+
+function getComponentUid(component: ical.Component): string {
+  return getTextProperty(component, 'uid').trim();
+}
+
+function normalizeRecurrenceIdString(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+
+  const dt = DateTime.fromISO(trimmed, { setZone: true });
+  if (!dt.isValid) return trimmed;
+  return dt.toISO({ suppressMilliseconds: true });
+}
+
+function getComponentRecurrenceId(component: ical.Component): string | null {
+  const prop = component.getFirstProperty('recurrence-id');
+  if (!prop) return null;
+
+  const value = prop.getFirstValue();
+  if (!(value instanceof ical.Time)) {
+    return normalizeRecurrenceIdString(String(value));
+  }
+
+  const dt = parseTimezoneAwareString(value);
+  if (value.isDate) {
+    return dt.toISODate();
+  }
+  return dt.toISO({ suppressMilliseconds: true });
+}
+
+function findVEventOverride(
+  vcalendar: ical.Component,
+  uid: string,
+  recurrenceId: string
+): ical.Component | null {
+  const normalizedRecurrenceId = normalizeRecurrenceIdString(recurrenceId);
+  if (!normalizedRecurrenceId) return null;
+
+  return (
+    vcalendar
+      .getAllSubcomponents('vevent')
+      .find(
+        vevent =>
+          getComponentUid(vevent) === uid &&
+          getComponentRecurrenceId(vevent) === normalizedRecurrenceId
+      ) ?? null
+  );
+}
+
+function removeSubcomponent(vcalendar: ical.Component, subcomponent: ical.Component): void {
+  (vcalendar as unknown as { removeSubcomponent(component: ical.Component): void }).removeSubcomponent(
+    subcomponent
   );
 }
 
@@ -780,14 +836,24 @@ export class CalDAVProvider
   }
 
   getCapabilities(): CalendarProviderCapabilities {
-    return { canCreate: true, canEdit: true, canDelete: true };
+    return {
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      supportsAlarms: true,
+      ownsRecurringInstanceOverrides: true
+    };
   }
 
   getEventHandle(event: OFCEvent): EventHandle | null {
+    const context = {
+      uid: event.uid,
+      recurrenceId: event.recurrenceId
+    };
     if (event.caldavHref) {
-      return { persistentId: event.caldavHref };
+      return { persistentId: event.caldavHref, ...context };
     }
-    return event.uid ? { persistentId: event.uid } : null;
+    return event.uid ? { persistentId: event.uid, ...context } : null;
   }
 
   computeSyncKey(event: OFCEvent): string {
@@ -1097,10 +1163,14 @@ export class CalDAVProvider
       newEvent.uid = oldEvent.uid || this.getUidFromHref(href);
     }
 
+    const url = this.resolveEventObjectUrl(href);
+    if (oldEvent.recurrenceId && oldEvent.uid) {
+      await this.updateRecurrenceOverride(url, oldEvent, newEvent);
+      return null;
+    }
+
     // Convert to ICS
     const icsContent = eventToIcs(newEvent);
-
-    const url = this.resolveEventObjectUrl(href);
 
     // PUT to update
     await this.doRequest(url, {
@@ -1119,6 +1189,11 @@ export class CalDAVProvider
 
   async deleteEvent(handle: EventHandle): Promise<void> {
     const url = this.resolveEventObjectUrl(handle.persistentId);
+
+    if (handle.uid && handle.recurrenceId) {
+      await this.deleteRecurrenceOverride(url, handle.uid, handle.recurrenceId);
+      return;
+    }
 
     await this.doRequest(url, {
       method: 'DELETE'
@@ -1331,6 +1406,72 @@ export class CalDAVProvider
     });
 
     return [overrideEventData, null];
+  }
+
+  private async fetchVCalendar(url: string): Promise<ical.Component> {
+    const headers: Record<string, string> = {};
+    const authHeader = createBasicAuthHeader(this.source.username, this.source.password);
+    if (authHeader) {
+      headers['Authorization'] = authHeader;
+    }
+
+    const res = await obsidianFetch(url, { method: 'GET', headers });
+    if (res.status >= 300) {
+      throw new Error(`Failed to fetch original event: ${res.status}`);
+    }
+    return parseVCalendar(await res.text());
+  }
+
+  private async putVCalendar(url: string, vcalendar: ical.Component): Promise<void> {
+    await this.doRequest(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'text/calendar; charset=utf-8'
+      },
+      body: (vcalendar as unknown as { toString(): string }).toString()
+    });
+  }
+
+  private async updateRecurrenceOverride(
+    url: string,
+    oldEvent: OFCEvent,
+    newEvent: OFCEvent
+  ): Promise<void> {
+    if (!oldEvent.uid || !oldEvent.recurrenceId) {
+      throw new Error('Cannot update CalDAV recurrence override without UID and RECURRENCE-ID.');
+    }
+
+    const vcalendar = await this.fetchVCalendar(url);
+    const existingOverride = findVEventOverride(vcalendar, oldEvent.uid, oldEvent.recurrenceId);
+    if (!existingOverride) {
+      throw new Error('Could not find CalDAV recurrence override to update.');
+    }
+
+    removeSubcomponent(vcalendar, existingOverride);
+    const overrideEventData: OFCEvent = {
+      ...newEvent,
+      uid: oldEvent.uid,
+      recurrenceId: oldEvent.recurrenceId,
+      timezone: newEvent.timezone || oldEvent.timezone
+    };
+    vcalendar.addSubcomponent(createOverrideVEvent(overrideEventData, oldEvent.recurrenceId));
+
+    await this.putVCalendar(url, vcalendar);
+  }
+
+  private async deleteRecurrenceOverride(
+    url: string,
+    uid: string,
+    recurrenceId: string
+  ): Promise<void> {
+    const vcalendar = await this.fetchVCalendar(url);
+    const existingOverride = findVEventOverride(vcalendar, uid, recurrenceId);
+    if (!existingOverride) {
+      throw new Error('Could not find CalDAV recurrence override to delete.');
+    }
+
+    removeSubcomponent(vcalendar, existingOverride);
+    await this.putVCalendar(url, vcalendar);
   }
 
   // Helper to attach auth and fetch

--- a/src/providers/caldav/CalDAVRecurrenceAndAlarm.test.ts
+++ b/src/providers/caldav/CalDAVRecurrenceAndAlarm.test.ts
@@ -173,6 +173,156 @@ END:VCALENDAR`)
     expect(body).toEqual(expect.stringContaining('TRIGGER:-PT10M'));
   });
 
+  it('creates Obsidian recurring events as real CalDAV recurrence series', async () => {
+    const event = {
+      type: 'recurring',
+      uid: 'obsidian-created-series',
+      title: 'Daily standup',
+      startRecur: '2026-06-01',
+      endDate: null,
+      daysOfWeek: ['M', 'T', 'W', 'R', 'F'],
+      repeatInterval: 1,
+      skipDates: [],
+      allDay: false,
+      startTime: '09:00',
+      endTime: '09:30',
+      timezone: 'Europe/Amsterdam'
+    } as OFCEvent;
+
+    mockObsidianFetch.mockResolvedValueOnce({ status: 201, statusText: 'Created' } as Response);
+
+    await provider.createEvent(event);
+
+    expect(mockObsidianFetch).toHaveBeenLastCalledWith(
+      'https://example.com/caldav/user/calendar/events/obsidian-created-series.ics',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    const body = mockObsidianFetch.mock.calls[0][1]?.body;
+    expect(body).toEqual(expect.stringContaining('BEGIN:VEVENT'));
+    expect(body).toEqual(expect.stringContaining('RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR'));
+    expect(body).toEqual(expect.stringContaining('DTSTART;TZID=Europe/Amsterdam:20260601T090000'));
+    expect(body).toEqual(expect.stringContaining('DTEND;TZID=Europe/Amsterdam:20260601T093000'));
+  });
+
+  it('updates a CalDAV recurrence override without replacing the recurring object', async () => {
+    const oldOverride = {
+      type: 'single',
+      uid: 'meeting-series',
+      recurrenceId: '2026-06-08T10:00:00.000+02:00',
+      caldavHref: '/caldav/user/calendar/events/real-object.ics',
+      title: 'Weekly Meeting moved',
+      date: '2026-06-09',
+      endDate: null,
+      allDay: false,
+      startTime: '12:00',
+      endTime: '13:00',
+      timezone: 'Europe/Amsterdam'
+    } as OFCEvent;
+
+    const newOverride = {
+      ...oldOverride,
+      title: 'Weekly Meeting moved again',
+      alarms: [{ minutesBefore: 30, action: 'DISPLAY' }]
+    } as OFCEvent;
+
+    mockObsidianFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        text: () =>
+          Promise.resolve(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:meeting-series
+SUMMARY:Weekly Meeting
+DTSTART;TZID=Europe/Amsterdam:20260601T100000
+DTEND;TZID=Europe/Amsterdam:20260601T110000
+RRULE:FREQ=WEEKLY
+END:VEVENT
+BEGIN:VEVENT
+UID:meeting-series
+RECURRENCE-ID;TZID=Europe/Amsterdam:20260608T100000
+SUMMARY:Weekly Meeting moved
+DTSTART;TZID=Europe/Amsterdam:20260609T120000
+DTEND;TZID=Europe/Amsterdam:20260609T130000
+END:VEVENT
+END:VCALENDAR`)
+      } as Response)
+      .mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response);
+
+    const handle = provider.getEventHandle(oldOverride);
+    if (!handle) throw new Error('Expected event handle');
+
+    await provider.updateEvent(handle, oldOverride, newOverride);
+
+    expect(mockObsidianFetch).toHaveBeenLastCalledWith(
+      'https://example.com/caldav/user/calendar/events/real-object.ics',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    const body = mockObsidianFetch.mock.calls[1][1]?.body;
+    expect(body).toEqual(expect.stringContaining('RRULE:FREQ=WEEKLY'));
+    expect(body).toEqual(expect.stringContaining('SUMMARY:Weekly Meeting'));
+    expect(body).toEqual(expect.stringContaining('SUMMARY:Weekly Meeting moved again'));
+    expect(body).toEqual(
+      expect.stringContaining('RECURRENCE-ID;TZID=Europe/Amsterdam:20260608T100000')
+    );
+    expect(body).toEqual(expect.stringContaining('TRIGGER:-PT30M'));
+  });
+
+  it('deletes a CalDAV recurrence override without deleting the shared recurring object', async () => {
+    const overrideEvent = {
+      type: 'single',
+      uid: 'meeting-series',
+      recurrenceId: '2026-06-08T10:00:00.000+02:00',
+      caldavHref: '/caldav/user/calendar/events/real-object.ics',
+      title: 'Weekly Meeting moved',
+      date: '2026-06-09',
+      endDate: null,
+      allDay: false,
+      startTime: '12:00',
+      endTime: '13:00',
+      timezone: 'Europe/Amsterdam'
+    } as OFCEvent;
+
+    mockObsidianFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        text: () =>
+          Promise.resolve(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:meeting-series
+SUMMARY:Weekly Meeting
+DTSTART;TZID=Europe/Amsterdam:20260601T100000
+DTEND;TZID=Europe/Amsterdam:20260601T110000
+RRULE:FREQ=WEEKLY
+END:VEVENT
+BEGIN:VEVENT
+UID:meeting-series
+RECURRENCE-ID;TZID=Europe/Amsterdam:20260608T100000
+SUMMARY:Weekly Meeting moved
+DTSTART;TZID=Europe/Amsterdam:20260609T120000
+DTEND;TZID=Europe/Amsterdam:20260609T130000
+END:VEVENT
+END:VCALENDAR`)
+      } as Response)
+      .mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response);
+
+    const handle = provider.getEventHandle(overrideEvent);
+    if (!handle) throw new Error('Expected event handle');
+
+    await provider.deleteEvent(handle);
+
+    expect(mockObsidianFetch).toHaveBeenLastCalledWith(
+      'https://example.com/caldav/user/calendar/events/real-object.ics',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    const body = mockObsidianFetch.mock.calls[1][1]?.body;
+    expect(body).toEqual(expect.stringContaining('RRULE:FREQ=WEEKLY'));
+    expect(body).toEqual(expect.stringContaining('SUMMARY:Weekly Meeting'));
+    expect(body).not.toEqual(expect.stringContaining('SUMMARY:Weekly Meeting moved'));
+    expect(body).not.toEqual(expect.stringContaining('RECURRENCE-ID'));
+  });
+
   it('keeps multiple moved recurrence exceptions distinct when syncing CalDAV', async () => {
     const propfindResponse = `
       <d:multistatus xmlns:d="DAV:">

--- a/src/providers/caldav/CalDAVRecurrenceAndAlarm.test.ts
+++ b/src/providers/caldav/CalDAVRecurrenceAndAlarm.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @jest-environment jsdom
+ */
+import { CalDAVProvider } from './CalDAVProvider';
+import { obsidianFetch } from './obsidian-fetch_caldav';
+import { CalDAVProviderConfig } from './typesCalDAV';
+import FullCalendarPlugin from '../../main';
+import { OFCEvent } from '../../types';
+
+jest.mock('./obsidian-fetch_caldav', () => ({
+  obsidianFetch: jest.fn()
+}));
+
+const mockObsidianFetch = obsidianFetch as jest.MockedFunction<typeof obsidianFetch>;
+
+describe('CalDAV recurrence exceptions and provider alarms', () => {
+  let provider: CalDAVProvider;
+  const mockConfig: CalDAVProviderConfig = {
+    id: 'caldav_1',
+    name: 'Test Calendar',
+    url: 'https://example.com/caldav/',
+    homeUrl: 'https://example.com/caldav/user/calendar/events/',
+    username: 'user',
+    password: 'password'
+  };
+
+  beforeEach(() => {
+    provider = new CalDAVProvider(mockConfig, {} as FullCalendarPlugin);
+    mockObsidianFetch.mockReset();
+  });
+
+  it('updates CalDAV events at the server href returned by REPORT', async () => {
+    const propfindResponse = `
+      <d:multistatus xmlns:d="DAV:">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:resourcetype>
+                <d:collection/>
+                <c:calendar xmlns:c="urn:ietf:params:xml:ns:caldav"/>
+              </d:resourcetype>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    const reportResponse = `
+      <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/server-generated-object.ics</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:getetag>"etag-1"</d:getetag>
+              <c:calendar-data>BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:not-the-file-name
+SUMMARY:Original
+DTSTART:20260615T100000Z
+DTEND:20260615T110000Z
+END:VEVENT
+END:VCALENDAR
+</c:calendar-data>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    mockObsidianFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(propfindResponse)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(reportResponse)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(`<d:multistatus xmlns:d="DAV:"></d:multistatus>`)
+      } as Response)
+      .mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response);
+
+    const [[oldEvent]] = await provider.getEvents();
+    const handle = provider.getEventHandle(oldEvent);
+    if (!handle) throw new Error('Expected event handle');
+
+    await provider.updateEvent(handle, oldEvent, {
+      ...oldEvent,
+      title: 'Updated',
+      alarms: [{ minutesBefore: 20, action: 'DISPLAY' }]
+    });
+
+    expect(mockObsidianFetch).toHaveBeenLastCalledWith(
+      'https://example.com/caldav/user/calendar/events/server-generated-object.ics',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          'If-Match': '"etag-1"'
+        }) as Record<string, unknown>
+      })
+    );
+
+    const body = mockObsidianFetch.mock.calls[3][1]?.body;
+    expect(body).toEqual(expect.stringContaining('BEGIN:VALARM'));
+    expect(body).toEqual(expect.stringContaining('TRIGGER:-PT20M'));
+  });
+
+  it('creates recurrence overrides in the original CalDAV object', async () => {
+    const masterEvent = {
+      type: 'rrule',
+      uid: 'meeting-series',
+      id: 'ics::meeting-series::2026-06-01::recurring',
+      caldavHref: '/caldav/user/calendar/events/real-object.ics',
+      title: 'Weekly Meeting',
+      startDate: '2026-06-01',
+      endDate: null,
+      rrule: 'FREQ=WEEKLY',
+      skipDates: [],
+      allDay: false,
+      startTime: '10:00',
+      endTime: '11:00',
+      timezone: 'Europe/Amsterdam',
+      notify: { value: 10 },
+      alarms: [{ minutesBefore: 10, action: 'DISPLAY' }]
+    } as OFCEvent;
+
+    const overrideEvent = {
+      type: 'single',
+      title: 'Weekly Meeting moved',
+      date: '2026-06-09',
+      endDate: null,
+      allDay: false,
+      startTime: '12:00',
+      endTime: '13:00'
+    } as OFCEvent;
+
+    mockObsidianFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        text: () =>
+          Promise.resolve(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:meeting-series
+SUMMARY:Weekly Meeting
+DTSTART:20260601T100000
+DTEND:20260601T110000
+RRULE:FREQ=WEEKLY
+END:VEVENT
+END:VCALENDAR`)
+      } as Response)
+      .mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response);
+
+    await provider.createInstanceOverride(masterEvent, '2026-06-08', overrideEvent);
+
+    expect(mockObsidianFetch).toHaveBeenLastCalledWith(
+      'https://example.com/caldav/user/calendar/events/real-object.ics',
+      expect.objectContaining({ method: 'PUT' })
+    );
+    const body = mockObsidianFetch.mock.calls[1][1]?.body;
+    expect(body).toEqual(expect.stringContaining('UID:meeting-series'));
+    expect(body).toEqual(
+      expect.stringContaining('RECURRENCE-ID;TZID=Europe/Amsterdam:20260608T100000')
+    );
+    expect(body).toEqual(expect.stringContaining('DTSTART;TZID=Europe/Amsterdam:20260609T120000'));
+    expect(body).toEqual(expect.stringContaining('BEGIN:VALARM'));
+    expect(body).toEqual(expect.stringContaining('TRIGGER:-PT10M'));
+  });
+
+  it('keeps multiple moved recurrence exceptions distinct when syncing CalDAV', async () => {
+    const propfindResponse = `
+      <d:multistatus xmlns:d="DAV:">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:resourcetype>
+                <d:collection/>
+                <c:calendar xmlns:c="urn:ietf:params:xml:ns:caldav"/>
+              </d:resourcetype>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    const reportResponse = `
+      <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/series.ics</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:getetag>"etag-series"</d:getetag>
+              <c:calendar-data>BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:series-with-exceptions
+SUMMARY:Weekly Meeting
+DTSTART;TZID=Europe/Amsterdam:20260601T100000
+DTEND;TZID=Europe/Amsterdam:20260601T110000
+RRULE:FREQ=WEEKLY
+END:VEVENT
+BEGIN:VEVENT
+UID:series-with-exceptions
+RECURRENCE-ID;TZID=Europe/Amsterdam:20260608T100000
+SUMMARY:Weekly Meeting moved once
+DTSTART;TZID=Europe/Amsterdam:20260609T120000
+DTEND;TZID=Europe/Amsterdam:20260609T130000
+END:VEVENT
+BEGIN:VEVENT
+UID:series-with-exceptions
+RECURRENCE-ID;TZID=Europe/Amsterdam:20260615T100000
+SUMMARY:Weekly Meeting moved twice
+DTSTART;TZID=Europe/Amsterdam:20260620T120000
+DTEND;TZID=Europe/Amsterdam:20260620T130000
+END:VEVENT
+END:VCALENDAR
+</c:calendar-data>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    mockObsidianFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(propfindResponse)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(reportResponse)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(`<d:multistatus xmlns:d="DAV:"></d:multistatus>`)
+      } as Response);
+
+    const events = await provider.getEvents();
+    const parsedEvents = events.map(([event]) => event);
+    const syncKeys = parsedEvents.map(event => provider.computeSyncKey(event));
+    const recurringEvent = parsedEvents.find(event => event.type === 'rrule');
+    const exceptionEvents = parsedEvents.filter(
+      (event): event is Extract<OFCEvent, { type: 'single' }> => event.type === 'single'
+    );
+
+    expect(parsedEvents).toHaveLength(3);
+    expect(new Set(syncKeys).size).toBe(3);
+    expect(recurringEvent?.type === 'rrule' ? recurringEvent.skipDates : []).toEqual([
+      '2026-06-08',
+      '2026-06-15'
+    ]);
+    expect(exceptionEvents.map(event => event.date)).toEqual(['2026-06-09', '2026-06-20']);
+  });
+});

--- a/src/providers/google/GoogleProvider.test.ts
+++ b/src/providers/google/GoogleProvider.test.ts
@@ -52,6 +52,7 @@ describe('GoogleProvider Configuration Wrapper', () => {
 import { PluginState } from '../../core/PluginState';
 import { OFCEvent } from '../../types';
 import { showNotice } from '../../utils/showNotice';
+import { fromGoogleEvent, toGoogleEvent } from './parser/parser_gcal';
 
 jest.mock('../../core/PluginState');
 jest.mock('../../utils/showNotice');
@@ -152,5 +153,42 @@ describe('GoogleProvider createLinkedNote', () => {
     const file = await provider.createLinkedNote(mockEvent);
     expect(file).toBeNull();
     expect(showNotice).toHaveBeenCalledWith(t('notices.configureLinkedNotesDirFirst'));
+  });
+});
+
+describe('GoogleProvider reminder mapping', () => {
+  it('maps Google popup reminders to provider alarms', () => {
+    const event = fromGoogleEvent({
+      id: 'google-event-1',
+      summary: 'Google Reminder',
+      start: { dateTime: '2026-06-15T10:00:00+02:00', timeZone: 'Europe/Amsterdam' },
+      end: { dateTime: '2026-06-15T11:00:00+02:00', timeZone: 'Europe/Amsterdam' },
+      reminders: {
+        useDefault: false,
+        overrides: [{ method: 'popup', minutes: 25 }]
+      }
+    });
+
+    expect(event?.alarms).toEqual([{ minutesBefore: 25, action: 'DISPLAY' }]);
+  });
+
+  it('serializes provider alarms as Google popup reminder overrides', () => {
+    const event = {
+      title: 'Google Reminder',
+      type: 'single',
+      date: '2026-06-15',
+      endDate: null,
+      allDay: false,
+      startTime: '10:00',
+      endTime: '11:00',
+      alarms: [{ minutesBefore: 25, action: 'DISPLAY' }]
+    } as OFCEvent;
+
+    expect(toGoogleEvent(event)).toMatchObject({
+      reminders: {
+        useDefault: false,
+        overrides: [{ method: 'popup', minutes: 25 }]
+      }
+    });
   });
 });

--- a/src/providers/google/GoogleProvider.ts
+++ b/src/providers/google/GoogleProvider.ts
@@ -108,7 +108,13 @@ export class GoogleProvider implements CalendarProvider<GoogleProviderConfig>, S
   }
 
   getCapabilities(): CalendarProviderCapabilities {
-    return { canCreate: true, canEdit: true, canDelete: true };
+    return {
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      supportsAlarms: true,
+      ownsRecurringInstanceOverrides: true
+    };
   }
 
   getEventHandle(event: OFCEvent): EventHandle | null {

--- a/src/providers/google/parser/parser_gcal.ts
+++ b/src/providers/google/parser/parser_gcal.ts
@@ -46,6 +46,13 @@ export interface GoogleEventLike {
   recurrence?: string[];
   location?: string;
   description?: string;
+  reminders?: {
+    useDefault?: boolean;
+    overrides?: Array<{
+      method?: string;
+      minutes?: number;
+    }>;
+  };
 }
 
 export function fromGoogleEvent(gEvent: GoogleEventLike): OFCEvent | null {
@@ -74,6 +81,12 @@ export function fromGoogleEvent(gEvent: GoogleEventLike): OFCEvent | null {
   eventData.title = gEvent.summary;
   eventData.location = gEvent.location;
   eventData.description = gEvent.description;
+  const popupReminder = gEvent.reminders?.overrides?.find(
+    reminder => reminder.method === 'popup' && typeof reminder.minutes === 'number'
+  );
+  if (popupReminder) {
+    eventData.alarms = [{ minutesBefore: popupReminder.minutes, action: 'DISPLAY' }];
+  }
 
   // All-Day vs. Timed Events
   if (gEvent.start && gEvent.start.date) {
@@ -201,6 +214,16 @@ export function toGoogleEvent(event: OFCEvent): object {
 
   if (recurrence.length > 0) {
     gEvent.recurrence = recurrence;
+  }
+
+  if (event.alarms && event.alarms.length > 0) {
+    gEvent.reminders = {
+      useDefault: false,
+      overrides: event.alarms.map(alarm => ({
+        method: 'popup',
+        minutes: alarm.minutesBefore
+      }))
+    };
   }
 
   // Handle Overrides (Exceptions)

--- a/src/providers/google/parser/parser_gcal.ts
+++ b/src/providers/google/parser/parser_gcal.ts
@@ -48,10 +48,10 @@ export interface GoogleEventLike {
   description?: string;
   reminders?: {
     useDefault?: boolean;
-    overrides?: Array<{
+    overrides?: {
       method?: string;
       minutes?: number;
-    }>;
+    }[];
   };
 }
 

--- a/src/providers/ics/ICSProvider.ts
+++ b/src/providers/ics/ICSProvider.ts
@@ -128,6 +128,9 @@ export class ICSProvider implements CalendarProvider<ICSProviderConfig>, SyncKey
     if (event.type === 'rrule' && event.id) {
       return event.id;
     }
+    if (event.uid && event.recurrenceId) {
+      return `${event.uid}::${event.recurrenceId}`;
+    }
     return event.uid || JSON.stringify(event);
   }
 

--- a/src/providers/ics/formatter.test.ts
+++ b/src/providers/ics/formatter.test.ts
@@ -210,4 +210,24 @@ describe('ICS Formatter timezone serialization', () => {
     expect(ics).toContain('RECURRENCE-ID;TZID=Europe/Amsterdam:20260520T100000');
     expect(ics).toContain('END:VTODO');
   });
+
+  it('should serialize provider alarms as VALARM components', () => {
+    const event = {
+      type: 'single',
+      title: 'Alarmed Event',
+      date: '2026-05-20',
+      startTime: '10:00',
+      endTime: '11:00',
+      allDay: false,
+      endDate: null,
+      alarms: [{ minutesBefore: 15, action: 'DISPLAY' }]
+    } as OFCEvent;
+
+    const ics = eventToIcs(event);
+    expect(ics).toContain('BEGIN:VALARM');
+    expect(ics).toContain('ACTION:DISPLAY');
+    expect(ics).toContain('TRIGGER:-PT15M');
+    expect(ics).toContain('DESCRIPTION:Alarmed Event');
+    expect(ics).toContain('END:VALARM');
+  });
 });

--- a/src/providers/ics/formatter.ts
+++ b/src/providers/ics/formatter.ts
@@ -62,6 +62,23 @@ function addTimeProperty(
   return prop;
 }
 
+function addProviderAlarms(component: ical.Component, event: OFCEvent): void {
+  for (const alarm of event.alarms || []) {
+    const valarm = new ical.Component('valarm');
+    valarm.addPropertyWithValue('action', alarm.action || 'DISPLAY');
+
+    const trigger = new ical.Property('trigger');
+    trigger.setValue(`-PT${alarm.minutesBefore}M`);
+    valarm.addProperty(trigger);
+
+    if ((alarm.action || 'DISPLAY') === 'DISPLAY') {
+      valarm.addPropertyWithValue('description', event.title);
+    }
+
+    component.addSubcomponent(valarm);
+  }
+}
+
 /**
  * Helper to generate the VEVENT component structure.
  */
@@ -129,6 +146,8 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
   if (event.description) {
     vevent.addPropertyWithValue('description', event.description);
   }
+
+  addProviderAlarms(vevent, event);
 
   // Recurrence (RRULE) - Only for master events, not overrides usually
   if (!isOverride && event.type === 'rrule' && event.rrule) {
@@ -238,6 +257,8 @@ function createVTodoComponent(event: OFCEvent, isOverride = false): ical.Compone
   if (event.description) {
     vtodo.addPropertyWithValue('description', event.description);
   }
+
+  addProviderAlarms(vtodo, event);
 
   // Location/URL mapping:
   if (event.url) {

--- a/src/providers/ics/formatter.ts
+++ b/src/providers/ics/formatter.ts
@@ -79,6 +79,65 @@ function addProviderAlarms(component: ical.Component, event: OFCEvent): void {
   }
 }
 
+function getRecurringEventRule(event: Extract<OFCEvent, { type: 'recurring' }>): string {
+  const parts: string[] = [];
+
+  if (event.month !== undefined && event.dayOfMonth !== undefined) {
+    parts.push('FREQ=YEARLY', `BYMONTH=${event.month}`, `BYMONTHDAY=${event.dayOfMonth}`);
+  } else if (event.repeatOn) {
+    const weekdays = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+    const weekday = weekdays[event.repeatOn.weekday] || 'MO';
+    const weekPrefix = event.repeatOn.week === -1 ? '-1' : String(event.repeatOn.week);
+    parts.push('FREQ=MONTHLY', `BYDAY=${weekPrefix}${weekday}`);
+  } else if (event.dayOfMonth !== undefined) {
+    parts.push('FREQ=MONTHLY', `BYMONTHDAY=${event.dayOfMonth}`);
+  } else if (event.daysOfWeek?.length) {
+    const weekdays: Record<string, string> = {
+      U: 'SU',
+      M: 'MO',
+      T: 'TU',
+      W: 'WE',
+      R: 'TH',
+      F: 'FR',
+      S: 'SA'
+    };
+    parts.push('FREQ=WEEKLY', `BYDAY=${event.daysOfWeek.map(day => weekdays[day]).join(',')}`);
+  } else {
+    parts.push('FREQ=DAILY');
+  }
+
+  if (event.repeatInterval && event.repeatInterval > 1) {
+    parts.push(`INTERVAL=${event.repeatInterval}`);
+  }
+
+  if (event.endRecur) {
+    const until = DateTime.fromISO(event.endRecur).endOf('day').toUTC();
+    if (until.isValid) {
+      parts.push(`UNTIL=${until.toFormat("yyyyMMdd'T'HHmmss'Z'")}`);
+    }
+  }
+
+  return parts.join(';');
+}
+
+function addRecurrenceRule(component: ical.Component, rule: string): void {
+  try {
+    const ruleStr = rule.replace(/^RRULE:/i, '');
+    const recur = (ical.Recur as unknown as { fromString?: (s: string) => unknown }).fromString
+      ? (ical.Recur as unknown as { fromString: (s: string) => unknown }).fromString(ruleStr)
+      : null;
+    if (recur) {
+      component.addPropertyWithValue('rrule', recur);
+    } else {
+      const prop = new ical.Property('rrule');
+      prop.setValue(ruleStr);
+      component.addProperty(prop);
+    }
+  } catch (e) {
+    console.error('Failed to add RRULE', e);
+  }
+}
+
 /**
  * Helper to generate the VEVENT component structure.
  */
@@ -151,21 +210,9 @@ function createVEventComponent(event: OFCEvent, isOverride = false): ical.Compon
 
   // Recurrence (RRULE) - Only for master events, not overrides usually
   if (!isOverride && event.type === 'rrule' && event.rrule) {
-    try {
-      const ruleStr = event.rrule.replace(/^RRULE:/i, '');
-      const recur = (ical.Recur as unknown as { fromString?: (s: string) => unknown }).fromString
-        ? (ical.Recur as unknown as { fromString: (s: string) => unknown }).fromString(ruleStr)
-        : null;
-      if (recur) {
-        vevent.addPropertyWithValue('rrule', recur);
-      } else {
-        const prop = new ical.Property('rrule');
-        prop.setValue(ruleStr);
-        vevent.addProperty(prop);
-      }
-    } catch (e) {
-      console.error('Failed to add RRULE', e);
-    }
+    addRecurrenceRule(vevent, event.rrule);
+  } else if (!isOverride && event.type === 'recurring') {
+    addRecurrenceRule(vevent, getRecurringEventRule(event));
   }
 
   // EXDATE - Only for master events
@@ -293,21 +340,9 @@ function createVTodoComponent(event: OFCEvent, isOverride = false): ical.Compone
 
   // Recurrence (RRULE) - Only for master events, not overrides usually
   if (!isOverride && event.type === 'rrule' && event.rrule) {
-    try {
-      const ruleStr = event.rrule.replace(/^RRULE:/i, '');
-      const recur = (ical.Recur as unknown as { fromString?: (s: string) => unknown }).fromString
-        ? (ical.Recur as unknown as { fromString: (s: string) => unknown }).fromString(ruleStr)
-        : null;
-      if (recur) {
-        vtodo.addPropertyWithValue('rrule', recur);
-      } else {
-        const prop = new ical.Property('rrule');
-        prop.setValue(ruleStr);
-        vtodo.addProperty(prop);
-      }
-    } catch (e) {
-      console.error('Failed to add RRULE', e);
-    }
+    addRecurrenceRule(vtodo, event.rrule);
+  } else if (!isOverride && event.type === 'recurring') {
+    addRecurrenceRule(vtodo, getRecurringEventRule(event));
   }
 
   // EXDATE - Only for master events

--- a/src/providers/ics/ics.test.ts
+++ b/src/providers/ics/ics.test.ts
@@ -44,6 +44,27 @@ END:VCALENDAR`;
     expect(events).toMatchSnapshot(ics);
   });
 
+  it('parses display VALARM triggers as provider alarms', () => {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:alarm-event
+SUMMARY:Alarmed Event
+DTSTART:20260615T100000Z
+DTEND:20260615T110000Z
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT15M
+DESCRIPTION:Alarmed Event
+END:VALARM
+END:VEVENT
+END:VCALENDAR`;
+
+    const events = getEventsFromICS(ics);
+    expect(events).toHaveLength(1);
+    expect(events[0].alarms).toEqual([{ minutesBefore: 15, action: 'DISPLAY' }]);
+  });
+
   it('parses gcal ics file and categories', () => {
     const ics = `BEGIN:VCALENDAR
 PRODID:-//Google Inc//Google Calendar 70.9054//EN

--- a/src/providers/ics/ics.ts
+++ b/src/providers/ics/ics.ts
@@ -47,6 +47,80 @@ function specifiesEnd(iCalEvent: ical.Event) {
   );
 }
 
+type ProviderAlarm = NonNullable<OFCEvent['alarms']>[number];
+
+function durationToSeconds(value: unknown): number | null {
+  if (typeof value === 'string') {
+    const match = value.match(/^(-?)P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i);
+    if (!match) return null;
+    const sign = match[1] === '-' ? -1 : 1;
+    const days = Number(match[2] || 0);
+    const hours = Number(match[3] || 0);
+    const minutes = Number(match[4] || 0);
+    const seconds = Number(match[5] || 0);
+    return sign * (days * 86400 + hours * 3600 + minutes * 60 + seconds);
+  }
+
+  if (value && typeof value === 'object') {
+    const candidate = value as {
+      toSeconds?: () => number;
+      isNegative?: boolean;
+      days?: number;
+      hours?: number;
+      minutes?: number;
+      seconds?: number;
+    };
+    if (typeof candidate.toSeconds === 'function') {
+      return candidate.toSeconds();
+    }
+    const seconds =
+      (candidate.days || 0) * 86400 +
+      (candidate.hours || 0) * 3600 +
+      (candidate.minutes || 0) * 60 +
+      (candidate.seconds || 0);
+    return candidate.isNegative ? -seconds : seconds;
+  }
+
+  return null;
+}
+
+function extractProviderAlarms(component: ical.Component): ProviderAlarm[] | undefined {
+  const alarms = component
+    .getAllSubcomponents('valarm')
+    .map((alarm): ProviderAlarm | null => {
+      const trigger = alarm.getFirstProperty('trigger');
+      if (!trigger) return null;
+
+      const seconds = durationToSeconds(trigger.getFirstValue());
+      if (seconds === null || seconds > 0) return null;
+
+      const action = String(alarm.getFirstPropertyValue('action') || 'DISPLAY').toUpperCase();
+      if (action !== 'DISPLAY' && action !== 'AUDIO' && action !== 'EMAIL') return null;
+
+      return {
+        minutesBefore: Math.round(Math.abs(seconds) / 60),
+        action
+      };
+    })
+    .filter((alarm): alarm is ProviderAlarm => alarm !== null);
+
+  return alarms.length > 0 ? alarms : undefined;
+}
+
+function recurrenceIdToString(recurrenceId: ical.Time | null): string | undefined {
+  if (!recurrenceId) return undefined;
+
+  const dt = parseTimezoneAwareString(recurrenceId);
+  if (!dt.isValid) return undefined;
+
+  return recurrenceId.isDate ? dt.toISODate() || undefined : dt.toISO() || undefined;
+}
+
+function recurrenceIdToDate(recurrenceId: string | undefined): string | undefined {
+  if (!recurrenceId) return undefined;
+  return DateTime.fromISO(recurrenceId, { setZone: true }).toISODate() || undefined;
+}
+
 // MODIFICATION: Remove settings parameter from icsToOFC
 function icsToOFC(input: ical.Event): OFCEvent | null {
   const summary = input.summary || '';
@@ -54,6 +128,7 @@ function icsToOFC(input: ical.Event): OFCEvent | null {
   const rruleProp = input.component.getFirstProperty('rrule');
   const rruleVal = rruleProp ? String(rruleProp.getFirstValue()) : null;
   const rruleStr = rruleVal ? String(rruleVal) : '';
+  const recurrenceId = recurrenceIdToString(input.recurrenceId);
 
   // Simplified: just use the title directly
   const eventData = { title: summary };
@@ -64,6 +139,7 @@ function icsToOFC(input: ical.Event): OFCEvent | null {
   const location = String(input.component.getFirstProperty('location')?.getFirstValue() || '');
   // Use extractEventUrl helper or input.component.getFirstProperty('url')
   const url = extractEventUrl(input);
+  const alarms = extractProviderAlarms(input.component);
 
   const startDate = parseTimezoneAwareString(input.startDate);
 
@@ -135,6 +211,7 @@ function icsToOFC(input: ical.Event): OFCEvent | null {
     return {
       type: 'rrule',
       uid,
+      ...(recurrenceId ? { recurrenceId } : {}),
       title: eventData.title,
       id: `ics::${uid}::${startDateISO}::recurring`,
       rrule: rrule.toString(),
@@ -144,6 +221,7 @@ function icsToOFC(input: ical.Event): OFCEvent | null {
       timezone,
       ...recurringTiming,
       description,
+      ...(alarms ? { alarms } : {}),
       url:
         url ||
         (location && typeof location === 'string' && location.startsWith('http')
@@ -191,12 +269,14 @@ function icsToOFC(input: ical.Event): OFCEvent | null {
   return {
     type: 'single',
     uid,
+    ...(recurrenceId ? { recurrenceId } : {}),
     title: eventData.title,
     date: date,
     endDate: date !== finalEndDate ? finalEndDate || null : null,
     timezone,
     ...singleTiming,
     description,
+    ...(alarms ? { alarms } : {}),
     url:
       url ||
       (location && typeof location === 'string' && location.startsWith('http')
@@ -235,6 +315,11 @@ function todoToOFC(todo: ical.Component): OFCEvent | null {
   const description = String(todo.getFirstPropertyValue('description') || '');
   const location = String(todo.getFirstPropertyValue('location') || '');
   const url = String(todo.getFirstPropertyValue('url') || '');
+  const alarms = extractProviderAlarms(todo);
+  const recurrenceIdProp = todo.getFirstProperty('recurrence-id');
+  const recurrenceId = recurrenceIdProp
+    ? recurrenceIdToString(recurrenceIdProp.getFirstValue())
+    : undefined;
 
   // Handle completed status
   const status = todo.getFirstPropertyValue('status');
@@ -318,6 +403,7 @@ function todoToOFC(todo: ical.Component): OFCEvent | null {
     return {
       type: 'rrule',
       uid,
+      ...(recurrenceId ? { recurrenceId } : {}),
       title: summary,
       id: `ics::${uid}::${startDateISO}::recurring`,
       rrule: rrule.toString(),
@@ -328,6 +414,7 @@ function todoToOFC(todo: ical.Component): OFCEvent | null {
       ...recurringTiming,
       isTask: true,
       description,
+      ...(alarms ? { alarms } : {}),
       url:
         url ||
         (location && typeof location === 'string' && location.startsWith('http')
@@ -382,6 +469,7 @@ function todoToOFC(todo: ical.Component): OFCEvent | null {
   return {
     type: 'single',
     uid,
+    ...(recurrenceId ? { recurrenceId } : {}),
     title: summary,
     date: date,
     endDate: date !== finalEndDate ? finalEndDate || null : null,
@@ -389,6 +477,7 @@ function todoToOFC(todo: ical.Component): OFCEvent | null {
     ...singleTiming,
     completed: completedValue,
     description,
+    ...(alarms ? { alarms } : {}),
     url:
       url ||
       (location && typeof location === 'string' && location.startsWith('http')
@@ -498,8 +587,9 @@ export function getEventsFromICS(text: string): OFCEvent[] {
       });
       continue;
     }
-    if (event.date) {
-      baseEvent.skipDates.push(event.date);
+    const originalDate = recurrenceIdToDate(event.recurrenceId) || event.date;
+    if (originalDate) {
+      baseEvent.skipDates.push(originalDate);
     }
   }
 
@@ -541,8 +631,9 @@ export function getEventsFromICS(text: string): OFCEvent[] {
     if (baseTodo.type !== 'rrule' || todoExc.type !== 'single') {
       continue;
     }
-    if (todoExc.date) {
-      baseTodo.skipDates.push(todoExc.date);
+    const originalDate = recurrenceIdToDate(todoExc.recurrenceId) || todoExc.date;
+    if (originalDate) {
+      baseTodo.skipDates.push(originalDate);
     }
   }
 

--- a/src/providers/outlook/OutlookProvider.test.ts
+++ b/src/providers/outlook/OutlookProvider.test.ts
@@ -53,6 +53,7 @@ describe('OutlookProvider Configuration Wrapper', () => {
 
 import { PluginState } from '../../core/PluginState';
 import { OFCEvent } from '../../types';
+import { fromOutlookEvent, toOutlookEvent } from './parser/parser_outlook';
 
 jest.mock('../../core/PluginState');
 jest.mock('../../utils/showNotice');
@@ -143,5 +144,39 @@ describe('OutlookProvider createLinkedNote', () => {
     expect(file).toBeDefined();
     expect(file!.path).toBe('Calendar/Notes/Outlook Linked Note Event.md');
     expect(file!.content).toContain('Teams: Outlook Linked Note Event');
+  });
+});
+
+describe('OutlookProvider reminder mapping', () => {
+  it('maps Outlook reminders to provider alarms', () => {
+    const event = fromOutlookEvent({
+      id: 'outlook-event-1',
+      subject: 'Outlook Reminder',
+      isAllDay: false,
+      start: { dateTime: '2026-06-15T10:00:00', timeZone: 'Europe/Amsterdam' },
+      end: { dateTime: '2026-06-15T11:00:00', timeZone: 'Europe/Amsterdam' },
+      isReminderOn: true,
+      reminderMinutesBeforeStart: 35
+    });
+
+    expect(event?.alarms).toEqual([{ minutesBefore: 35, action: 'DISPLAY' }]);
+  });
+
+  it('serializes provider alarms as Outlook reminders', () => {
+    const event = {
+      title: 'Outlook Reminder',
+      type: 'single',
+      date: '2026-06-15',
+      endDate: null,
+      allDay: false,
+      startTime: '10:00',
+      endTime: '11:00',
+      alarms: [{ minutesBefore: 35, action: 'DISPLAY' }]
+    } as OFCEvent;
+
+    expect(toOutlookEvent(event)).toMatchObject({
+      isReminderOn: true,
+      reminderMinutesBeforeStart: 35
+    });
   });
 });

--- a/src/providers/outlook/OutlookProvider.ts
+++ b/src/providers/outlook/OutlookProvider.ts
@@ -122,7 +122,13 @@ export class OutlookProvider implements CalendarProvider<OutlookProviderConfig>,
   }
 
   getCapabilities(): CalendarProviderCapabilities {
-    return { canCreate: true, canEdit: true, canDelete: true };
+    return {
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      supportsAlarms: true,
+      ownsRecurringInstanceOverrides: true
+    };
   }
 
   getEventHandle(event: OFCEvent): EventHandle | null {

--- a/src/providers/outlook/parser/parser_outlook.ts
+++ b/src/providers/outlook/parser/parser_outlook.ts
@@ -40,6 +40,8 @@ export interface OutlookEventLike {
     dateTime?: string;
     timeZone?: string;
   } | null;
+  isReminderOn?: boolean;
+  reminderMinutesBeforeStart?: number;
 }
 
 const OUTLOOK_DAY_TO_CHAR: Record<string, 'U' | 'M' | 'T' | 'W' | 'R' | 'F' | 'S'> = {
@@ -107,6 +109,11 @@ export function fromOutlookEvent(event: OutlookEventLike): OFCEvent | null {
       isTask: false,
       skipDates: []
     };
+    if (event.isReminderOn && typeof event.reminderMinutesBeforeStart === 'number') {
+      recurringBase.alarms = [
+        { minutesBefore: event.reminderMinutesBeforeStart, action: 'DISPLAY' }
+      ];
+    }
 
     if (!event.isAllDay) {
       recurringBase.startTime = start.toFormat('HH:mm');
@@ -174,7 +181,14 @@ export function fromOutlookEvent(event: OutlookEventLike): OFCEvent | null {
       title: event.subject,
       allDay: true,
       date: start.toISODate() || '',
-      endDate: inclusiveEnd || null
+      endDate: inclusiveEnd || null,
+      ...(event.isReminderOn && typeof event.reminderMinutesBeforeStart === 'number'
+        ? {
+            alarms: [
+              { minutesBefore: event.reminderMinutesBeforeStart, action: 'DISPLAY' as const }
+            ]
+          }
+        : {})
     };
   }
 
@@ -188,7 +202,12 @@ export function fromOutlookEvent(event: OutlookEventLike): OFCEvent | null {
     startTime: start.toFormat('HH:mm'),
     endDate: end.toISODate() !== start.toISODate() ? end.toISODate() : null,
     endTime: end.toFormat('HH:mm'),
-    timezone: event.start.timeZone || undefined
+    timezone: event.start.timeZone || undefined,
+    ...(event.isReminderOn && typeof event.reminderMinutesBeforeStart === 'number'
+      ? {
+          alarms: [{ minutesBefore: event.reminderMinutesBeforeStart, action: 'DISPLAY' as const }]
+        }
+      : {})
   };
 }
 
@@ -196,6 +215,13 @@ export function toOutlookEvent(event: OFCEvent): object {
   const payload: Record<string, unknown> = {
     subject: constructTitle(event.category, event.subCategory, event.title)
   };
+
+  if (event.alarms && event.alarms.length > 0) {
+    payload.isReminderOn = true;
+    payload.reminderMinutesBeforeStart = event.alarms[0].minutesBefore;
+  } else {
+    payload.isReminderOn = false;
+  }
 
   if (event.allDay) {
     if (event.type !== 'single' && event.type !== 'recurring') {

--- a/src/providers/typesProvider.ts
+++ b/src/providers/typesProvider.ts
@@ -5,6 +5,8 @@ import { ComponentType } from 'react';
  */
 export type EventHandle = {
   persistentId: string;
+  uid?: string;
+  recurrenceId?: string;
   location?: { path: string; lineNumber?: number };
 };
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -64,6 +64,8 @@ export const CommonSchema = z.object({
   title: z.string(), // This will now store the CLEAN title.
   id: z.string().optional(),
   uid: z.string().optional(),
+  caldavHref: z.string().optional(),
+  recurrenceId: z.string().optional(),
   timezone: z.string().optional(),
   etag: z.string().optional(),
   category: z.string().optional(), // This will store the parsed category.
@@ -80,6 +82,14 @@ export const CommonSchema = z.object({
     .object({
       value: z.number().min(0).max(1440)
     })
+    .optional(),
+  alarms: z
+    .array(
+      z.object({
+        minutesBefore: z.number().int().min(0).max(10080),
+        action: z.enum(['DISPLAY', 'AUDIO', 'EMAIL']).default('DISPLAY')
+      })
+    )
     .optional()
 });
 

--- a/src/ui/calendar/ViewEventInteractionHandler.ts
+++ b/src/ui/calendar/ViewEventInteractionHandler.ts
@@ -11,6 +11,67 @@ import { t } from '../../features/i18n/i18n';
 import { dateEndpointsToFrontmatter, fromEventApi } from '../../core/interop';
 import { ViewContext } from './ViewContext';
 import { LinkedNoteIndex } from '../../providers/utils/LinkedNoteIndex';
+import { OFCEvent } from '../../types';
+
+const shiftIsoDate = (date: string | undefined, days: number): string | undefined => {
+  if (!date || days === 0) {
+    return date;
+  }
+
+  return DateTime.fromISO(date).plus({ days }).toISODate() || date;
+};
+
+const getEventDate = (eventApi: EventApi): string | null =>
+  eventApi.start ? DateTime.fromJSDate(eventApi.start).toISODate() : null;
+
+const getDayDelta = (oldEvent: EventApi, newEvent: EventApi): number => {
+  if (!oldEvent.start || !newEvent.start) {
+    return 0;
+  }
+
+  const oldStart = DateTime.fromJSDate(oldEvent.start).startOf('day');
+  const newStart = DateTime.fromJSDate(newEvent.start).startOf('day');
+  return Math.round(newStart.diff(oldStart, 'days').days);
+};
+
+function buildRecurringSequenceReschedule(
+  masterEvent: OFCEvent,
+  oldEvent: EventApi,
+  newEvent: EventApi,
+  modifiedInstance: OFCEvent
+): OFCEvent {
+  if (masterEvent.type !== 'recurring' && masterEvent.type !== 'rrule') {
+    return masterEvent;
+  }
+
+  const dayDelta = getDayDelta(oldEvent, newEvent);
+  const nextEvent = {
+    ...masterEvent,
+    allDay: modifiedInstance.allDay,
+    timezone: modifiedInstance.timezone || masterEvent.timezone
+  } as Record<string, unknown>;
+
+  if (modifiedInstance.allDay) {
+    delete nextEvent.startTime;
+    delete nextEvent.endTime;
+  } else if ('startTime' in modifiedInstance) {
+    nextEvent.startTime = modifiedInstance.startTime;
+    nextEvent.endTime = modifiedInstance.endTime;
+  }
+
+  if (masterEvent.type === 'recurring') {
+    return {
+      ...nextEvent,
+      startRecur: shiftIsoDate(masterEvent.startRecur, dayDelta),
+      endRecur: shiftIsoDate(masterEvent.endRecur, dayDelta)
+    } as OFCEvent;
+  }
+
+  return {
+    ...nextEvent,
+    startDate: shiftIsoDate(masterEvent.startDate, dayDelta) || masterEvent.startDate
+  } as OFCEvent;
+}
 
 export class ViewEventInteractionHandler {
   constructor(private ctx: ViewContext) {}
@@ -158,35 +219,93 @@ export class ViewEventInteractionHandler {
         throw new Error('Original event not found in cache.');
       }
 
-      if (originalEvent.type === 'single' && originalEvent.recurringEventId) {
-        const oldDate = oldEvent.start ? DateTime.fromJSDate(oldEvent.start).toISODate() : null;
-        const newDate = newEvent.start ? DateTime.fromJSDate(newEvent.start).toISODate() : null;
-
-        if (oldDate && newDate && oldDate !== newDate) {
-          showNotice(t('ui.view.errors.moveRecurringDayError'), 6000);
-          return false;
-        }
-      }
-
       if (originalEvent.type === 'rrule' || originalEvent.type === 'recurring') {
         if (!oldEvent.start) {
           throw new Error('Recurring instance is missing original start date.');
         }
 
-        const instanceDate = DateTime.fromJSDate(oldEvent.start).toISODate();
+        const instanceDate = getEventDate(oldEvent);
         if (!instanceDate) {
           throw new Error('Could not determine instance date from recurring event.');
         }
 
         const modifiedEvent = fromEventApi(newEvent, PluginState.getSettings(), newResource);
-
-        await PluginState.getCache().modifyRecurringInstance(
-          oldEvent.id,
-          instanceDate,
-          modifiedEvent
-        );
-        return true;
+        const { RescheduleRecurringModal } = await import('../modals/RescheduleRecurringModal');
+        new RescheduleRecurringModal(
+          this.ctx.app,
+          () => {
+            void PluginState.getCache().modifyRecurringInstance(
+              oldEvent.id,
+              instanceDate,
+              modifiedEvent
+            );
+          },
+          () => {
+            void PluginState.getCache().updateEventWithId(
+              oldEvent.id,
+              buildRecurringSequenceReschedule(originalEvent, oldEvent, newEvent, modifiedEvent)
+            );
+          },
+          instanceDate
+        ).open();
+        return false;
       }
+
+      if (
+        originalEvent.type === 'single' &&
+        (originalEvent.recurringEventId || originalEvent.recurrenceId)
+      ) {
+        const oldDate = getEventDate(oldEvent);
+        const modifiedEvent = fromEventApi(newEvent, PluginState.getSettings(), newResource);
+        const masterDetails = PluginState.getCache()
+          .store.getAllEvents()
+          .find(candidate => {
+            if (
+              candidate.event.type !== 'recurring' &&
+              candidate.event.type !== 'rrule'
+            ) {
+              return false;
+            }
+            if (candidate.event.uid && candidate.event.uid === originalEvent.uid) {
+              return true;
+            }
+            if (
+              originalEvent.recurringEventId &&
+              candidate.event.uid === originalEvent.recurringEventId
+            ) {
+              return true;
+            }
+            const parentFilename = originalEvent.recurringEventId?.split('/').pop();
+            const candidateFilename = candidate.location?.path.split('/').pop();
+            return Boolean(parentFilename && candidateFilename === parentFilename);
+          });
+
+        if (!oldDate || !masterDetails) {
+          return await PluginState.getCache().updateEventWithId(oldEvent.id, modifiedEvent);
+        }
+
+        const { RescheduleRecurringModal } = await import('../modals/RescheduleRecurringModal');
+        new RescheduleRecurringModal(
+          this.ctx.app,
+          () => {
+            void PluginState.getCache().updateEventWithId(oldEvent.id, modifiedEvent);
+          },
+          () => {
+            void PluginState.getCache().updateEventWithId(
+              masterDetails.id,
+              buildRecurringSequenceReschedule(
+                masterDetails.event,
+                oldEvent,
+                newEvent,
+                modifiedEvent
+              )
+            );
+          },
+          oldDate
+        ).open();
+        return false;
+      }
+
       const didModify = await PluginState.getCache().updateEventWithId(
         oldEvent.id,
         fromEventApi(newEvent, PluginState.getSettings(), newResource)

--- a/src/ui/calendar/ViewEventInteractionHandler.ts
+++ b/src/ui/calendar/ViewEventInteractionHandler.ts
@@ -169,14 +169,6 @@ export class ViewEventInteractionHandler {
       }
 
       if (originalEvent.type === 'rrule' || originalEvent.type === 'recurring') {
-        const oldDate = oldEvent.start ? DateTime.fromJSDate(oldEvent.start).toISODate() : null;
-        const newDate = newEvent.start ? DateTime.fromJSDate(newEvent.start).toISODate() : null;
-
-        if (oldDate && newDate && oldDate !== newDate) {
-          showNotice(t('ui.view.errors.moveRecurringInstanceError'), 6000);
-          return false;
-        }
-
         if (!oldEvent.start) {
           throw new Error('Recurring instance is missing original start date.');
         }

--- a/src/ui/context/EventContextMenuBuilder.ts
+++ b/src/ui/context/EventContextMenuBuilder.ts
@@ -1,4 +1,3 @@
-import { showNotice } from '../../utils/showNotice';
 import { PluginState } from '../../core/PluginState';
 import { EventApi } from '@fullcalendar/core';
 import { Menu } from 'obsidian';
@@ -238,7 +237,6 @@ function buildDeleteActions(
           await PluginState.getCache().deleteEvent(context.eventId);
         }
 
-        showNotice(t('ui.view.success.deletedEvent', { title: context.title }));
       }
     }
   ];

--- a/src/ui/modals/EditEvent.tsx
+++ b/src/ui/modals/EditEvent.tsx
@@ -19,6 +19,7 @@ import { AutocompleteInput } from '../components/forms/AutocompleteInput';
 import { parseSubcategoryTitle } from '../../features/category/categoryParser';
 import { t } from '../../features/i18n/i18n';
 import { setIcon } from 'obsidian';
+import { PluginState } from '../../core/PluginState';
 
 const Icon = ({ name }: { name: string }) => {
   const ref = React.useRef<HTMLDivElement>(null);
@@ -226,8 +227,10 @@ export const EditEvent = ({
 
   const selectedCalendar = calendars[calendarIndex];
   const isDailyNoteCalendar = selectedCalendar.type === 'dailynote';
-  const supportsProviderNotifications = ['caldav', 'google', 'outlook'].includes(
-    selectedCalendar.type
+  const supportsProviderNotifications = Boolean(
+    PluginState.getProviderRegistry()
+      .getInstance(selectedCalendar.id)
+      ?.getCapabilities().supportsAlarms
   );
   const recurringTooltip = isDailyNoteCalendar
     ? t('modals.editEvent.tooltips.dailyNoteRecurring')

--- a/src/ui/modals/EditEvent.tsx
+++ b/src/ui/modals/EditEvent.tsx
@@ -191,6 +191,13 @@ export const EditEvent = ({
   const [notifyValue, setNotifyValue] = useState(
     initialEvent?.notify?.value !== undefined ? initialEvent.notify.value : ''
   );
+  const [providerNotifyValue, setProviderNotifyValue] = useState(
+    initialEvent?.alarms?.[0]?.minutesBefore !== undefined
+      ? initialEvent.alarms[0].minutesBefore
+      : initialEvent?.notify?.value !== undefined
+        ? initialEvent.notify.value
+        : ''
+  );
   // END ADDITION
   type MonthlyMode = 'dayOfMonth' | 'onThe';
   const getInitialMonthlyMode = (): MonthlyMode =>
@@ -219,6 +226,9 @@ export const EditEvent = ({
 
   const selectedCalendar = calendars[calendarIndex];
   const isDailyNoteCalendar = selectedCalendar.type === 'dailynote';
+  const supportsProviderNotifications = ['caldav', 'google', 'outlook'].includes(
+    selectedCalendar.type
+  );
   const recurringTooltip = isDailyNoteCalendar
     ? t('modals.editEvent.tooltips.dailyNoteRecurring')
     : '';
@@ -305,6 +315,10 @@ export const EditEvent = ({
       description: description || undefined,
 
       notify: notifyValue !== '' ? { value: Number(notifyValue) } : undefined,
+      alarms:
+        supportsProviderNotifications && providerNotifyValue !== ''
+          ? [{ minutesBefore: Number(providerNotifyValue), action: 'DISPLAY' }]
+          : undefined,
       ...timeInfo,
       ...eventData
     } as OFCEvent;
@@ -493,24 +507,47 @@ export const EditEvent = ({
               </div>
             </div>
             <div className="setting-item-control ofc-notify-group">
-              <input
-                type="number"
-                min="0"
-                max="1440"
-                placeholder={t('modals.editEvent.fields.notification.mins') || 'Mins'}
-                value={notifyValue}
-                onChange={e => setNotifyValue(e.target.value)}
-                style={{ width: '80px', marginRight: '8px' }}
-              />
+              <label className="ofc-notify-field">
+                <span>Obsidian reminder</span>
+                <input
+                  type="number"
+                  min="0"
+                  max="1440"
+                  placeholder="Minutes before start"
+                  value={notifyValue}
+                  onChange={e => setNotifyValue(e.target.value)}
+                  title="Minutes before the event starts"
+                />
+              </label>
+              {supportsProviderNotifications && (
+                <label className="ofc-notify-field">
+                  <span>Calendar provider reminder</span>
+                  <input
+                    type="number"
+                    min="0"
+                    max="10080"
+                    placeholder="Minutes before start"
+                    value={providerNotifyValue}
+                    onChange={e => setProviderNotifyValue(e.target.value)}
+                    title="Minutes before the event starts"
+                  />
+                </label>
+              )}
               <select
                 onChange={e => {
                   const val = e.target.value;
-                  if (val) setNotifyValue(val);
+                  if (val) {
+                    setNotifyValue(val);
+                    if (supportsProviderNotifications) {
+                      setProviderNotifyValue(val);
+                    }
+                  }
                 }}
                 value="" // Always reset to allow re-selection
+                title="Reminder time preset"
               >
                 <option value="" disabled>
-                  {t('modals.editEvent.fields.notification.select') || 'Select...'}
+                  Preset
                 </option>
                 <option value="30">{t('modals.editEvent.fields.notification.presets.30m')}</option>
                 <option value="60">{t('modals.editEvent.fields.notification.presets.1h')}</option>

--- a/src/ui/modals/RescheduleRecurringModal.ts
+++ b/src/ui/modals/RescheduleRecurringModal.ts
@@ -1,0 +1,62 @@
+import { App, ButtonComponent, Modal, Setting } from 'obsidian';
+import { t } from '../../features/i18n/i18n';
+
+export class RescheduleRecurringModal extends Modal {
+  constructor(
+    app: App,
+    private onRescheduleInstance: () => void,
+    private onRescheduleSequence: () => void,
+    private instanceDate?: string
+  ) {
+    super(app);
+  }
+
+  onOpen() {
+    this.modalEl.addClass('full-calendar-confirm-modal');
+    const { contentEl } = this;
+    contentEl.createEl('h2', { text: t('modals.rescheduleRecurring.title') });
+    contentEl.createEl('p', {
+      text: t('modals.rescheduleRecurring.description')
+    });
+
+    new Setting(contentEl)
+      .setName(t('modals.rescheduleRecurring.rescheduleInstance.name'))
+      .setDesc(
+        this.instanceDate
+          ? t('modals.rescheduleRecurring.rescheduleInstance.description', {
+              date: this.instanceDate
+            })
+          : t('modals.rescheduleRecurring.rescheduleInstance.descriptionNoDate')
+      )
+      .addButton((btn: ButtonComponent) =>
+        btn
+          .setButtonText(t('modals.rescheduleRecurring.rescheduleInstance.button'))
+          .setCta()
+          .onClick(() => {
+            this.close();
+            this.onRescheduleInstance();
+          })
+      );
+
+    new Setting(contentEl)
+      .setName(t('modals.rescheduleRecurring.rescheduleSequence.name'))
+      .setDesc(t('modals.rescheduleRecurring.rescheduleSequence.description'))
+      .addButton((btn: ButtonComponent) =>
+        btn
+          .setButtonText(t('modals.rescheduleRecurring.rescheduleSequence.button'))
+          .setCta()
+          .onClick(() => {
+            this.close();
+            this.onRescheduleSequence();
+          })
+      );
+
+    new Setting(contentEl).addButton((btn: ButtonComponent) =>
+      btn.setButtonText(t('modals.rescheduleRecurring.cancel')).onClick(() => this.close())
+    );
+  }
+
+  onClose() {
+    this.contentEl.empty();
+  }
+}

--- a/src/ui/modals/event_modal.ts
+++ b/src/ui/modals/event_modal.ts
@@ -221,7 +221,7 @@ export function launchEditModal(
         },
         deleteEvent: async () => {
           try {
-            await PluginState.getCache().deleteEvent(eventId);
+            await PluginState.getCache().deleteEvent(eventId, { instanceDate });
             closeModal();
           } catch (e) {
             if (e instanceof Error) {

--- a/src/ui/settings/sections/calendars/styles/overrides.css
+++ b/src/ui/settings/sections/calendars/styles/overrides.css
@@ -262,14 +262,32 @@
     align-items: center;
     gap: 8px;
     width: 100%;
+    flex-wrap: wrap;
+}
+
+.full-calendar-edit-modal .ofc-notify-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 0;
+}
+
+.full-calendar-edit-modal .ofc-notify-field span {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+.full-calendar-edit-modal .ofc-notify-field input[type="number"] {
+    width: 150px;
 }
 
 .full-calendar-edit-modal .ofc-notify-group input[type="number"] {
-    width: 80px;
+    width: 150px;
 }
 
 .full-calendar-edit-modal .ofc-notify-group select {
-    flex: 1;
+    width: 120px;
 }
 
 .full-calendar-edit-modal .options-group label {
@@ -1303,21 +1321,23 @@
 /* Mobile overrides for Notification inputs group */
 .is-phone .full-calendar-edit-modal .ofc-notify-group {
     display: flex;
-    flex-direction: row;
-    align-items: center;
+    flex-direction: column;
+    align-items: stretch;
     gap: 10px;
     width: 100%;
 }
 
 .is-phone .full-calendar-edit-modal .ofc-notify-group input[type="number"] {
-    flex: 0 0 100px;
-    width: 100px;
+    width: 100%;
     min-height: 48px;
     box-sizing: border-box;
 }
 
+.is-phone .full-calendar-edit-modal .ofc-notify-field {
+    width: 100%;
+}
+
 .is-phone .full-calendar-edit-modal .ofc-notify-group select {
-    flex: 1;
     width: 100%;
     min-height: 48px;
     box-sizing: border-box;


### PR DESCRIPTION
Recurring CalDAV events were only being changed locally in several cases. The previous implementation guessed CalDAV object URLs from UID values, created overrides without preserving the recurring master UID/RECURRENCE-ID correctly, and let multiple exceptions collide because they shared the same UID. This meant moved instances could disappear after re-sync, hide the wrong occurrence, or wipe out other exceptions in the series.

Use the CalDAV href returned by the server as the persistent object handle for updates, deletes, and overrides. Create provider-native recurrence exceptions with the master UID, a timed RECURRENCE-ID based on the original occurrence start, and a distinct sync key of UID::RECURRENCE-ID so any number of moved instances can coexist. Preserve the master event in cache without rewriting the provider's recurring object after a native exception has been created.

Provider reminders are now first-class event data. Parse and serialize ICS VALARM, map Google popup reminders and Outlook reminders into the same provider alarm model, show existing provider reminders in the Edit Event screen, and preserve both Obsidian notify values and provider alarms when dragging a recurring occurrence into an override.

The notification controls now label Obsidian and calendar-provider reminders separately and use the event's own provider automatically instead of exposing an unclear provider selection field. Added regression coverage for multiple CalDAV exceptions, moved timed exceptions, retained reminders, ICS alarms, and Google/Outlook reminder mapping.

Hopefully recurring events are now more stable!