### PR TITLE
docs: update license information for FullCalendar library

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Integrations include
 
 > This is the remastered edition of original [Full Calender plugin](https://github.com/obsidian-community/obsidian-full-calendar) by [Davis Haupt](https://davi.sh/), with the [core additions](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/whats_new/).
 
-The FullCalendar library is released under the [GPLv3 license](https://fullcalendar.io/license). It's an awesome piece of work, and it would not have been possible to make something like this plugin so easily without it.
+The FullCalendar Standard library is released under the [MIT License](https://opensource.org/licenses/MIT). FullCalendar Premium, including [Premium Plugins](https://fullcalendar.io/docs/plugin-index) and the `fullcalendar-scheduler` bundle, are utilized under the [GPLv3 license](http://www.gnu.org/licenses/gpl-3.0.en.html) as part of FullCalendar's [GPLv3 open-source project](https://fullcalendar.io/license) provision. It's an awesome piece of work, and it would not have been possible to make something like this plugin so easily without it.
 
 ## Installation
 


### PR DESCRIPTION
## Description
Updates README.md to include license information on FullCalendar Standard, FullCalendar Premium, and how this project adheres to the FullCalendar license under GPLv3.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor 
- [x] Documentation
- [ ] Chore / maintenance

## Code Quality Checklist (MANDATORY)
*Please read and verify you have adhered to all guidelines outlined in [CONTRIBUTING.md](https://github.com/obsidian-full-calendar-remastered/plugin-full-calendar/blob/main/CONTRIBUTING.md).*

- **[SOLID](https://en.wikipedia.org/wiki/SOLID), [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)** :
  - [ ] Designed polymorphically where appropriate.
  - [ ] Kept classes and UI views decoupled (e.g., separating layout/filtering scroll sections from persistent creation footers).
  - [ ] Shared reusable helpers instead of copying/pasting logic.
- **Internationalization (i18n)**:
  - [ ] Declared all new UI headers, text, labels, and placeholders inside `src/features/i18n/locales/en.json` and retrieved them using `t()`; **no** user-facing strings are hardcoded in the codebase. <!-- Not necessary to translate other lang files, updating the en.json and running pnpm run ra should en.json entries into other files - which is fine!  -->
- **Documentation Sync**:
  - [ ] Updated corresponding architectural documentation (under `docs/architecture/`).
  - [ ] Updated corresponding user-facing documentation (under `docs/user/`).
  - [x] Adhered to the hyperlinked, compact, table-based concise formatting style.
- **Code Integrity & Type Safety**:
  - [ ] Ran `pnpm run ra` locally and confirmed that compilation, ESLint (`lint_report.txt` and `css_report.txt`), i18n checks, and Jest unit tests pass with **0 errors**.
- **Test Integrity**:
  - [ ] Kept all existing `.test` files completely untouched.
  - [ ] Added new unit/integration tests for new features.