### PR TITLE
fix(tasks): generate recurring tasks when completing from calendar

### DIFF
--- a/src/providers/tasks/TasksPluginProvider.ts
+++ b/src/providers/tasks/TasksPluginProvider.ts
@@ -197,44 +197,52 @@ export class TasksPluginProvider
   static getConfigurationComponent(): FCReactComponent<TasksConfigComponentProps> {
     return TasksConfigComponent;
   }
-  /**
-   * Adds or removes the done date (✅) from a task's markdown line.
-   * @param originalMarkdown The original line of the task.
-   * @param isDone The desired completion state.
-   * @returns The modified task line.
-   */
-  private setDoneState(originalMarkdown: string, isDone: boolean): string {
-    const doneDateRegex = /\s*✅\s*\d{4}-\d{2}-\d{2}/;
-    const blockLinkRegex = /(\s*\^[a-zA-Z0-9-]+)$/;
-    let updated = originalMarkdown;
+  private async toggleTaskWithTasksApi(task: CalendarTask, isDone: boolean): Promise<void> {
+    const tasksApi = (
+      this.plugin.app as unknown as {
+        plugins?: {
+          plugins?: Record<
+            string,
+            {
+              apiV1?: {
+                executeToggleTaskDoneCommand?: (line: string, path: string) => string;
+              };
+            }
+          >;
+        };
+      }
+    ).plugins?.plugins?.['obsidian-tasks-plugin']?.apiV1;
 
-    if (isDone) {
-      // Change '- [ ]' to '- [x]'
-      updated = updated.replace(/^- \[ \]/, '- [x]');
-      // Add done date if not present
-      if (!doneDateRegex.test(updated)) {
-        const doneDate = DateTime.now().toFormat('yyyy-MM-dd');
-        const doneComponent = ` ✅ ${doneDate}`;
-        const blockLinkMatch = updated.match(blockLinkRegex);
-        if (blockLinkMatch) {
-          const contentWithoutBlockLink = updated.replace(blockLinkRegex, '');
-          updated = `${contentWithoutBlockLink.trim()}${doneComponent}${blockLinkMatch[1]}`;
-        } else {
-          updated = `${updated.trim()}${doneComponent}`;
-        }
-      }
-    } else {
-      // Change '- [x]' to '- [ ]'
-      updated = updated.replace(/^- \[x\]/, '- [ ]');
-      // Remove done date if present
-      updated = updated.replace(doneDateRegex, '').trim();
-      // Preserve block link if present
-      const blockLinkMatch = originalMarkdown.match(blockLinkRegex);
-      if (blockLinkMatch && !updated.endsWith(blockLinkMatch[1])) {
-        updated += blockLinkMatch[1];
-      }
+    if (typeof tasksApi?.executeToggleTaskDoneCommand !== 'function') {
+      throw new Error('Unable to toggle task status: the Obsidian Tasks API is unavailable.');
     }
-    return updated;
+    const executeToggleTaskDoneCommand = tasksApi.executeToggleTaskDoneCommand;
+
+    const file = this.app.getFileByPath(task.filePath);
+    if (!file) throw new Error(`File not found: ${task.filePath}`);
+
+    await this.app.rewrite(file, content => {
+      const newline = content.includes('\r\n') ? '\r\n' : '\n';
+      const lines = content.split(/\r?\n/);
+      const lineIndex = task.lineNumber - 1;
+      const currentLine = lines[lineIndex];
+      if (currentLine !== task.originalMarkdown) {
+        throw new Error(
+          'Unable to toggle task status: the task line changed. Wait for sync and try again.'
+        );
+      }
+
+      const standardCheckbox = currentLine.match(/^\s*[-*+]\s+\[([ xX])\]/);
+      if (standardCheckbox) {
+        const currentIsDone = standardCheckbox[1].toLowerCase() === 'x';
+        if (currentIsDone === isDone) return content;
+      }
+
+      const replacement = executeToggleTaskDoneCommand(currentLine, task.filePath);
+      const replacementLines = replacement.split(/\r?\n/);
+      lines.splice(lineIndex, 1, ...replacementLines);
+      return lines.join(newline);
+    });
   }
 
   public async toggleComplete(eventId: string, isDone: boolean): Promise<boolean> {
@@ -251,16 +259,7 @@ export class TasksPluginProvider
         throw new Error(`Task with persistent ID ${event.uid} not found in provider cache.`);
       }
 
-      const newLine = this.setDoneState(task.originalMarkdown, isDone);
-
-      // If the line didn't change, we don't need to do anything.
-      if (newLine === task.originalMarkdown) {
-        return true;
-      }
-
-      // 1. Perform the I/O to update the file.
-      // The line number on the task object is 1-based, which is what replaceTaskInFile expects.
-      await this.replaceTaskInFile(task.filePath, task.lineNumber, [newLine]);
+      await this.toggleTaskWithTasksApi(task, isDone);
 
       // 2. Optimistically update the cache.
       // The file watcher will eventually confirm this, but we want immediate UI feedback.
@@ -273,7 +272,6 @@ export class TasksPluginProvider
       };
 
       // Update our internal task model to match the optimistic state.
-      task.originalMarkdown = newLine;
       task.isDone = isDone;
 
       // Push the update to the EventCache.
@@ -722,13 +720,7 @@ export class TasksPluginProvider
         throw new Error(`Task with persistent ID ${taskId} not found in provider cache.`);
       }
 
