### PR TITLE
Fix task rescheduling metadata and CalDAV backlog reloads

### DIFF
--- a/docs/user/calendars/tasknotes.md
+++ b/docs/user/calendars/tasknotes.md
@@ -18,6 +18,32 @@ The TaskNotes provider connects to the TaskNotes internal cache. It interprets a
 *   **Custom UI**: Clicking a TaskNotes event opens the native TaskNotes edit modal for advanced task refinement.
 *   **Status Awareness**: The provider respects completion statuses. Completed tasks are visually distinguished on the calendar.
 
+## Rescheduling and TaskNotes Properties
+
+Dragging or resizing a TaskNotes event in Full Calendar updates the original task note in your vault.
+
+Full Calendar always writes these TaskNotes scheduling properties:
+
+```yaml
+scheduled: 2026-04-23
+scheduled-link: "[[2026-04-23]]"
+```
+
+The `scheduled` value is the date, or date and time, that TaskNotes uses to place the task on the calendar. The `scheduled-link` value is the matching daily-note link.
+
+Full Calendar may also update these companion properties when they still point at the old scheduled date:
+
+```yaml
+due: 2026-04-23
+due-link: "[[2026-04-23]]"
+deadline: 2026-04-23
+deadline-link: "[[2026-04-23]]"
+```
+
+`due` is the task's due date and `deadline` is the task's deadline date. The `-link` properties are daily-note links for those dates. If a `due` or `deadline` value is different from the previous scheduled date, Full Calendar leaves it unchanged so intentional due/deadline metadata is preserved.
+
+These properties are part of TaskNotes task metadata. See the [TaskNotes documentation](https://github.com/YouFoundJK/obsidian-tasknotes) for the current TaskNotes field definitions.
+
 ## NLP Endpoint Modes
 
 When an [NLP create command](../features/nlp.md) targets a TaskNotes calendar, Full Calendar delegates creation to TaskNotes UI.

--- a/src/providers/caldav/CalDAVProvider.test.ts
+++ b/src/providers/caldav/CalDAVProvider.test.ts
@@ -238,20 +238,6 @@ END:VCALENDAR
       </d:multistatus>
     `;
 
-    const mockInboxPropfind = `
-      <d:multistatus xmlns:d="DAV:">
-        <d:response>
-          <d:href>/caldav/user/calendar/events/tasks.ics</d:href>
-          <d:propstat>
-            <d:prop>
-              <d:getetag>"task-etag"</d:getetag>
-            </d:prop>
-            <d:status>HTTP/1.1 200 OK</d:status>
-          </d:propstat>
-        </d:response>
-      </d:multistatus>
-    `;
-
     const mockIcs = `BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VTODO
@@ -269,6 +255,21 @@ STATUS:NEEDS-ACTION
 END:VTODO
 END:VCALENDAR`;
 
+    const mockInboxReport = `
+      <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/tasks.ics</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:getetag>"task-etag"</d:getetag>
+              <c:calendar-data><![CDATA[${mockIcs}]]></c:calendar-data>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
     mockObsidianFetch
       .mockResolvedValueOnce({
         status: 207,
@@ -276,11 +277,7 @@ END:VCALENDAR`;
       } as Response)
       .mockResolvedValueOnce({
         status: 207,
-        text: () => Promise.resolve(mockInboxPropfind)
-      } as Response)
-      .mockResolvedValueOnce({
-        status: 200,
-        text: () => Promise.resolve(mockIcs)
+        text: () => Promise.resolve(mockInboxReport)
       } as Response);
 
     const tasks = await provider.refreshUndatedTasks();
@@ -295,6 +292,65 @@ END:VCALENDAR`;
       completed: false,
       etag: '"task-etag"'
     });
+  });
+
+  it('loads CalDAV backlog items from remote on a cold provider start', async () => {
+    const mockPropfindResponse = `
+      <d:multistatus xmlns:d="DAV:">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:resourcetype>
+                <d:collection/>
+                <c:calendar xmlns:c="urn:ietf:params:xml:ns:caldav"/>
+              </d:resourcetype>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    const mockIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-1
+SUMMARY:Backlog After Reload
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`;
+    const mockInboxReport = `
+      <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/task-1.ics</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:getetag>"task-etag"</d:getetag>
+              <c:calendar-data><![CDATA[${mockIcs}]]></c:calendar-data>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    mockObsidianFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(mockPropfindResponse)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(mockInboxReport)
+      } as Response);
+
+    await expect(provider.getTaskBacklogItems()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'caldav::caldav_1::task-1',
+        title: 'Backlog After Reload'
+      })
+    ]);
   });
 
   it('creates an unscheduled CalDAV task for the task inbox', async () => {
@@ -506,6 +562,81 @@ END:VCALENDAR`;
     await expect(provider.getUndatedTasks()).resolves.toEqual([
       expect.objectContaining({ uid: 'task-1', title: 'Schedule Me' })
     ]);
+  });
+
+  it('reschedules a CalDAV task after it was returned to the backlog even when remote dates are stale', async () => {
+    const mockInboxPropfind = `
+      <d:multistatus xmlns:d="DAV:">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/task-1.ics</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:getetag>"task-etag"</d:getetag>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+    const mockCollectionPropfind = `
+      <d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+        <d:response>
+          <d:href>/caldav/user/calendar/events/</d:href>
+          <d:propstat>
+            <d:prop>
+              <d:resourcetype>
+                <d:collection/>
+                <c:calendar/>
+              </d:resourcetype>
+            </d:prop>
+            <d:status>HTTP/1.1 200 OK</d:status>
+          </d:propstat>
+        </d:response>
+      </d:multistatus>
+    `;
+
+    const scheduledIcs = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:task-1
+SUMMARY:Schedule Me
+STATUS:NEEDS-ACTION
+DTSTART;TZID=Europe/Amsterdam:20260615T143000
+DUE;TZID=Europe/Amsterdam:20260615T153000
+END:VTODO
+END:VCALENDAR`;
+
+    mockObsidianFetch.mockImplementation((_url, options) => {
+      if (options?.method === 'PROPFIND') {
+        const headers = options.headers as Record<string, string> | undefined;
+        return Promise.resolve({
+          status: 207,
+          text: () =>
+            Promise.resolve(headers?.Depth === '0' ? mockCollectionPropfind : mockInboxPropfind)
+        } as Response);
+      }
+      if (options?.method === 'GET') {
+        return Promise.resolve({
+          status: 200,
+          text: () => Promise.resolve(scheduledIcs)
+        } as Response);
+      }
+      return Promise.resolve({
+        status: 204,
+        statusText: 'No Content'
+      } as Response);
+    });
+
+    await provider.unscheduleTask('task-1');
+    await provider.scheduleTask('caldav::caldav_1::task-1', new Date(2026, 5, 16));
+
+    const putCalls = mockObsidianFetch.mock.calls.filter(([, options]) => options?.method === 'PUT');
+    const body = putCalls[1][1]?.body;
+    if (typeof body !== 'string') {
+      throw new Error('Expected CalDAV reschedule PUT body to be a string');
+    }
+    expect(body).toContain('DUE;VALUE=DATE:20260616');
+    expect(body).not.toContain('DUE;TZID=Europe/Amsterdam:20260615T153000');
   });
 
   it('deletes an unscheduled CalDAV backlog task', async () => {

--- a/src/providers/caldav/CalDAVProvider.ts
+++ b/src/providers/caldav/CalDAVProvider.ts
@@ -682,6 +682,93 @@ async function fetchCalendarObjectsForComponent(
   return { icsList, fellBack: false };
 }
 
+async function fetchAllVTodoObjects(
+  collectionUrl: string,
+  authHeader?: string
+): Promise<CalendarObjectData[]> {
+  const reportBody = `<?xml version="1.0" encoding="utf-8"?>
+<c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:prop>
+    <d:getetag/>
+    <c:calendar-data/>
+  </d:prop>
+  <c:filter>
+    <c:comp-filter name="VCALENDAR">
+      <c:comp-filter name="VTODO"/>
+    </c:comp-filter>
+  </c:filter>
+</c:calendar-query>`;
+
+  const reportHeaders: Record<string, string> = {
+    Depth: '1',
+    'Content-Type': 'application/xml; charset=utf-8',
+    Accept: '*/*'
+  };
+  if (authHeader) {
+    reportHeaders['Authorization'] = authHeader;
+  }
+
+  const reportRes = await obsidianFetch(canonCollection(collectionUrl), {
+    method: 'REPORT',
+    headers: reportHeaders,
+    body: reportBody
+  });
+  const xml = await reportRes.text();
+
+  if (reportRes.status < 200 || reportRes.status >= 300) {
+    if (shouldUseCompatibilityFetch(reportRes.status)) {
+      console.warn(
+        `[CalDAVProvider] REPORT for all VTODO ${reportRes.status}; attempting compatibility fallback.`
+      );
+      return fetchCalendarObjectsViaPropfindFallback(collectionUrl, authHeader);
+    }
+    console.error(
+      `[CalDAVProvider] VTODO REPORT request failed`,
+      reportRes.status,
+      xml.slice(0, 800)
+    );
+    throw new Error(`REPORT ${reportRes.status}`);
+  }
+
+  assertNonEmptyText(xml, 'CalDAV VTODO REPORT returned an empty body.');
+  const doc = ensureXmlDocument(xml, 'CalDAV VTODO REPORT');
+  const icsList: CalendarObjectData[] = [];
+  const responses = Array.from(doc.getElementsByTagNameNS('*', 'response'));
+
+  for (const response of responses) {
+    const prop = getSuccessfulPropNode(response);
+    if (!prop) continue;
+
+    const calendarData =
+      prop.getElementsByTagNameNS('urn:ietf:params:xml:ns:caldav', 'calendar-data')[0] ||
+      prop.getElementsByTagNameNS('*', 'calendar-data')[0];
+    if (!calendarData) continue;
+
+    const hrefNode =
+      response.getElementsByTagNameNS('DAV:', 'href')[0] ||
+      response.getElementsByTagNameNS('*', 'href')[0];
+    const href = hrefNode?.textContent?.trim() || '';
+    const etag =
+      prop.getElementsByTagNameNS('DAV:', 'getetag')[0]?.textContent ||
+      prop.getElementsByTagNameNS('*', 'getetag')[0]?.textContent ||
+      undefined;
+
+    icsList.push({
+      href,
+      ics: assertIcsPayload(
+        assertNonEmptyText(
+          calendarData.textContent || '',
+          'CalDAV VTODO REPORT returned empty calendar-data payload.'
+        ),
+        'CalDAV VTODO REPORT'
+      ),
+      etag: etag || undefined
+    });
+  }
+
+  return icsList;
+}
+
 // --- Direct REPORT + GET implementation (standards-compliant) ---
 async function fetchCalendarObjects(
   collectionUrl: string,
@@ -1017,7 +1104,7 @@ export class CalDAVProvider
     }
 
     const authHeader = createBasicAuthHeader(this.source.username, this.source.password);
-    const objects = await fetchCalendarObjectsViaPropfindFallback(this.source.homeUrl, authHeader);
+    const objects = await fetchAllVTodoObjects(this.source.homeUrl, authHeader);
     return objects.flatMap(object =>
       parseUnscheduledTasksFromObject(object, this.source.id, this.source.name)
     );
@@ -1047,10 +1134,8 @@ export class CalDAVProvider
   }
 
   async getUndatedTasks(): Promise<CalDAVTaskInboxItem[]> {
-    if (!this.hasLoadedUndatedTasks && !this.undatedTaskLoadPromise) {
-      void this.refreshUndatedTasks()
-        .then(() => PluginState.getProviderRegistry().refreshCalDAVTaskInboxViews())
-        .catch(err => console.warn('[CalDAVProvider] Failed to refresh task inbox.', err));
+    if (!this.hasLoadedUndatedTasks) {
+      return this.refreshUndatedTasks();
     }
 
     return Promise.resolve([...this.undatedTaskCache]);
@@ -1325,7 +1410,7 @@ export class CalDAVProvider
     for (const object of objects) {
       const vcalendar = parseVCalendar(object.ics);
       const todo = findTodoByUid(vcalendar, taskUid);
-      if (!todo || !isUnscheduledTodo(todo)) {
+      if (!todo) {
         continue;
       }
 
@@ -1377,7 +1462,7 @@ export class CalDAVProvider
       return;
     }
 
-    throw new Error(`CalDAV task ${taskUid} was not found or is already scheduled.`);
+    throw new Error(`CalDAV task ${taskUid} was not found.`);
   }
 
   async unscheduleTask(taskId: string): Promise<void> {

--- a/src/providers/tasknotes/TaskNotesProvider.test.ts
+++ b/src/providers/tasknotes/TaskNotesProvider.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TaskNotesProvider } from './TaskNotesProvider';
+import { TaskNotesProviderConfig } from './typesTaskNotes';
+import FullCalendarPlugin from '../../main';
+import { OFCEvent } from '../../types';
+
+describe('TaskNotesProvider', () => {
+  const config: TaskNotesProviderConfig = {
+    id: 'tasknotes_1',
+    name: 'TaskNotes'
+  };
+
+  it('updates managed date link properties in the task file when rescheduling', async () => {
+    const file = { path: 'Tasks/Task.md' };
+    let fileContents =
+      '---\n' +
+      'custom: keep-me\n' +
+      'scheduled: 2026-04-20\n' +
+      'scheduled-link: [[2026-04-20]]\n' +
+      'due: 2026-04-20\n' +
+      'due-link: [[2026-04-20]]\n' +
+      'deadline: 2026-04-20\n' +
+      'deadline-link: [[2026-04-20]]\n' +
+      '---\n' +
+      'Body must remain unchanged.';
+    const task = {
+      path: 'Tasks/Task.md',
+      title: 'Task',
+      status: 'TODO',
+      scheduled: '2026-04-20',
+      timeEstimate: 60
+    };
+    const updateProperty = jest.fn(
+      async (
+        inputTask: typeof task,
+        property: 'scheduled' | 'timeEstimate',
+        value: unknown
+      ): Promise<typeof task> => ({ ...inputTask, [property]: value })
+    );
+    const taskNotes = {
+      cacheManager: {
+        getAllTasks: jest.fn(),
+        getTaskInfo: jest.fn().mockResolvedValue(task),
+        on: jest.fn()
+      },
+      taskService: {
+        updateProperty
+      }
+    };
+    const plugin = {
+      app: {
+        plugins: { plugins: { tasknotes: taskNotes } },
+        vault: {
+          getFileByPath: jest.fn().mockReturnValue(file),
+          read: jest.fn().mockImplementation(() => Promise.resolve(fileContents)),
+          modify: jest.fn().mockImplementation((_file: typeof file, updatedContents: string) => {
+            fileContents = updatedContents;
+            return Promise.resolve();
+          })
+        }
+      }
+    } as unknown as FullCalendarPlugin;
+    const provider = new TaskNotesProvider(config, plugin);
+    const oldEvent: OFCEvent = {
+      type: 'single',
+      uid: 'Tasks/Task.md',
+      title: 'Task',
+      allDay: true,
+      date: '2026-04-20',
+      endDate: null,
+      completed: false
+    };
+    const newEvent: OFCEvent = {
+      ...oldEvent,
+      date: '2026-04-23'
+    };
+
+    await provider.updateEvent({ persistentId: 'Tasks/Task.md' }, oldEvent, newEvent);
+
+    expect(taskNotes.taskService.updateProperty).toHaveBeenCalledWith(
+      task,
+      'scheduled',
+      '2026-04-23'
+    );
+    expect(fileContents).toContain('custom: keep-me');
+    expect(fileContents).toContain('scheduled: 2026-04-23');
+    expect(fileContents).toContain('scheduled-link: "[[2026-04-23]]"');
+    expect(fileContents).toContain('due: 2026-04-23');
+    expect(fileContents).toContain('due-link: "[[2026-04-23]]"');
+    expect(fileContents).toContain('deadline: 2026-04-23');
+    expect(fileContents).toContain('deadline-link: "[[2026-04-23]]"');
+    expect(fileContents).not.toContain('[["2026-04-23"]]');
+    expect(fileContents.endsWith('Body must remain unchanged.')).toBe(true);
+  });
+});

--- a/src/providers/tasknotes/TaskNotesProvider.test.ts
+++ b/src/providers/tasknotes/TaskNotesProvider.test.ts
@@ -5,6 +5,7 @@ import { TaskNotesProvider } from './TaskNotesProvider';
 import { TaskNotesProviderConfig } from './typesTaskNotes';
 import FullCalendarPlugin from '../../main';
 import { OFCEvent } from '../../types';
+import { modifyFrontmatterString } from '../fullnote/frontmatter';
 
 describe('TaskNotesProvider', () => {
   const config: TaskNotesProviderConfig = {
@@ -35,9 +36,12 @@ describe('TaskNotesProvider', () => {
     const updateProperty = jest.fn(
       async (
         inputTask: typeof task,
-        property: 'scheduled' | 'timeEstimate',
+        property: 'scheduled' | 'due' | 'timeEstimate',
         value: unknown
-      ): Promise<typeof task> => ({ ...inputTask, [property]: value })
+      ): Promise<typeof task> => {
+        fileContents = modifyFrontmatterString(fileContents, { [property]: value });
+        return { ...inputTask, [property]: value };
+      }
     );
     const taskNotes = {
       cacheManager: {
@@ -84,6 +88,11 @@ describe('TaskNotesProvider', () => {
       'scheduled',
       '2026-04-23'
     );
+    expect(taskNotes.taskService.updateProperty).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduled: '2026-04-23' }),
+      'due',
+      '2026-04-23'
+    );
     expect(fileContents).toContain('custom: keep-me');
     expect(fileContents).toContain('scheduled: 2026-04-23');
     expect(fileContents).toContain('scheduled-link: "[[2026-04-23]]"');
@@ -93,5 +102,85 @@ describe('TaskNotesProvider', () => {
     expect(fileContents).toContain('deadline-link: "[[2026-04-23]]"');
     expect(fileContents).not.toContain('[["2026-04-23"]]');
     expect(fileContents.endsWith('Body must remain unchanged.')).toBe(true);
+  });
+
+  it('preserves due and deadline properties that do not match the previous scheduled date', async () => {
+    const file = { path: 'Tasks/Task.md' };
+    let fileContents =
+      '---\n' +
+      'scheduled: 2026-04-20\n' +
+      'scheduled-link: [[2026-04-20]]\n' +
+      'due: 2026-04-25\n' +
+      'due-link: [[2026-04-25]]\n' +
+      'deadline: 2026-04-30\n' +
+      'deadline-link: [[2026-04-30]]\n' +
+      '---\n';
+    const task = {
+      path: 'Tasks/Task.md',
+      title: 'Task',
+      status: 'TODO',
+      scheduled: '2026-04-20',
+      timeEstimate: 60
+    };
+    const taskNotes = {
+      cacheManager: {
+        getAllTasks: jest.fn(),
+        getTaskInfo: jest.fn().mockResolvedValue(task),
+        on: jest.fn()
+      },
+      taskService: {
+        updateProperty: jest.fn(
+          async (
+            inputTask: typeof task,
+            property: 'scheduled' | 'due' | 'timeEstimate',
+            value: unknown
+          ): Promise<typeof task> => {
+            fileContents = modifyFrontmatterString(fileContents, { [property]: value });
+            return { ...inputTask, [property]: value };
+          }
+        )
+      }
+    };
+    const plugin = {
+      app: {
+        plugins: { plugins: { tasknotes: taskNotes } },
+        vault: {
+          getFileByPath: jest.fn().mockReturnValue(file),
+          read: jest.fn().mockImplementation(() => Promise.resolve(fileContents)),
+          modify: jest.fn().mockImplementation((_file: typeof file, updatedContents: string) => {
+            fileContents = updatedContents;
+            return Promise.resolve();
+          })
+        }
+      }
+    } as unknown as FullCalendarPlugin;
+    const provider = new TaskNotesProvider(config, plugin);
+    const oldEvent: OFCEvent = {
+      type: 'single',
+      uid: 'Tasks/Task.md',
+      title: 'Task',
+      allDay: true,
+      date: '2026-04-20',
+      endDate: null,
+      completed: false
+    };
+    const newEvent: OFCEvent = {
+      ...oldEvent,
+      date: '2026-04-23'
+    };
+
+    await provider.updateEvent({ persistentId: 'Tasks/Task.md' }, oldEvent, newEvent);
+
+    expect(fileContents).toContain('scheduled: 2026-04-23');
+    expect(fileContents).toContain('scheduled-link: "[[2026-04-23]]"');
+    expect(taskNotes.taskService.updateProperty).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'due',
+      expect.anything()
+    );
+    expect(fileContents).toContain('due: 2026-04-25');
+    expect(fileContents).toContain('due-link: [[2026-04-25]]');
+    expect(fileContents).toContain('deadline: 2026-04-30');
+    expect(fileContents).toContain('deadline-link: [[2026-04-30]]');
   });
 });

--- a/src/providers/tasknotes/TaskNotesProvider.ts
+++ b/src/providers/tasknotes/TaskNotesProvider.ts
@@ -29,6 +29,7 @@ type TaskNotesTask = {
   title: string;
   status: string;
   dateModified?: string;
+  due?: string;
   scheduled?: string;
   recurrence?: string;
   recurrence_anchor?: 'scheduled' | 'completion';
@@ -49,7 +50,6 @@ type TaskNotesTaskCreationData = {
 
 const TASK_UPDATE_COALESCE_MS = 80;
 const TASKNOTES_COMPANION_LINK_PROPERTIES = ['due-link', 'deadline-link'] as const;
-const TASKNOTES_COMPANION_DATE_PROPERTIES = ['due', 'deadline'] as const;
 
 type TaskNotesPluginApi = {
   cacheManager: {
@@ -61,7 +61,7 @@ type TaskNotesPluginApi = {
   taskService: {
     updateProperty(
       task: TaskNotesTask,
-      property: 'scheduled' | 'timeEstimate',
+      property: 'scheduled' | 'due' | 'timeEstimate',
       value: unknown
     ): Promise<TaskNotesTask>;
     toggleStatus?(task: TaskNotesTask): Promise<TaskNotesTask>;
@@ -328,20 +328,19 @@ export class TaskNotesProvider
     return new RegExp(`^${escapedProperty}:.*${date}`, 'm').test(contents);
   }
 
-  private async updateTaskFileScheduleProperties(
+  private async getTaskFileScheduleCompanionUpdates(
     task: TaskNotesTask,
-    scheduledValue: string,
+    scheduledDate: string,
     previousDate?: string
-  ): Promise<void> {
+  ): Promise<{ modifications: Record<string, unknown>; shouldUpdateDue: boolean }> {
     const file = this.plugin.app.vault.getFileByPath(task.path);
-    if (!file) return;
+    if (!file) return { modifications: {}, shouldUpdateDue: false };
 
-    const scheduledDate = this.scheduledDateFromValue(scheduledValue);
     const contents = await this.plugin.app.vault.read(file);
     const modifications: Record<string, unknown> = {
-      scheduled: scheduledValue,
       'scheduled-link': this.taskNotesDailyNoteLink(scheduledDate)
     };
+    let shouldUpdateDue = false;
 
     if (previousDate) {
       for (const property of TASKNOTES_COMPANION_LINK_PROPERTIES) {
@@ -350,13 +349,26 @@ export class TaskNotesProvider
         }
       }
 
-      for (const property of TASKNOTES_COMPANION_DATE_PROPERTIES) {
-        if (this.frontmatterLineContainsDate(contents, property, previousDate)) {
-          modifications[property] = scheduledDate;
-        }
+      shouldUpdateDue = this.frontmatterLineContainsDate(contents, 'due', previousDate);
+
+      if (this.frontmatterLineContainsDate(contents, 'deadline', previousDate)) {
+        modifications.deadline = scheduledDate;
       }
     }
 
+    return { modifications, shouldUpdateDue };
+  }
+
+  private async updateTaskFileScheduleCompanionProperties(
+    task: TaskNotesTask,
+    modifications: Record<string, unknown>
+  ): Promise<void> {
+    if (Object.keys(modifications).length === 0) return;
+
+    const file = this.plugin.app.vault.getFileByPath(task.path);
+    if (!file) return;
+
+    const contents = await this.plugin.app.vault.read(file);
     const updatedContents = modifyFrontmatterString(contents, modifications);
     if (updatedContents !== contents) {
       await this.plugin.app.vault.modify(file, updatedContents);
@@ -1192,9 +1204,19 @@ export class TaskNotesProvider
       timeEstimateValue = this.computeMinutes(startTime, endTime);
     }
 
-    let updatedTask = await taskNotes.taskService.updateProperty(task, 'scheduled', scheduledValue);
     const previousDate = oldEvent.type === 'single' ? oldEvent.date : undefined;
-    await this.updateTaskFileScheduleProperties(updatedTask, scheduledValue, previousDate);
+    const scheduledDate = this.scheduledDateFromValue(scheduledValue);
+    const { modifications, shouldUpdateDue } = await this.getTaskFileScheduleCompanionUpdates(
+      task,
+      scheduledDate,
+      previousDate
+    );
+
+    let updatedTask = await taskNotes.taskService.updateProperty(task, 'scheduled', scheduledValue);
+    if (shouldUpdateDue) {
+      updatedTask = await taskNotes.taskService.updateProperty(updatedTask, 'due', scheduledDate);
+    }
+    await this.updateTaskFileScheduleCompanionProperties(updatedTask, modifications);
 
     try {
       updatedTask = await taskNotes.taskService.updateProperty(

--- a/src/providers/tasknotes/TaskNotesProvider.ts
+++ b/src/providers/tasknotes/TaskNotesProvider.ts
@@ -20,6 +20,7 @@ import {
   TaskNotesConfigComponentProps
 } from './TaskNotesConfigComponent';
 import { t } from '../../features/i18n/i18n';
+import { modifyFrontmatterString } from '../fullnote/frontmatter';
 
 export type EditableEventResponse = [OFCEvent, EventLocation | null];
 
@@ -47,6 +48,8 @@ type TaskNotesTaskCreationData = {
 };
 
 const TASK_UPDATE_COALESCE_MS = 80;
+const TASKNOTES_COMPANION_LINK_PROPERTIES = ['due-link', 'deadline-link'] as const;
+const TASKNOTES_COMPANION_DATE_PROPERTIES = ['due', 'deadline'] as const;
 
 type TaskNotesPluginApi = {
   cacheManager: {
@@ -310,6 +313,54 @@ export class TaskNotesProvider
       diff += 24 * 60;
     }
     return Math.round(diff);
+  }
+
+  private taskNotesDailyNoteLink(date: string | null): string | null {
+    return date ? `"[[${date}]]"` : null;
+  }
+
+  private scheduledDateFromValue(value: string): string {
+    return value.split('T')[0] || value;
+  }
+
+  private frontmatterLineContainsDate(contents: string, property: string, date: string): boolean {
+    const escapedProperty = property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`^${escapedProperty}:.*${date}`, 'm').test(contents);
+  }
+
+  private async updateTaskFileScheduleProperties(
+    task: TaskNotesTask,
+    scheduledValue: string,
+    previousDate?: string
+  ): Promise<void> {
+    const file = this.plugin.app.vault.getFileByPath(task.path);
+    if (!file) return;
+
+    const scheduledDate = this.scheduledDateFromValue(scheduledValue);
+    const contents = await this.plugin.app.vault.read(file);
+    const modifications: Record<string, unknown> = {
+      scheduled: scheduledValue,
+      'scheduled-link': this.taskNotesDailyNoteLink(scheduledDate)
+    };
+
+    if (previousDate) {
+      for (const property of TASKNOTES_COMPANION_LINK_PROPERTIES) {
+        if (this.frontmatterLineContainsDate(contents, property, previousDate)) {
+          modifications[property] = this.taskNotesDailyNoteLink(scheduledDate);
+        }
+      }
+
+      for (const property of TASKNOTES_COMPANION_DATE_PROPERTIES) {
+        if (this.frontmatterLineContainsDate(contents, property, previousDate)) {
+          modifications[property] = scheduledDate;
+        }
+      }
+    }
+
+    const updatedContents = modifyFrontmatterString(contents, modifications);
+    if (updatedContents !== contents) {
+      await this.plugin.app.vault.modify(file, updatedContents);
+    }
   }
 
   private isTaskNotesSourceId(): boolean {
@@ -1142,6 +1193,8 @@ export class TaskNotesProvider
     }
 
     let updatedTask = await taskNotes.taskService.updateProperty(task, 'scheduled', scheduledValue);
+    const previousDate = oldEvent.type === 'single' ? oldEvent.date : undefined;
+    await this.updateTaskFileScheduleProperties(updatedTask, scheduledValue, previousDate);
 
     try {
       updatedTask = await taskNotes.taskService.updateProperty(


### PR DESCRIPTION
Rescheduling task-backed notes exposed two related issues.

First, provider-backed task files could keep stale scheduling metadata after a calendar move. TaskNotes updates were persisted through the TaskNotes API, but companion properties such as scheduled-link, due, due-link, deadline, and deadline-link could remain pointed at the old date. The TaskNotes provider now performs a scoped frontmatter update after the canonical scheduled value is accepted, preserving unrelated file content while keeping date-link metadata aligned.

Second, CalDAV VTODO backlog loading was using an approach that could miss undated tasks after an Obsidian reload. Once a task is returned from the calendar to the backlog, it has no DTSTART or DUE, so it no longer appears as a calendar event. The backlog path now explicitly queries all VTODO objects with a no-time-range CalDAV REPORT and filters locally for tasks without scheduling dates. The first cold getUndatedTasks call also awaits the remote load instead of returning an empty cache.

CalDAV scheduling is now idempotent for an existing task UID, so a task moved back to the backlog can be scheduled again even if the server briefly returns stale date fields.

Added regression coverage for cold CalDAV backlog loading, rescheduling a task after returning it to the backlog, and TaskNotes frontmatter date-link updates.