### PR TITLE
[codex] fix Full Note type frontmatter collision

### DIFF
--- a/src/providers/fullnote/FullNoteProvider.test.ts
+++ b/src/providers/fullnote/FullNoteProvider.test.ts
@@ -363,6 +363,83 @@ describe('FullNoteCalendar Tests', () => {
     );
   });
 
+  it.each([null, 'meeting'])(
+    'loads a single event when frontmatter type is %p',
+    async customType => {
+      const filename = '2026-06-23 Custom Type.md';
+      const obsidian = makeApp(
+        MockAppBuilder.make()
+          .folder(
+            new MockAppBuilder(dirName).file(
+              filename,
+              new FileBuilder().frontmatter({
+                title: 'Custom Type',
+                date: '2026-06-23',
+                type: customType
+              })
+            )
+          )
+          .done()
+      );
+      const calendar = new FullNoteProvider(
+        { directory: dirName, id: 'local_1' },
+        makePlugin(),
+        obsidian
+      );
+
+      const events = await calendar.getEvents();
+
+      expect(events).toHaveLength(1);
+      expect(events[0][0]).toEqual(
+        expect.objectContaining({
+          title: 'Custom Type',
+          date: '2026-06-23',
+          type: 'single'
+        })
+      );
+    }
+  );
+
+  it.each([
+    [
+      'recurring',
+      {
+        title: 'Recurring Event',
+        type: 'recurring',
+        daysOfWeek: ['M'],
+        startRecur: '2026-06-23'
+      }
+    ],
+    [
+      'rrule',
+      {
+        title: 'RRULE Event',
+        type: 'rrule',
+        startDate: '2026-06-23',
+        rrule: 'FREQ=WEEKLY'
+      }
+    ]
+  ])('preserves the internal %s event type', async (expectedType, frontmatter) => {
+    const filename = `2026-06-23 ${expectedType}.md`;
+    const obsidian = makeApp(
+      MockAppBuilder.make()
+        .folder(
+          new MockAppBuilder(dirName).file(filename, new FileBuilder().frontmatter(frontmatter))
+        )
+        .done()
+    );
+    const calendar = new FullNoteProvider(
+      { directory: dirName, id: 'local_1' },
+      makePlugin(),
+      obsidian
+    );
+
+    const events = await calendar.getEvents();
+
+    expect(events).toHaveLength(1);
+    expect(events[0][0].type).toBe(expectedType);
+  });
+
   it('create and delete workflow succeeds end-to-end', async () => {
     const app = MockAppBuilder.make().folder(new MockAppBuilder(dirName)).done();
     const obsidian = makeApp(app);

--- a/src/providers/fullnote/FullNoteProvider.ts
+++ b/src/providers/fullnote/FullNoteProvider.ts
@@ -201,9 +201,15 @@ export class FullNoteProvider implements CalendarProvider<FullNoteProviderConfig
       return [];
     }
 
+    const frontmatter = metadata.frontmatter as Record<string, unknown>;
+    const frontmatterType = frontmatter.type;
+    const eventType =
+      frontmatterType === 'recurring' || frontmatterType === 'rrule' ? frontmatterType : 'single';
+
     const rawEventData = {
-      ...metadata.frontmatter,
-      title: (metadata.frontmatter as { title?: string }).title || file.basename
+      ...frontmatter,
+      type: eventType,
+      title: frontmatter.title || file.basename
     } as Record<string, unknown>;
 
     const event = validateEvent(rawEventData);


### PR DESCRIPTION
## Summary

- normalize Full Note frontmatter `type` values before event validation
- preserve the internal `recurring` and `rrule` event variants
- treat empty or unrelated custom `type` values as the default `single` event type
- add regression coverage for custom, empty, recurring, and RRULE values

## Root cause

`parseEvent()` supplies `type: 'single'` as a default, but Full Note frontmatter is spread over that default. A custom Obsidian property such as `type: meeting` or an empty `type:` therefore replaces the internal event discriminator.

The resulting value is not accepted by the Zod discriminated union, so validation returns `null` and the Full Note provider silently skips the event.

The normalization is intentionally scoped to `FullNoteProvider` so other providers that use the shared event parser retain their existing behavior.

Fixes #317.

## Validation

- `jest src/providers/fullnote/FullNoteProvider.test.ts --runInBand` — 21 passed
- complete Jest suite — 65 suites passed, 719 tests passed, 1 existing todo
- TypeScript compile check passed
- ESLint and Prettier checks passed for the changed files
- production build and Terser minification completed successfully