-      const newLine = this.setDoneState(task.originalMarkdown, isDone);
-      if (newLine === task.originalMarkdown) {
-        return true;
-      }
-
-      await this.replaceTaskInFile(task.filePath, task.lineNumber, [newLine]);
-      task.originalMarkdown = newLine;
+      await this.toggleTaskWithTasksApi(task, isDone);
       task.isDone = isDone;
       PluginState.getProviderRegistry().refreshBacklogViews();
       return true;

--- a/src/providers/tasks/tests/TasksPluginProvider.test.ts
+++ b/src/providers/tasks/tests/TasksPluginProvider.test.ts
@@ -14,6 +14,7 @@ import { PluginState } from '../../../core/PluginState';
 import type EventCache from '../../../core/EventCache';
 import { DEFAULT_SETTINGS, FullCalendarSettings } from '../../../types/settings';
 import type { ProviderRegistry } from '../../ProviderRegistry';
+import type { CalendarTask } from '../taskPayloadAdapter';
 
 // Mock the dependencies
 jest.mock('../../../ObsidianAdapter');
@@ -37,7 +38,10 @@ type MockPlugin = {
       plugins?: Record<
         string,
         {
-          apiV1?: { editTaskLineModal: jest.Mock };
+          apiV1?: {
+            editTaskLineModal?: jest.Mock;
+            executeToggleTaskDoneCommand?: jest.Mock;
+          };
           settings?: { globalQuery?: string };
         }
       >;
@@ -137,6 +141,125 @@ describe('TasksPluginProvider', () => {
         allowGenericTaskActions: false,
         providesNativeTaskSemantics: true
       });
+    });
+  });
+
+  describe('task completion through the Tasks API', () => {
+    const task = (originalMarkdown: string, lineNumber = 1, isDone = false) =>
+      ({
+        id: `Tasks.md::${lineNumber - 1}`,
+        title: 'Task',
+        filePath: 'Tasks.md',
+        lineNumber,
+        originalMarkdown,
+        isDone
+      }) as CalendarTask;
+
+    const toggle = async (calendarTask: CalendarTask, isDone = true) => {
+      (provider as unknown as { allTasks: CalendarTask[] }).allTasks = [calendarTask];
+      return provider.setTaskBacklogItemComplete(calendarTask.id, isDone);
+    };
+
+    const arrangeFile = (content: string, replacement?: string) => {
+      let fileContent = content;
+      mockApp.getFileByPath.mockReturnValue({ path: 'Tasks.md' });
+      mockApp.rewrite.mockImplementation(
+        async (_file: unknown, rewrite: (content: string) => string | Promise<string>) => {
+          fileContent = await rewrite(fileContent);
+        }
+      );
+      const executeToggleTaskDoneCommand = replacement
+        ? jest.fn().mockReturnValue(replacement)
+        : undefined;
+      mockPlugin.app.plugins = {
+        plugins: {
+          'obsidian-tasks-plugin': {
+            apiV1: { executeToggleTaskDoneCommand }
+          }
+        }
+      };
+      return {
+        content: () => fileContent,
+        executeToggleTaskDoneCommand
+      };
+    };
+
+    it('writes the completed markdown returned for a normal task', async () => {
+      const original = '- [ ] 普通任务 ⏳ 2026-07-07';
+      const completed = '- [x] 普通任务 ⏳ 2026-07-07 ✅ 2026-07-10';
+      const file = arrangeFile(original, completed);
+
+      await expect(toggle(task(original))).resolves.toBe(true);
+
+      expect(file.content()).toBe(completed);
+      expect(file.executeToggleTaskDoneCommand).toHaveBeenCalledWith(original, 'Tasks.md');
+    });
+
+    it('uses the live markdown state when the Tasks cache completion state is stale', async () => {
+      const original = '- [ ] stale cache task ⏳ 2026-07-07';
+      const completed = '- [x] stale cache task ⏳ 2026-07-07 ✅ 2026-07-10';
+      const file = arrangeFile(original, completed);
+
+      await expect(toggle(task(original, 1, true), true)).resolves.toBe(true);
+
+      expect(file.content()).toBe(completed);
+      expect(file.executeToggleTaskDoneCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes every line returned for a recurring task', async () => {
+      const original = '- [ ] 棉兰（周二） 🔁 every week on Tuesday ⏳ 2026-07-07';
+      const replacement =
+        '- [x] 棉兰（周二） 🔁 every week on Tuesday ⏳ 2026-07-07 ✅ 2026-07-10\n' +
+        '- [ ] 棉兰（周二） 🔁 every week on Tuesday ⏳ 2026-07-14';
+      const file = arrangeFile(`before\n${original}\nafter`, replacement);
+
+      await expect(toggle(task(original, 2))).resolves.toBe(true);
+
+      expect(file.content()).toBe(`before\n${replacement}\nafter`);
+    });
+
+    it('preserves indentation and CRLF when Tasks returns recurring subtasks', async () => {
+      const original = '    - [ ] 子任务 🔁 every day ⏳ 2026-07-07';
+      const replacement =
+        '    - [x] 子任务 🔁 every day ⏳ 2026-07-07 ✅ 2026-07-10\n' +
+        '    - [ ] 子任务 🔁 every day ⏳ 2026-07-08';
+      const file = arrangeFile(`parent\r\n${original}\r\nend`, replacement);
+
+      await expect(toggle(task(original, 2))).resolves.toBe(true);
+
+      expect(file.content()).toBe(`parent\r\n${replacement.replace(/\n/g, '\r\n')}\r\nend`);
+    });
+
+    it('keeps the Tasks API block ID output unchanged', async () => {
+      const original = '- [ ] 循环任务 🔁 every week ⏳ 2026-07-07 ^task-id';
+      const replacement =
+        '- [x] 循环任务 🔁 every week ⏳ 2026-07-07 ✅ 2026-07-10 ^task-id\n' +
+        '- [ ] 循环任务 🔁 every week ⏳ 2026-07-14';
+      const file = arrangeFile(original, replacement);
+
+      await expect(toggle(task(original))).resolves.toBe(true);
+
+      expect(file.content()).toBe(replacement);
+      expect(file.content().match(/\^task-id/g)).toHaveLength(1);
+    });
+
+    it('does not modify a recurring task when the Tasks API is unavailable', async () => {
+      const original = '- [ ] 循环任务 🔁 every week ⏳ 2026-07-07';
+      const file = arrangeFile(original);
+
+      await expect(toggle(task(original))).resolves.toBe(false);
+      expect(file.content()).toBe(original);
+      expect(mockApp.rewrite).not.toHaveBeenCalled();
+    });
+
+    it('refuses to write when the cached task line is stale', async () => {
+      const cached = '- [ ] old task ⏳ 2026-07-07';
+      const current = '- [ ] changed task ⏳ 2026-07-07';
+      const file = arrangeFile(current, '- [x] old task ⏳ 2026-07-07 ✅ 2026-07-10');
+
+      await expect(toggle(task(cached))).resolves.toBe(false);
+      expect(file.content()).toBe(current);
+      expect(file.executeToggleTaskDoneCommand).not.toHaveBeenCalled();
     });
   });
 
@@ -523,12 +646,20 @@ describe('TasksPluginProvider', () => {
 
     it('marks backlog tasks complete through the backlog checkbox action', async () => {
       const file = { path: 'Daily.md' };
+      const completed = '- [x] Backlog task ✅ 2026-07-10';
       mockApp.getFileByPath.mockReturnValue(file);
       mockApp.rewrite.mockImplementation((_file: unknown, update: (content: string) => string) => {
         const updated = update('- [ ] Backlog task');
-        expect(updated).toMatch(/^- \[x\] Backlog task ✅ \d{4}-\d{2}-\d{2}$/);
+        expect(updated).toBe(completed);
         return Promise.resolve();
       });
+      mockPlugin.app.plugins = {
+        plugins: {
+          'obsidian-tasks-plugin': {
+            apiV1: { executeToggleTaskDoneCommand: jest.fn().mockReturnValue(completed) }
+          }
+        }
+      };
       mockPlugin.app.workspace.trigger.mockImplementation(
         (eventName: string, callback: (data: unknown) => void) => {
           if (eventName === 'obsidian-tasks-plugin:request-cache-update') {


### PR DESCRIPTION
## Summary

Delegate Obsidian Tasks completion toggles to the official Tasks API instead of manually changing the checkbox and completion date.

## Root cause

The Tasks provider changed `[ ]` to `[x]` and added a done date itself. That bypassed the Tasks plugin's recurrence, custom-status, and completion semantics, so completing a recurring task from Full Calendar did not create its next occurrence.

## Changes

- Call `apiV1.executeToggleTaskDoneCommand(originalLine, filePath)` for Tasks completion actions.
- Write the complete returned Markdown, including multi-line recurring-task output.
- Re-read and validate the target line before writing.
- Preserve the file's CRLF or LF line endings and all surrounding content.
- Determine standard checkbox state from the live Markdown instead of potentially stale cache state.
- Fail safely when the Tasks API is unavailable or the cached task line has changed.
- Apply the same Tasks semantics to calendar and backlog completion actions.

## Impact

Completing a recurring Obsidian Tasks item from Full Calendar now completes the current task and lets Tasks generate the next occurrence. Full Calendar continues to rely on the Tasks cache update event to add the new task to the calendar.

## Validation

- `pnpm exec jest src/providers/tasks/tests/TasksPluginProvider.test.ts --runInBand --silent` — 39 tests passed.
- `pnpm run compile` — passed.
- `pnpm run lint` — passed with two existing CSS baseline warnings.
- Verified manually in Obsidian 1.12.7 with Tasks 8.2.2: completing a weekly task from the calendar wrote both the completed occurrence and the following week's task.
