### PR TITLE
feat: improve linked task notes and daily note navigation

### DIFF
--- a/docs/architecture/system/features/event-linked-notes.md
+++ b/docs/architecture/system/features/event-linked-notes.md
@@ -9,21 +9,23 @@
 |---|---|---|
 | `LinkedNoteIndex` | Reactive index matching remote event UIDs and recurrence IDs to Obsidian file paths. Supports compound key mapping (`eventUid::recurrenceId`) for instance-level note lookup. | Listens to Obsidian vault events; decoupled from [EventStore](../event-storage.md#eventstore-model). |
 | `TemplateEngine` | Renders a clean markdown body from event fields using a custom layout. | Pure functional renderer; no file system or vault side effects. |
-| `createLinkedNoteForProvider` | Centralized helper that orchestrates note creation for any remote provider. | Combines `TemplateEngine`, `noteUtils`, and `frontmatter` utilities in a single DRY entry point. |
+| `createLinkedNoteForProvider` | Centralized helper that resolves or creates a linked note according to the configured strategy. | Combines exact title-path lookup, `LinkedNoteIndex`, `TemplateEngine`, `noteUtils`, and frontmatter utilities in a single DRY entry point. |
 | `noteUtils` | General file-handling, title sanitization, and YAML serialization. | Shared file utility layer; DRY wrapper around Obsidian API. |
 | Remote Providers | Delegate to `createLinkedNoteForProvider` for note creation; query `LinkedNoteIndex` during event reads. | Zero manual frontmatter construction in providers. |
 
 ---
 
-## Source Of Truth
+## Identity Sources
 
-Linked note identity is **frontmatter-driven**. The canonical identifiers are:
+Deadline-based identity and renamed/moved-note recovery are **frontmatter-driven**. The canonical identifiers are:
 
 * `fc-event-uid`
 * `fc-calendar-id`
-* `fc-event-recurrence-id` for instance-specific recurring notes
+* `fc-event-recurrence-id` for deadline-based instance-specific recurring notes
 
-`LinkedNoteIndex` is only an in-memory projection of those identifiers. Filenames, rendered body text, and cache state are not authoritative and may change without breaking linkage.
+In name-based mode, the exact sanitized title path inside the configured linked-notes directory is the primary lookup key. When that file is reused or created, the plugin attaches the stable calendar/UID identifiers so `LinkedNoteIndex` can continue resolving it after a later rename or move.
+
+Rendered body text and cache state are never authoritative.
 
 ## Architectural Principles & SOLID Boundaries
 
@@ -39,7 +41,7 @@ Instead of the core mapping files to events:
 
 ### 2️⃣ Standalone Body Templating (SOLID: Single Responsibility Principle)
 To avoid vault contamination and ensure data cleanliness:
-* The frontmatter of the linked note remains **minimal** (e.g., storing only identifiers like `fc-event-uid` and `fc-calendar-id`).
+* The frontmatter of the linked note remains **managed and scoped**. Shared linked-note identity uses fields such as `fc-event-uid` and `fc-calendar-id`; CalDAV task notes may additionally manage scheduled/due properties.
 * All rich metadata (title, formatted date, times, location, description, and source calendar name) is rendered directly inside the **body** of the note.
 * `TemplateEngine` is a pure utility that parses double-braced expressions (e.g., `{{title}}`, `{{timeString}}`, `{{location}}`) inside customizable layouts, and operates independently of Obsidian's storage or settings UI layers.
 
@@ -57,22 +59,28 @@ Rather than executing expensive, repetitive full-vault scans on every calendar l
 
 ### 4️⃣ Centralized Note Creation (SOLID: DRY)
 All remote providers delegate to a single centralized helper `createLinkedNoteForProvider()` in `src/features/linked-notes/linkedNotes.ts`. This function:
-1. Checks if a linked note already exists via `LinkedNoteIndex`.
-2. Reads the linked notes directory and template from `PluginState.getSettings()`.
-3. Renders the note body via `TemplateEngine`.
-4. Constructs minimal frontmatter using `serializeFrontmatter()`.
-5. Applies frontmatter using `replaceFrontmatter()` from the FullNote provider utilities.
-6. Writes the file via `ObsidianIO`.
+1. Reads the linked-note strategy, directory, and template from `PluginState.getSettings()`.
+2. In name mode, checks the exact sanitized title path first and attaches managed identity properties when reusing an existing file.
+3. Falls back to `LinkedNoteIndex` so renamed or moved notes remain resolvable.
+4. Renders the note body via `TemplateEngine` only when creating a new file.
+5. Constructs managed frontmatter using `serializeFrontmatter()`.
+6. Writes the exact title path in name mode, or a collision-safe occurrence path in deadline mode.
 
 No provider implements its own frontmatter construction, template rendering, or file creation logic.
 
-### 5️⃣ Recurring Event Instance Support (Unique Instance Identity)
-To resolve note collisions for recurring remote events (daily or weekly meetings), the linking model supports instance-level mapping:
+### 5️⃣ Configurable Recurring Event Identity
+The `linkedNoteLinkStrategy` setting selects how occurrence dates participate in note identity:
+* **Deadline-based**: Uses instance-level mapping and remains the compatibility default.
+* **Name-based**: Resolves the exact sanitized title path before UID lookup. An existing file at that path is reused and receives only the managed calendar/UID identity properties; otherwise the exact path is created without a collision suffix. UID lookup remains the fallback for notes later renamed or moved.
+
+For deadline-based mapping:
 * **Compound Key Indexing**: `LinkedNoteIndex` computes compound keys using `${eventUid}::${recurrenceId}` when the YAML frontmatter includes `fc-event-recurrence-id`.
 * **Fallback Strategy**: When querying notes, `LinkedNoteIndex.getFileForEvent(uid, recurrenceId)` prioritizes matching compound keys first, falling back to the master series note (`uid`) only if no instance note exists.
 * **Reactive Cache Scrubbing**: During reactive updates, if a note's frontmatter is modified to add or change the recurrence ID, `LinkedNoteIndex` automatically purges the old orphan key pointing to that same file path.
 * **Instance-Aware Filenames & Templating**: File names for newly created notes automatically append the occurrence date (e.g., `Weekly Sync 2026-05-20.md`) to avoid vault conflicts, and the `TemplateEngine` uses the instance date to format the `{{date}}` placeholder in the note body.
 * **Recurring Identity Source Of Truth**: The recurrence-specific frontmatter field remains canonical. Filename date suffixes are collision-avoidance and readability aids only.
+
+For name-based mapping, the exact title path is the first lookup key and intentionally makes equal titles share a note. The stable calendar ID and master event UID are attached to the file as a secondary identity so later renames or moves remain resolvable.
 
 ---
 
@@ -86,6 +94,16 @@ sequenceDiagram
     participant LNI as LinkedNoteIndex
     participant TE as TemplateEngine
     participant V as Obsidian Vault
+
+    Note over UI,V: Name-Based Resolution
+    UI->>LN: open/create linked note
+    LN->>V: check exact sanitized title path
+    alt title file exists
+        LN->>V: update managed calendar/UID properties only
+        LN-->>UI: open existing title file
+    else title file absent
+        LN->>LNI: fallback lookup by UID
+    end
 
     Note over GP,LNI: Read Path
     GP->>LNI: getFileForEvent(uid, recurrenceId)
@@ -109,8 +127,9 @@ sequenceDiagram
 ## Invariants for Contributors
 
 * **Do not pollute core files**: Never modify [`EventCache.ts`](file:///d:/Codes/plugin-full-calendar/src/core/EventCache.ts), sync modules, or cache stores to orchestrate note creation or path association.
-* **Keep frontmatter minimal**: Only add parameters crucial for identity matching (`fc-event-uid`, `fc-calendar-id`) to the YAML frontmatter. Put all other variables in the note body.
+* **Keep frontmatter changes scoped**: Shared linked-note code manages only identity parameters (`fc-event-uid`, `fc-calendar-id`, and optional recurrence ID). Provider-specific managed properties, such as CalDAV task dates, must update without altering unrelated frontmatter or note body content.
 * **Always sanitize inputs**: Always pipe event titles through `sanitizeTitleForFilename` to strip OS-reserved characters before attempting a file write.
+* **Never suffix name-based files**: Name mode must reuse or create the exact sanitized title path. Collision suffixes are reserved for deadline-based creation.
 * **Locale-independent tests**: When asserting date or time strings in the template test suite, always calculate the expected outcome dynamically using Luxon's local formatter to prevent timezone/locale mismatches on test machines.
 * **Never duplicate logic in providers**: All note creation must go through `createLinkedNoteForProvider`. Providers must not construct frontmatter, render templates, or create files independently.
 
@@ -125,7 +144,7 @@ sequenceDiagram
 *   [`src/providers/fullnote/frontmatter.ts`](file:///d:/Codes/plugin-full-calendar/src/providers/fullnote/frontmatter.ts) — Frontmatter parsing and serialization.
 *   [`src/utils/eventActions.ts`](file:///d:/Codes/plugin-full-calendar/src/utils/eventActions.ts) — Re-exports `openOrCreateLinkedNote` for UI access.
 *   [`src/ui/modals/event_modal.ts`](file:///d:/Codes/plugin-full-calendar/src/ui/modals/event_modal.ts) — Event modal with "Open Note" button integration.
-*   [`src/ui/settings/sections/renderCalendars.ts`](file:///d:/Codes/plugin-full-calendar/src/ui/settings/sections/renderCalendars.ts) — Linked note settings UI (directory picker + template editor).
+*   [`src/ui/settings/sections/renderCalendars.ts`](file:///d:/Codes/plugin-full-calendar/src/ui/settings/sections/renderCalendars.ts) — Linked note settings UI (directory picker, link strategy, and template editor).
 
 ---
 
@@ -133,4 +152,3 @@ sequenceDiagram
 
 *   [Event Linked Notes User Guide](../../../user/features/event-linked-notes.md) — Learn how to configure directories and design custom templates.
 *   [Provider Architecture](../../calendars/architecture.md) — Unified blueprint of remote and local calendar models.
-

--- a/docs/user/calendars/caldav.md
+++ b/docs/user/calendars/caldav.md
@@ -30,6 +30,23 @@ CalDAV tasks (`VTODO` components) that do not have a scheduled or due date are p
 - **Task Creation**: Create new unscheduled CalDAV tasks directly in the backlog sidebar by choosing your CalDAV calendar from the creation source dropdown.
 - **Linked Notes**: Clicking the note icon next to a CalDAV task in the backlog will automatically generate and open a local linked markdown note in Obsidian using your configured templates, allowing you to attach rich local notes and details to remote tasks.
 
+The global **Linked Note Link Strategy** also applies to CalDAV tasks. Name-based mode reuses the exact task-title file across reschedules and recurring occurrences; deadline-based mode keeps dated occurrence notes separate.
+
+### Linked Task Date Properties
+
+Linked notes for scheduled CalDAV tasks automatically receive managed date properties:
+
+```yaml
+scheduled: 2026-04-23
+scheduled-link: "[[2026-04-23]]"
+due: 2026-04-24
+due-link: "[[2026-04-24]]"
+```
+
+The `scheduled` and `due` values are ISO dates. The corresponding `-link` values are daily-note links. The outer quotes are YAML syntax and prevent Obsidian from interpreting the wiki-link as a nested list; the property value itself is `[[2026-04-23]]`.
+
+These properties are updated when the task is rescheduled or synchronized from CalDAV. When a task becomes unscheduled, only these managed date properties are removed. Other frontmatter and note content are left unchanged.
+
 ---
 
 ## Apple Calendar

--- a/docs/user/calendars/gcal.md
+++ b/docs/user/calendars/gcal.md
@@ -57,7 +57,7 @@ If you prefer to maintain your own OAuth Client ID and Secret for privacy or dev
 - **Two-Way Sync**: Changes made in Obsidian (create, edit, delete) are instantly reflected in Google Calendar.
 - **Recurring Events**: Supports exceptions and cancellations. Deleting a single instance in a series creates a proper "cancelled" instance in the Google API.
 - **Timezone Management**: Events are normalized to your **[Display Timezone](../settings/fc_config.md)** while respecting the original source timezone for recurrence rules.
-- **Event Linked Notes**: Keep rich local meeting notes or agendas connected directly to remote Google Calendar events with automated template population. See the **[Event Linked Notes Guide](../features/event-linked-notes.md)** for details.
+- **Event Linked Notes**: Keep rich local meeting notes or agendas connected directly to remote Google Calendar events with automated template population. Name-based mode reuses the exact sanitized title file; deadline-based mode can keep recurring occurrences separate. See the **[Event Linked Notes Guide](../features/event-linked-notes.md)** for details.
 - **Mobile Support**: On iOS/Android, the login flow opens a blank tab first to bypass popup blockers. Ensure popups are allowed for Obsidian.
 
 ---

--- a/docs/user/calendars/gtasks.md
+++ b/docs/user/calendars/gtasks.md
@@ -41,6 +41,7 @@ Keep detailed project notes or task descriptions locally in Obsidian while keepi
 - Click a task event in the calendar or backlog, and click **Create Event Note**.
 - A local markdown note will be created, indexed, and linked using **[Event Linked Notes](../features/event-linked-notes.md)** templates.
 - The linked note indicator will automatically show that a local page is associated with the Google Task.
+- The global linked-note strategy applies: **Name-based** reuses the exact task-title file across due-date changes, while **Deadline-based** uses dated occurrence identity.
 
 ---
 

--- a/docs/user/features/event-linked-notes.md
+++ b/docs/user/features/event-linked-notes.md
@@ -11,13 +11,22 @@ When you click on a remote calendar event in Obsidian, the event details modal o
 
 1. **Open Note**: Click the **Open Note** button in the top-right corner of the event modal. If no linked note exists yet, one will be created automatically in your configured directory.
 2. **Automated Templating**: The new note is populated with rich event details (date, time, location, description, calendar name) according to your template.
-3. **Instant Access**: On subsequent clicks, the same note is opened — the plugin uses [frontmatter-based identity matching](../../architecture/system/features/event-linked-notes.md#1-core-blindness-solid-open-closed-principle) to find the existing note, so you'll never get duplicates.
+3. **Instant Access**: On subsequent clicks, the same note is opened according to your selected link strategy. Name-based mode checks the exact title path first; deadline-based mode uses event and occurrence identity.
 
 ---
 
 ## Handling Recurring Events
 
-For recurring remote calendar events (such as daily or weekly standups), the plugin creates and manages **instance-specific linked notes** by default. Clicking or editing a specific calendar occurrence of a recurring series will open or create a note dedicated to *that specific instance date* rather than a single shared note for the entire series.
+The **Linked note link strategy** setting controls how recurring remote events and rescheduled task instances use notes:
+
+* **Deadline-based** is the compatibility default. Each occurrence gets an instance-specific note.
+* **Name-based** first checks for an exact title-matched file in the configured linked-notes folder. It opens that file when present, or creates it without a suffix when absent. Moving a task deadline or opening another occurrence continues to use the same note.
+
+When name mode reuses an existing title-matched file, it adds or updates only the calendar ID and event UID properties; the existing body and unrelated properties remain unchanged. These stable frontmatter IDs preserve lookup after the note is later renamed or moved.
+
+Name-based matching is folder-specific and exact after filename sanitization. For example, an event titled `Project / Launch` matches `Project Launch.md` inside the configured linked-notes folder. It does not search other folders or add collision suffixes such as `-_-_-1`.
+
+In deadline-based mode:
 
 * **Collision-Free Filenames**: Newly generated notes automatically append the occurrence date directly to the filename to avoid vault conflicts in your notes folder (e.g., `Weekly Sync 2026-05-20.md`).
 * **Instance Frontmatter Identity**: The note's YAML frontmatter includes an additional field `fc-event-recurrence-id` specifying the exact date of that occurrence:
@@ -37,7 +46,11 @@ Go to [Settings → Calendars](../settings/sources.md) to set up the default beh
 ### 1️⃣ Linked Notes Directory
 Choose the folder inside your Obsidian vault where all newly created event notes will be stored (e.g., `Meetings` or `Inbox/Calendar`). Use the folder dropdown to select an existing folder. If the folder does not exist, it will be automatically created upon the first note generation.
 
-### 2️⃣ Linked Note Template
+### 2️⃣ Linked Note Link Strategy
+
+Choose **Name-based** when a project, recurring series, or rescheduled task should keep one shared note. Exact matching uses the sanitized event title inside the configured linked-notes folder, so events with the same title intentionally share that note. Choose **Deadline-based** when every dated occurrence needs its own note. Changing this setting affects future lookup and creation; it does not rename or merge existing notes.
+
+### 3️⃣ Linked Note Template
 Write a custom template that will populate the body of every new note. You can use standard markdown and insert the following double-braced dynamic placeholders:
 
 | Placeholder | Replaced With | Example Output |
@@ -79,11 +92,11 @@ Write a custom template that will populate the body of every new note. You can u
     fc-event-uid: 0q5u45oijpqnkljsndpfoiash98
     fc-calendar-id: google-calendar-work
     ```
-    Because of this metadata-driven design:
-    * **Rename Safe**: You can rename your note files or move them between directories inside your vault; the calendar will never lose the link.
-    * **Re-sync Safe**: If you disconnect your calendar and add it back, or clear the local calendar cache, the plugin reactively re-indexes the frontmatter and restores the link immediately.
-    * **No Vault Bloat**: We only add these two simple IDs to the frontmatter, keeping the rest of your note completely customizable and clean.
-    * **No Duplicates**: The plugin checks for existing notes before creating new ones, so pressing "Open Note" multiple times always opens the same file.
+    These IDs support reactive indexing and preserve the connection after a linked note is renamed or moved:
+    * **Rename and Move Recovery**: After identity properties are attached, the reactive index can continue resolving a linked note that is renamed or moved within the configured linked-notes directory.
+    * **Re-sync Recovery**: Clearing the local calendar cache does not remove the identity properties stored in the note.
+    * **Minimal Changes**: Reusing an existing name-based note updates only managed identity properties. CalDAV task notes may additionally contain managed scheduled/due properties.
+    * **Predictable Reuse**: Name-based mode intentionally shares one file between events with the same sanitized title in the configured folder. Deadline-based mode keeps dated occurrences separate.
 
 ---
 
@@ -97,4 +110,3 @@ Write a custom template that will populate the body of every new note. You can u
 
 === "Technical Deep-Dives"
     *   [Event Linked Notes Architecture](../../architecture/system/features/event-linked-notes.md) — Decoupled reactive architecture and SOLID principles.
-

--- a/docs/user/features/interactions.md
+++ b/docs/user/features/interactions.md
@@ -5,6 +5,7 @@ This page documents direct interactions in the calendar UI.
 ## Mouse and Trackpad
 
 - Click empty date/time slot: create event.
+- Click a date label above a time-grid column: open or create that day's Obsidian daily note when the Daily Notes core plugin is enabled.
 - Drag event: move event to a new day or time.
 - Resize event edge: change event duration.
 - Right-click event: open context actions.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -11,7 +11,7 @@ Here are some handy **Guides** ([Onboarding and Daily Use](guides/index.md), [Co
 |---|---|---|
 | Connect a calendar now | [Calendars](./calendars/index.md) | [Google Calendar](./calendars/gcal.md), [CalDAV](./calendars/caldav.md), [ICS](./calendars/ics.md) |
 | Create, edit, and organize events | [Events](./events/index.md) | [Event Management](./events/manage.md), [Recurring Events](./events/recurring.md), [Category Coloring](./events/categories.md) |
-| Link notes to calendar events | [Event Linked Notes](./features/event-linked-notes.md) | [Template Engine](./features/event-linked-notes.md#2-linked-note-template), [Settings -> Calendars](./settings/sources.md) |
+| Link notes to calendar events | [Event Linked Notes](./features/event-linked-notes.md) | [Template Engine](./features/event-linked-notes.md#3-linked-note-template), [Settings -> Calendars](./settings/sources.md) |
 | Learn commands and interactions quickly | [Commands and Shortcuts](guides/commands-and-shortcuts.md) | [Interactions and Gestures](features/interactions.md), [Reminders and Notifications](features/reminders.md) |
 | Manage reminders & daemon sync | [FCR Reminder Companion](./features/fcr-reminder.md) | [Unified Reminders](./features/reminders.md), [Reminders Settings](./settings/reminders.md) |
 | Filter backlog with global query | [Tasks Integration](./calendars/tasks-plugin-integration.md) | [Supported Global Query Syntax](./calendars/tasks-plugin-integration.md#supported-global-query-syntax) |

--- a/docs/user/settings/sources.md
+++ b/docs/user/settings/sources.md
@@ -42,6 +42,9 @@ Access these settings in **Full Calendar Settings → Calendar Sources**.
 ## Global Source Settings
 
 *   **Default Calendar**: Choose which calendar is selected by default when creating a new event via the UI or [FCR Command](../features/nlp.md).
+*   **Linked Note Link Strategy**:
+    * `Name-based`: Reuse or create the exact sanitized event-title file in the configured linked-notes folder. Existing matching files keep their body and unrelated properties; no collision suffix is added.
+    * `Deadline-based`: Keep separate notes for dated recurring occurrences, using occurrence identity and collision-safe filenames.
 *   **Revalidate Remote Calendars**: Manually trigger a refresh of all external feeds.
 *   **Reset Event Cache**: A deep reload that forces the plugin to re-read all data from all sources. See [Data Integrity](../reference/data_integrity.md).
 

--- a/src/features/daily-notes/openDailyNote.test.ts
+++ b/src/features/daily-notes/openDailyNote.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TFile } from 'obsidian';
+import {
+  appHasDailyNotesPluginLoaded,
+  createDailyNote,
+  getAllDailyNotes,
+  getDailyNote
+} from 'obsidian-daily-notes-interface';
+import { openDailyNoteForDate } from './openDailyNote';
+
+jest.mock('obsidian', () => {
+  const obsidianMock: typeof import('obsidian') = jest.requireActual('../../../__mocks__/obsidian');
+  return {
+    ...obsidianMock,
+    moment: (date: Date) => ({ toDate: () => date })
+  };
+});
+
+jest.mock('obsidian-daily-notes-interface', () => ({
+  appHasDailyNotesPluginLoaded: jest.fn(),
+  createDailyNote: jest.fn(),
+  getAllDailyNotes: jest.fn(),
+  getDailyNote: jest.fn()
+}));
+
+const hasDailyNotes = appHasDailyNotesPluginLoaded as jest.MockedFunction<
+  typeof appHasDailyNotesPluginLoaded
+>;
+const createDailyNoteMock = createDailyNote as jest.MockedFunction<typeof createDailyNote>;
+const getAllDailyNotesMock = getAllDailyNotes as jest.MockedFunction<typeof getAllDailyNotes>;
+const getDailyNoteMock = getDailyNote as jest.MockedFunction<typeof getDailyNote>;
+
+describe('openDailyNoteForDate', () => {
+  const openFile = jest.fn();
+  const app = {
+    workspace: {
+      getLeaf: jest.fn().mockReturnValue({ openFile })
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hasDailyNotes.mockReturnValue(true);
+    getAllDailyNotesMock.mockReturnValue({});
+  });
+
+  it('opens an existing daily note', async () => {
+    const file = new TFile();
+    file.name = '2026-03-21.md';
+    getDailyNoteMock.mockReturnValue(file);
+
+    await openDailyNoteForDate(app as never, new Date(2026, 2, 21));
+
+    expect(createDailyNoteMock).not.toHaveBeenCalled();
+    expect(openFile).toHaveBeenCalledWith(file);
+  });
+
+  it('creates and opens a missing daily note', async () => {
+    const file = new TFile();
+    file.name = '2026-03-21.md';
+    getDailyNoteMock.mockImplementation(() => null!);
+    createDailyNoteMock.mockResolvedValue(file);
+
+    await openDailyNoteForDate(app as never, new Date(2026, 2, 21));
+
+    expect(createDailyNoteMock).toHaveBeenCalled();
+    expect(openFile).toHaveBeenCalledWith(file);
+  });
+
+  it('does nothing when Daily Notes is unavailable', async () => {
+    hasDailyNotes.mockReturnValue(false);
+
+    await openDailyNoteForDate(app as never, new Date(2026, 2, 21));
+
+    expect(getDailyNoteMock).not.toHaveBeenCalled();
+    expect(openFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/daily-notes/openDailyNote.ts
+++ b/src/features/daily-notes/openDailyNote.ts
@@ -1,0 +1,22 @@
+import { App, moment as obsidianMoment } from 'obsidian';
+import {
+  appHasDailyNotesPluginLoaded,
+  createDailyNote,
+  getAllDailyNotes,
+  getDailyNote
+} from 'obsidian-daily-notes-interface';
+
+type MomentFactory = typeof import('moment');
+const moment = obsidianMoment as unknown as MomentFactory;
+
+export async function openDailyNoteForDate(app: App, date: Date): Promise<void> {
+  if (!appHasDailyNotesPluginLoaded()) {
+    return;
+  }
+
+  const day = moment(date);
+  const file = getDailyNote(day, getAllDailyNotes()) || (await createDailyNote(day));
+  if (file) {
+    await app.workspace.getLeaf(false).openFile(file);
+  }
+}

--- a/src/features/i18n/locales/de.json
+++ b/src/features/i18n/locales/de.json
@@ -288,6 +288,12 @@
         "label": "Vorlage für verknüpfte Notizen",
         "description": "Definieren Sie die Vorlage, die zum Erstellen neuer verknüpfter Notizen verwendet wird. Unterstützt: {{title}}, {{description}}, {{date}}, {{timeString}}, {{location}}, {{calendarName}}, {{url}}",
         "placeholder": "Geben Sie die Markdown-Vorlage für Notizen ein..."
+      },
+      "linkedNoteLinkStrategy": {
+        "label": "Linked note link strategy",
+        "description": "Choose whether recurring event occurrences share one title-based note or use separate date-specific notes.",
+        "deadline": "Deadline-based (one note per occurrence)",
+        "name": "Name-based (one note per event series)"
       }
     },
     "reminders": {

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -289,6 +289,12 @@
         "description": "Choose the folder path where event linked notes will be created.",
         "vaultRoot": "/ (Vault Root)"
       },
+      "linkedNoteLinkStrategy": {
+        "label": "Linked note link strategy",
+        "description": "Choose whether recurring event occurrences share one title-based note or use separate date-specific notes.",
+        "deadline": "Deadline-based (one note per occurrence)",
+        "name": "Name-based (one note per event series)"
+      },
       "linkedNoteTemplate": {
         "label": "Linked note template",
         "description": "Define the template used for creating new linked notes. Supports: {{title}}, {{description}}, {{date}}, {{timeString}}, {{location}}, {{calendarName}}, {{url}}",

--- a/src/features/i18n/locales/es.json
+++ b/src/features/i18n/locales/es.json
@@ -288,6 +288,12 @@
         "label": "Plantilla de nota vinculada",
         "description": "Defina la plantilla utilizada para crear nuevas notas vinculadas. Compatible con: {{title}}, {{description}}, {{date}}, {{timeString}}, {{location}}, {{calendarName}}, {{url}}",
         "placeholder": "Introduzca la plantilla Markdown de la nota..."
+      },
+      "linkedNoteLinkStrategy": {
+        "label": "Linked note link strategy",
+        "description": "Choose whether recurring event occurrences share one title-based note or use separate date-specific notes.",
+        "deadline": "Deadline-based (one note per occurrence)",
+        "name": "Name-based (one note per event series)"
       }
     },
     "reminders": {

--- a/src/features/i18n/locales/fr.json
+++ b/src/features/i18n/locales/fr.json
@@ -288,6 +288,12 @@
         "label": "Modèle de note liée",
         "description": "Définissez le modèle utilisé pour créer de nouvelles notes liées. Prend en charge : {{title}}, {{description}}, {{date}}, {{timeString}}, {{location}}, {{calendarName}}, {{url}}",
         "placeholder": "Entrez le modèle Markdown de la note..."
+      },
+      "linkedNoteLinkStrategy": {
+        "label": "Linked note link strategy",
+        "description": "Choose whether recurring event occurrences share one title-based note or use separate date-specific notes.",
+        "deadline": "Deadline-based (one note per occurrence)",
+        "name": "Name-based (one note per event series)"
       }
     },
     "reminders": {

--- a/src/features/i18n/locales/it.json
+++ b/src/features/i18n/locales/it.json
@@ -288,6 +288,12 @@
         "label": "Modello per note collegate",
         "description": "Definisci il modello usato per creare nuove note collegate. Supporta: {{title}}, {{description}}, {{date}}, {{timeString}}, {{location}}, {{calendarName}}, {{url}}",
         "placeholder": "Inserisci il modello Markdown della nota..."
+      },
+      "linkedNoteLinkStrategy": {
+        "label": "Linked note link strategy",
+        "description": "Choose whether recurring event occurrences share one title-based note or use separate date-specific notes.",
+        "deadline": "Deadline-based (one note per occurrence)",
+        "name": "Name-based (one note per event series)"
       }
     },
     "reminders": {

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -288,6 +288,12 @@
         "label": "关联笔记模板",
         "description": "定义用于创建新关联笔记的模板。支持：{{title}}, {{description}}, {{date}}, {{timeString}}, {{location}}, {{calendarName}}, {{url}}",
         "placeholder": "输入笔记的 Markdown 模板..."
+      },
+      "linkedNoteLinkStrategy": {
+        "label": "Linked note link strategy",
+        "description": "Choose whether recurring event occurrences share one title-based note or use separate date-specific notes.",
+        "deadline": "Deadline-based (one note per occurrence)",
+        "name": "Name-based (one note per event series)"
       }
     },
     "reminders": {

--- a/src/features/linked-notes/linkedNotes.ts
+++ b/src/features/linked-notes/linkedNotes.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from 'obsidian';
+import { App, TFile, normalizePath } from 'obsidian';
 import { OFCEvent } from '../../types';
 import { PluginState } from '../../core/PluginState';
 import { TemplateEngine } from './TemplateEngine';
@@ -11,13 +11,57 @@ import {
   findUniquePath,
   sanitizeTitleForFilename
 } from '../../providers/utils/noteUtils';
-import { replaceFrontmatter } from '../../providers/fullnote/frontmatter';
+import { modifyFrontmatterString, replaceFrontmatter } from '../../providers/fullnote/frontmatter';
 import FullCalendarPlugin from '../../main';
 
 const linkedNoteCreationPromises = new Map<string, Promise<TFile | null>>();
 
+function linkedNoteIdentityInstanceDate(instanceDate?: string): string | undefined {
+  return PluginState.getSettings().linkedNoteLinkStrategy === 'name' ? undefined : instanceDate;
+}
+
+function isNameBasedLinkedNotes(): boolean {
+  return PluginState.getSettings().linkedNoteLinkStrategy === 'name';
+}
+
+function titleBasedLinkedNotePath(directory: string, event: OFCEvent): string {
+  const baseFilename = sanitizeTitleForFilename(event.title || t('linkedNotes.untitledNote'));
+  return normalizePath(`${directory}/${baseFilename}.md`);
+}
+
+function quotedFrontmatterString(value: string): string {
+  return JSON.stringify(value);
+}
+
+async function linkExistingTitleFile(
+  app: App,
+  event: OFCEvent,
+  calendarId: string,
+  directory: string
+): Promise<TFile | null> {
+  const file = app.vault.getFileByPath(titleBasedLinkedNotePath(directory, event));
+  const eventUid = event.uid || event.id;
+  if (!file || !eventUid) {
+    return file;
+  }
+
+  const contents = await app.vault.read(file);
+  const updatedContents = modifyFrontmatterString(contents, {
+    'fc-event-uid': quotedFrontmatterString(eventUid),
+    'fc-calendar-id': quotedFrontmatterString(calendarId),
+    'fc-event-recurrence-id': null
+  });
+  if (updatedContents !== contents) {
+    await app.vault.modify(file, updatedContents);
+  }
+  return file;
+}
+
 function linkedNoteCreationKey(calendarId: string, event: OFCEvent, instanceDate?: string): string {
-  return `${calendarId}::${event.uid || ''}::${instanceDate || ''}`;
+  if (isNameBasedLinkedNotes()) {
+    return `${calendarId}::name::${sanitizeTitleForFilename(event.title || t('linkedNotes.untitledNote'))}`;
+  }
+  return `${calendarId}::${event.uid || event.id || ''}::${instanceDate || ''}`;
 }
 
 /**
@@ -38,15 +82,24 @@ export async function createLinkedNoteForProvider({
   linkedNoteIndex: LinkedNoteIndex;
   instanceDate?: string;
 }): Promise<TFile | null> {
+  const identityInstanceDate = linkedNoteIdentityInstanceDate(instanceDate);
+  const directory = PluginState.getSettings().linkedNotesDirectory;
+  if (isNameBasedLinkedNotes() && directory) {
+    const titleFile = await linkExistingTitleFile(app, event, calendarId, directory);
+    if (titleFile) {
+      return titleFile;
+    }
+  }
+
   const existingFile = await linkedNoteIndex.getFileForEventAfterHydration(
     event.uid || event.id || '',
-    instanceDate
+    identityInstanceDate
   );
   if (existingFile) {
     return existingFile;
   }
 
-  const creationKey = linkedNoteCreationKey(calendarId, event, instanceDate);
+  const creationKey = linkedNoteCreationKey(calendarId, event, identityInstanceDate);
   const inFlightCreation = linkedNoteCreationPromises.get(creationKey);
   if (inFlightCreation) {
     return inFlightCreation;
@@ -57,7 +110,8 @@ export async function createLinkedNoteForProvider({
     event,
     calendarId,
     calendarName,
-    instanceDate
+    instanceDate,
+    identityInstanceDate
   }).finally(() => {
     linkedNoteCreationPromises.delete(creationKey);
   });
@@ -70,13 +124,15 @@ async function createLinkedNoteFile({
   event,
   calendarId,
   calendarName,
-  instanceDate
+  instanceDate,
+  identityInstanceDate
 }: {
   app: App;
   event: OFCEvent;
   calendarId: string;
   calendarName: string;
   instanceDate?: string;
+  identityInstanceDate?: string;
 }): Promise<TFile | null> {
   const settings = PluginState.getSettings();
   const directory = settings.linkedNotesDirectory;
@@ -92,8 +148,8 @@ async function createLinkedNoteFile({
     'fc-event-uid': event.uid || event.id,
     'fc-calendar-id': calendarId
   };
-  if (instanceDate) {
-    frontmatter['fc-event-recurrence-id'] = instanceDate;
+  if (identityInstanceDate) {
+    frontmatter['fc-event-recurrence-id'] = identityInstanceDate;
   }
 
   const yaml = serializeFrontmatter(frontmatter);
@@ -101,11 +157,13 @@ async function createLinkedNoteFile({
   const fileContent = replaceFrontmatter(bodyContent, yaml);
 
   let baseFilename = sanitizeTitleForFilename(event.title || t('linkedNotes.untitledNote'));
-  if (instanceDate) {
-    baseFilename = `${baseFilename} ${instanceDate}`;
+  if (identityInstanceDate) {
+    baseFilename = `${baseFilename} ${identityInstanceDate}`;
   }
   const appAdapter = new ObsidianIO(app);
-  const uniquePath = findUniquePath(appAdapter, directory, baseFilename);
+  const uniquePath = isNameBasedLinkedNotes()
+    ? titleBasedLinkedNotePath(directory, event)
+    : findUniquePath(appAdapter, directory, baseFilename);
 
   const file = await appAdapter.create(uniquePath, fileContent);
   return file;
@@ -139,10 +197,25 @@ export async function openOrCreateLinkedNote(
   }
 
   // 2. Check if note already exists
+  if (isNameBasedLinkedNotes()) {
+    const titleFile = await linkExistingTitleFile(
+      plugin.app,
+      event,
+      calendarId,
+      settings.linkedNotesDirectory
+    );
+    if (titleFile) {
+      const leaf = plugin.app.workspace.getLeaf(openInNewLeaf);
+      await leaf.openFile(titleFile);
+      return;
+    }
+  }
+
   if (linkedNoteProvider.linkedNoteIndex) {
+    const identityInstanceDate = linkedNoteIdentityInstanceDate(instanceDate);
     const existingFile = await linkedNoteProvider.linkedNoteIndex.getFileForEventAfterHydration(
       event.uid || event.id || '',
-      instanceDate
+      identityInstanceDate
     );
     if (existingFile) {
       const leaf = plugin.app.workspace.getLeaf(openInNewLeaf);

--- a/src/providers/caldav/CalDAVProvider.test.ts
+++ b/src/providers/caldav/CalDAVProvider.test.ts
@@ -886,6 +886,8 @@ END:VCALENDAR
     interface MockCalDAVVault {
       getAbstractFileByPath: jest.Mock;
       create: jest.Mock;
+      read: jest.Mock;
+      modify: jest.Mock;
     }
 
     interface MockCalDAVMetadataCache {
@@ -925,7 +927,17 @@ END:VCALENDAR
           create: jest
             .fn()
             .mockImplementation((path: string, content: string): MockCalDAVCreatedFile => {
-              return { path, content };
+              const file = { path, content };
+              return file;
+            }),
+          read: jest
+            .fn()
+            .mockImplementation((file: MockCalDAVCreatedFile) => Promise.resolve(file.content)),
+          modify: jest
+            .fn()
+            .mockImplementation((file: MockCalDAVCreatedFile, content: string) => {
+              file.content = content;
+              return Promise.resolve();
             })
         },
         metadataCache: {
@@ -969,6 +981,67 @@ END:VCALENDAR
       expect(file).toBeDefined();
       expect(file!.path).toBe('Calendar/Notes/CalDAV Linked Note Event.md');
       expect(file!.content).toContain('My Template: CalDAV Linked Note Event');
+    });
+
+    it('adds proper dates and daily-note links when creating a linked task note', async () => {
+      PluginState.getSettings = jest.fn().mockReturnValue({
+        linkedNotesDirectory: 'Calendar/Notes',
+        linkedNoteTemplate: 'Task body that must remain unchanged'
+      });
+      const task: OFCEvent = {
+        ...mockEvent,
+        completed: false,
+        date: '2026-04-23',
+        endDate: '2026-04-24'
+      };
+
+      const file = (await caldavProvider.createLinkedNote(task)) as MockCalDAVCreatedFile | null;
+
+      expect(file!.content).toContain('scheduled: 2026-04-23');
+      expect(file!.content).toContain('scheduled-link: "[[2026-04-23]]"');
+      expect(file!.content).toContain('due: 2026-04-24');
+      expect(file!.content).toContain('due-link: "[[2026-04-24]]"');
+      expect(file!.content).not.toContain('[["2026-04-23"]]');
+      expect(file!.content.endsWith('Task body that must remain unchanged')).toBe(true);
+    });
+
+    it('updates only managed task date properties when a linked task is rescheduled', async () => {
+      const linkedFile = {
+        path: 'Calendar/Notes/task.md',
+        content:
+          '---\nfc-event-uid: "caldav-uid-999"\ncustom: keep-me\nscheduled: 2026-04-20\nscheduled-link: [[2026-04-20]]\ndue: 2026-04-20\ndue-link: [[2026-04-20]]\n---\nBody must remain unchanged.'
+      };
+      jest.spyOn(caldavProvider.linkedNoteIndex, 'getFileForEventAfterHydration').mockResolvedValue(
+        linkedFile as unknown as import('obsidian').TFile
+      );
+      mockObsidianFetch.mockResolvedValueOnce({
+        status: 204,
+        statusText: 'No Content'
+      } as Response);
+      const oldTask: OFCEvent = {
+        ...mockEvent,
+        completed: false,
+        date: '2026-04-20'
+      };
+      const rescheduledTask: OFCEvent = {
+        ...oldTask,
+        date: '2026-04-23',
+        endDate: '2026-04-24'
+      };
+
+      await caldavProvider.updateEvent(
+        { persistentId: 'caldav-uid-999.ics' },
+        oldTask,
+        rescheduledTask
+      );
+
+      expect(linkedFile.content).toContain('custom: keep-me');
+      expect(linkedFile.content).toContain('scheduled: 2026-04-23');
+      expect(linkedFile.content).toContain('scheduled-link: "[[2026-04-23]]"');
+      expect(linkedFile.content).toContain('due: 2026-04-24');
+      expect(linkedFile.content).toContain('due-link: "[[2026-04-24]]"');
+      expect(linkedFile.content).not.toContain('[["2026-04-23"]]');
+      expect(linkedFile.content.endsWith('Body must remain unchanged.')).toBe(true);
     });
   });
 });

--- a/src/providers/caldav/CalDAVProvider.ts
+++ b/src/providers/caldav/CalDAVProvider.ts
@@ -26,6 +26,8 @@ import {
 import { parseTimezoneAwareString } from '../../features/timezone/Timezone';
 import { PluginState } from '../../core/PluginState';
 import { DateTime } from 'luxon';
+import { isTask } from '../../types/tasks';
+import { modifyFrontmatterString } from '../fullnote/frontmatter';
 
 import { fetchCalendarInfo } from './helper_caldav';
 
@@ -401,6 +403,33 @@ function taskToLinkedNoteEvent(task: CalDAVTaskInboxItem): OFCEvent {
     description: task.description,
     location: task.location,
     url: task.url
+  };
+}
+
+const LINKED_TASK_DATE_PROPERTIES = ['scheduled', 'scheduled-link', 'due', 'due-link'] as const;
+
+function linkedTaskDailyNoteLink(date: string | null): string | null {
+  // YAML must quote wiki-links or Obsidian parses [[date]] as a nested array.
+  return date ? `"[[${date}]]"` : null;
+}
+
+function linkedTaskDateProperties(event: OFCEvent): Record<string, unknown> {
+  let scheduled: string | null = null;
+  let due: string | null = null;
+
+  if (event.type === 'single') {
+    scheduled = event.date || null;
+    due = event.endDate || scheduled;
+  } else if (event.type === 'rrule') {
+    scheduled = event.startDate || null;
+    due = event.endDate || scheduled;
+  }
+
+  return {
+    scheduled,
+    'scheduled-link': linkedTaskDailyNoteLink(scheduled),
+    due,
+    'due-link': linkedTaskDailyNoteLink(due)
   };
 }
 
@@ -805,7 +834,7 @@ export class CalDAVProvider
   }
 
   async createLinkedNote(event: OFCEvent, instanceDate?: string): Promise<TFile | null> {
-    return createLinkedNoteForProvider({
+    const file = await createLinkedNoteForProvider({
       app: this.plugin.app,
       event,
       calendarId: this.source.id,
@@ -813,6 +842,10 @@ export class CalDAVProvider
       linkedNoteIndex: this.linkedNoteIndex,
       instanceDate
     });
+    if (file && isTask(event)) {
+      await this.updateLinkedTaskNoteDates(event, file);
+    }
+    return file;
   }
 
   async createLinkedNoteForTask(task: CalDAVTaskInboxItem): Promise<TFile | null> {
@@ -854,6 +887,34 @@ export class CalDAVProvider
       return { persistentId: event.caldavHref, ...context };
     }
     return event.uid ? { persistentId: event.uid, ...context } : null;
+  }
+
+  private async updateLinkedTaskNoteDates(event: OFCEvent, knownFile?: TFile): Promise<void> {
+    const uid = event.uid || event.id;
+    if (!uid) return;
+
+    const file =
+      knownFile ||
+      (await this.linkedNoteIndex.getFileForEventAfterHydration(uid, event.recurrenceId));
+    if (!file) return;
+
+    const contents = await this.plugin.app.vault.read(file);
+    const updatedContents = modifyFrontmatterString(contents, linkedTaskDateProperties(event));
+    if (updatedContents !== contents) {
+      await this.plugin.app.vault.modify(file, updatedContents);
+    }
+  }
+
+  private async clearLinkedTaskNoteDates(uid: string): Promise<void> {
+    const file = await this.linkedNoteIndex.getFileForEventAfterHydration(uid);
+    if (!file) return;
+
+    const contents = await this.plugin.app.vault.read(file);
+    const removals = Object.fromEntries(LINKED_TASK_DATE_PROPERTIES.map(property => [property, null]));
+    const updatedContents = modifyFrontmatterString(contents, removals);
+    if (updatedContents !== contents) {
+      await this.plugin.app.vault.modify(file, updatedContents);
+    }
   }
 
   computeSyncKey(event: OFCEvent): string {
@@ -922,6 +983,10 @@ export class CalDAVProvider
       if (parseFailures > 0) {
         console.warn(`[CalDAVProvider] Skipped ${parseFailures} malformed ICS payload(s).`);
       }
+
+      await Promise.all(
+        parsedEvents.filter(isTask).map(event => this.updateLinkedTaskNoteDates(event))
+      );
 
       return parsedEvents.map(ev => {
         const linkedFile = this.linkedNoteIndex.getFileForEvent(ev.uid || '');
@@ -1166,6 +1231,9 @@ export class CalDAVProvider
     const url = this.resolveEventObjectUrl(href);
     if (oldEvent.recurrenceId && oldEvent.uid) {
       await this.updateRecurrenceOverride(url, oldEvent, newEvent);
+      if (isTask(newEvent)) {
+        await this.updateLinkedTaskNoteDates(newEvent);
+      }
       return null;
     }
 
@@ -1183,6 +1251,10 @@ export class CalDAVProvider
       },
       body: icsContent
     });
+
+    if (isTask(newEvent)) {
+      await this.updateLinkedTaskNoteDates(newEvent);
+    }
 
     return null;
   }
@@ -1283,6 +1355,23 @@ export class CalDAVProvider
 
       this.undatedTaskCache = this.undatedTaskCache.filter(task => task.uid !== taskUid);
       this.hasLoadedUndatedTasks = true;
+      const scheduledDate = DateTime.fromJSDate(date).toISODate() || '';
+      const scheduledTask: OFCEvent = {
+        type: 'single',
+        uid: taskUid,
+        title: getTextProperty(todo, 'summary') || 'Untitled task',
+        date: scheduledDate,
+        endDate: null,
+        completed: isCompletedTodo(todo) ? DateTime.now().toISO() : false,
+        ...(allDay
+          ? { allDay: true }
+          : {
+              allDay: false,
+              startTime: DateTime.fromJSDate(date).toFormat('HH:mm'),
+              endTime: DateTime.fromJSDate(date).plus({ hours: 1 }).toFormat('HH:mm')
+            })
+      };
+      await this.updateLinkedTaskNoteDates(scheduledTask);
       return;
     }
 
@@ -1333,6 +1422,7 @@ export class CalDAVProvider
         ...unscheduledTasks
       ];
       this.hasLoadedUndatedTasks = true;
+      await this.clearLinkedTaskNoteDates(taskUid);
       return;
     }
 

--- a/src/providers/fullnote/frontmatter.ts
+++ b/src/providers/fullnote/frontmatter.ts
@@ -88,7 +88,10 @@ export function newFrontmatter(fields: Partial<OFCEvent>): string {
     .join('\n');
 }
 
-export function modifyFrontmatterString(page: string, modifications: Partial<OFCEvent>): string {
+export function modifyFrontmatterString(
+  page: string,
+  modifications: Record<string, unknown>
+): string {
   const frontmatter = extractFrontmatter(page);
   const sourceLines = frontmatter ? frontmatter.split('\n') : [];
 

--- a/src/providers/ics/ICSProvider.test.ts
+++ b/src/providers/ics/ICSProvider.test.ts
@@ -5,13 +5,17 @@ import { ICSProvider } from './ICSProvider';
 import FullCalendarPlugin from '../../main';
 import { PluginState } from '../../core/PluginState';
 import { OFCEvent } from '../../types';
+import { TFile } from 'obsidian';
 
 jest.mock('../../core/PluginState');
 jest.mock('../../utils/showNotice');
 
 interface MockVault {
   getAbstractFileByPath: jest.Mock;
+  getFileByPath: jest.Mock;
   create: jest.Mock;
+  read: jest.Mock;
+  modify: jest.Mock;
 }
 
 interface MockMetadataCache {
@@ -56,9 +60,12 @@ describe('ICSProvider createLinkedNote', () => {
     mockApp = {
       vault: {
         getAbstractFileByPath: jest.fn().mockReturnValue(null),
+        getFileByPath: jest.fn().mockReturnValue(null),
         create: jest.fn().mockImplementation((path: string, content: string): MockCreatedFile => {
           return { path, content };
-        })
+        }),
+        read: jest.fn(),
+        modify: jest.fn()
       },
       metadataCache: {
         getFileCache: jest.fn(),
@@ -100,5 +107,93 @@ describe('ICSProvider createLinkedNote', () => {
     expect(file).toBeDefined();
     expect(file!.path).toBe('Calendar/Notes/ICS Linked Note Event.md');
     expect(file!.content).toContain('ICS Custom: ICS Linked Note Event');
+  });
+
+  it('creates one shared title-based note for recurring occurrences in name mode', async () => {
+    PluginState.getSettings = jest.fn().mockReturnValue({
+      linkedNotesDirectory: 'Calendar/Notes',
+      linkedNoteTemplate: '',
+      linkedNoteLinkStrategy: 'name'
+    });
+    const recurringEvent: OFCEvent = {
+      title: 'Five Day Project',
+      type: 'rrule',
+      startDate: '2026-03-21',
+      endDate: null,
+      rrule: 'FREQ=DAILY;COUNT=5',
+      skipDates: [],
+      allDay: true,
+      isTask: true,
+      uid: 'project-series'
+    };
+    const lookup = jest
+      .spyOn(provider.linkedNoteIndex, 'getFileForEventAfterHydration')
+      .mockResolvedValue(null);
+
+    const file = (await provider.createLinkedNote(
+      recurringEvent,
+      '2026-03-23'
+    )) as MockCreatedFile | null;
+
+    expect(file!.path).toBe('Calendar/Notes/Five Day Project.md');
+    expect(file!.content).not.toContain('fc-event-recurrence-id');
+    expect(lookup).toHaveBeenCalledWith('project-series', undefined);
+  });
+
+  it('keeps separate occurrence notes in deadline mode', async () => {
+    PluginState.getSettings = jest.fn().mockReturnValue({
+      linkedNotesDirectory: 'Calendar/Notes',
+      linkedNoteTemplate: '',
+      linkedNoteLinkStrategy: 'deadline'
+    });
+    const recurringEvent: OFCEvent = {
+      title: 'Five Day Project',
+      type: 'rrule',
+      startDate: '2026-03-21',
+      endDate: null,
+      rrule: 'FREQ=DAILY;COUNT=5',
+      skipDates: [],
+      allDay: true,
+      isTask: true,
+      uid: 'project-series'
+    };
+
+    const file = (await provider.createLinkedNote(
+      recurringEvent,
+      '2026-03-23'
+    )) as MockCreatedFile | null;
+
+    expect(file!.path).toBe('Calendar/Notes/Five Day Project 2026-03-23.md');
+    expect(file!.content).toContain('fc-event-recurrence-id: "2026-03-23"');
+  });
+
+  it('reuses an existing exact-title file in name mode without adding a suffix', async () => {
+    PluginState.getSettings = jest.fn().mockReturnValue({
+      linkedNotesDirectory: 'Calendar/Notes',
+      linkedNoteTemplate: '',
+      linkedNoteLinkStrategy: 'name'
+    });
+    const existingFile = new TFile();
+    existingFile.name = 'ICS Linked Note Event.md';
+    const existingContents = '---\ncustom: keep-me\n---\nExisting project notes.';
+    let updatedContents = existingContents;
+    mockApp.vault.getFileByPath.mockReturnValue(existingFile);
+    mockApp.vault.read.mockResolvedValue(existingContents);
+    mockApp.vault.modify.mockImplementation((_file: TFile, contents: string) => {
+      updatedContents = contents;
+      return Promise.resolve();
+    });
+
+    const file = await provider.createLinkedNote(mockEvent);
+
+    expect(file).toBe(existingFile);
+    expect(mockApp.vault.getFileByPath).toHaveBeenCalledWith(
+      'Calendar/Notes/ICS Linked Note Event.md'
+    );
+    expect(mockApp.vault.create).not.toHaveBeenCalled();
+    expect(updatedContents).toContain('custom: keep-me');
+    expect(updatedContents).toContain('fc-event-uid: "ics-uid-123"');
+    expect(updatedContents).toContain('fc-calendar-id: "ics_1"');
+    expect(updatedContents.endsWith('Existing project notes.')).toBe(true);
   });
 });

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -38,6 +38,7 @@ export interface ActivityWatchSettings {
 }
 
 export type TasksDateTarget = 'scheduledDate' | 'startDate' | 'dueDate';
+export type LinkedNoteLinkStrategy = 'name' | 'deadline';
 
 export type TasksBacklogDateTarget = TasksDateTarget;
 export type TasksDisplayFormat = 'standard' | 'dayPlanner';
@@ -195,6 +196,7 @@ export interface FullCalendarSettings {
   currentVersion: string | null;
   linkedNotesDirectory: string;
   linkedNoteTemplate: string;
+  linkedNoteLinkStrategy: LinkedNoteLinkStrategy;
   taskBacklogLastProviderId: string;
   caldavTaskInboxLastCalendarId: string;
   weatherCity: string;
@@ -288,6 +290,7 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
   defaultReminderMinutes: 10,
   currentVersion: null,
   linkedNotesDirectory: '',
+  linkedNoteLinkStrategy: 'deadline',
   taskBacklogLastProviderId: '',
   caldavTaskInboxLastCalendarId: '',
   weatherCity: '',

--- a/src/ui/settings/sections/calendars/calendar.ts
+++ b/src/ui/settings/sections/calendars/calendar.ts
@@ -37,6 +37,7 @@ import {
   formatTempRange
 } from '../../../../features/weather/Weather';
 import { WeatherDetailModal } from '../../../../features/weather/WeatherDetailModal';
+import { openDailyNoteForDate } from '../../../../features/daily-notes/openDailyNote';
 
 interface ExtraRenderProps {
   eventClick?: (info: EventClickArg) => void;
@@ -655,6 +656,21 @@ export async function renderCalendar(
     });
   };
 
+  const bindDailyNoteHeaderClick = (el: HTMLElement, date: Date): void => {
+    const dateLabel = el.querySelector<HTMLElement>('.fc-col-header-cell-cushion');
+    if (!dateLabel || dateLabel.dataset.ofcDailyNoteBound === 'true') {
+      return;
+    }
+
+    dateLabel.dataset.ofcDailyNoteBound = 'true';
+    dateLabel.setCssProps({ cursor: 'pointer' });
+    dateLabel.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+      void openDailyNoteForDate(PluginState.getPlugin().app, date);
+    });
+  };
+
   const handleViewChangeAndFetchWeather = async (view: { activeStart: Date; activeEnd: Date }) => {
     // DO NOT clear pendingHeaders, pendingCells, or activeForecast at the start of this function!
     // FullCalendar mounts headers and cells BEFORE datesSet triggers.
@@ -718,6 +734,9 @@ export async function renderCalendar(
 
   const cal = new CalendarCtor(containerEl, {
     dayHeaderDidMount: arg => {
+      if (arg.view.type.startsWith('timeGrid')) {
+        bindDailyNoteHeaderClick(arg.el, arg.date);
+      }
       const settings = PluginState.getSettings();
       if (settings.weatherHide) {
         return;

--- a/src/ui/settings/sections/renderCalendars.ts
+++ b/src/ui/settings/sections/renderCalendars.ts
@@ -56,6 +56,20 @@ export function renderCalendarManagement(
     });
 
   new Setting(containerEl)
+    .setName(t('settings.general.linkedNoteLinkStrategy.label'))
+    .setDesc(t('settings.general.linkedNoteLinkStrategy.description'))
+    .addDropdown(dropdown => {
+      dropdown
+        .addOption('deadline', t('settings.general.linkedNoteLinkStrategy.deadline'))
+        .addOption('name', t('settings.general.linkedNoteLinkStrategy.name'))
+        .setValue(PluginState.getSettings().linkedNoteLinkStrategy || 'deadline')
+        .onChange(async value => {
+          PluginState.getSettings().linkedNoteLinkStrategy = value as 'name' | 'deadline';
+          await PluginState.saveSettings();
+        });
+    });
+
+  new Setting(containerEl)
     .setName(t('settings.general.linkedNoteTemplate.label'))
     .setDesc(t('settings.general.linkedNoteTemplate.description'))
     .addTextArea(text => {

--- a/src/ui/settings/utilsSettings.ts
+++ b/src/ui/settings/utilsSettings.ts
@@ -98,6 +98,8 @@ export function migrateAndSanitizeSettings(settings: unknown): {
       raw.milestoneNotifierDuration ?? DEFAULT_SETTINGS.milestoneNotifierDuration,
     currentVersion: raw.currentVersion ?? null,
     linkedNotesDirectory: raw.linkedNotesDirectory ?? DEFAULT_SETTINGS.linkedNotesDirectory,
+    linkedNoteLinkStrategy:
+      raw.linkedNoteLinkStrategy ?? DEFAULT_SETTINGS.linkedNoteLinkStrategy,
     taskBacklogLastProviderId:
       raw.taskBacklogLastProviderId ??
       raw.caldavTaskInboxLastCalendarId ??


### PR DESCRIPTION
Add managed CalDAV task date properties and keep them synchronized across note creation, remote sync, rescheduling, scheduling, and unscheduling without modifying unrelated note content.

Introduce configurable name-based and deadline-based linked-note strategies. Name-based linking now reuses or creates the exact sanitized title file without collision suffixes, attaches stable identity properties, and retains UID fallback after notes are renamed or moved.

Make time-grid date headers open or create the corresponding Obsidian daily note, documented the new behavior and strategy tradeoffs, synchronize locale keys, and expand provider and utility test coverage.

Validated with TypeScript compilation, ESLint, i18n checks, git diff checks, and the full Jest suite (61 suites, 671 tests passed).