### PR TITLE
fix(ics): normalize Outlook GTB timezone

### DIFF
--- a/src/features/timezone/Timezone.ts
+++ b/src/features/timezone/Timezone.ts
@@ -117,6 +117,7 @@ function mapWindowsTimezoneToIANA(windowsTz: string): string | null {
     'W. Europe Standard Time': 'Europe/Berlin',
     'Central Europe Standard Time': 'Europe/Budapest',
     'E. Europe Standard Time': 'Europe/Bucharest',
+    'GTB Standard Time': 'Europe/Bucharest',
     'Russian Standard Time': 'Europe/Moscow',
     'GMT Standard Time': 'Europe/London',
     'Greenwich Standard Time': 'Europe/London',

--- a/src/providers/ics/ics.timezone.test.ts
+++ b/src/providers/ics/ics.timezone.test.ts
@@ -1,0 +1,63 @@
+import { DateTime } from 'luxon';
+
+import { toEventInput } from '../../core/interop';
+import { DEFAULT_SETTINGS, FullCalendarSettings } from '../../types/settings';
+import { getEventsFromICS } from './ics';
+
+jest.mock('../../ui/view', () => ({
+  getCalendarColors: (color: string) => ({ color, textColor: '#ffffff' })
+}));
+
+const settings: FullCalendarSettings = {
+  ...DEFAULT_SETTINGS,
+  displayTimezone: 'Asia/Nicosia'
+};
+
+describe('Outlook ICS Windows timezone rendering', () => {
+  it.each([
+    ['summer', '20260729', '+03:00'],
+    ['winter', '20260129', '+02:00']
+  ])(
+    'keeps a GTB Standard Time event at 10:00 in Asia/Nicosia in %s',
+    (_season, icsDate, expectedOffset) => {
+      const events = getEventsFromICS(`BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Synthetic Outlook ICS Test//EN
+BEGIN:VEVENT
+UID:synthetic-gtb-${icsDate}
+DTSTART;TZID=GTB Standard Time:${icsDate}T100000
+DTEND;TZID=GTB Standard Time:${icsDate}T103000
+SUMMARY:Synthetic timezone test
+END:VEVENT
+END:VCALENDAR`);
+
+      expect(events).toHaveLength(1);
+      const event = events[0];
+
+      // EventDetails formats these cached wall-clock fields directly.
+      expect(event).toMatchObject({
+        type: 'single',
+        allDay: false,
+        startTime: '10:00',
+        endTime: '10:30',
+        timezone: 'Europe/Bucharest'
+      });
+
+      const eventInput = toEventInput(`synthetic-gtb-${icsDate}`, event, settings);
+      expect(eventInput).not.toBeNull();
+
+      const sourceStart = DateTime.fromISO(String(eventInput?.start), { setZone: true });
+      const sourceEnd = DateTime.fromISO(String(eventInput?.end), { setZone: true });
+      expect(sourceStart.toFormat('ZZ')).toBe(expectedOffset);
+      expect(sourceEnd.toFormat('ZZ')).toBe(expectedOffset);
+
+      // FullCalendar is configured with Asia/Nicosia and renders these instants there.
+      const renderedStart = sourceStart.setZone(settings.displayTimezone!);
+      const renderedEnd = sourceEnd.setZone(settings.displayTimezone!);
+      expect(renderedStart.toFormat('HH:mm')).toBe('10:00');
+      expect(renderedEnd.toFormat('HH:mm')).toBe('10:30');
+      expect(renderedStart.toFormat('HH:mm')).not.toBe(_season === 'summer' ? '13:00' : '12:00');
+      expect(renderedEnd.toFormat('HH:mm')).not.toBe(_season === 'summer' ? '13:30' : '12:30');
+    }
+  );
+});


### PR DESCRIPTION
## Description

This PR fixes an issue where Outlook ICS events using the Windows timezone identifier `GTB Standard Time` are rendered at the wrong time.

The timezone normalization table did not include `GTB Standard Time`, causing Luxon to fall back to UTC while preserving the event's wall-clock time. As a result:

- The event details popup displayed the correct time (e.g. 10:00–10:30).
- FullCalendar received an incorrect UTC instant.
- Events were rendered several hours later in the calendar (e.g. 13:00 in `Asia/Nicosia` during summer).

This change adds the missing Windows-to-IANA timezone mapping:

- `GTB Standard Time` → `Europe/Bucharest`

allowing the existing timezone conversion logic to use the correct source timezone.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance

## Testing

Added a new regression test using synthetic Outlook ICS data that verifies:

- Summer (`UTC+3`) and winter (`UTC+2`) dates.
- Correct Windows timezone normalization.
- Correct cached event times.
- Correct FullCalendar `EventInput`.
- Correct rendering in `Asia/Nicosia`.
- The previous incorrect rendering offsets no longer occur.

Also verified:

- TypeScript compilation
- ESLint
- Prettier
- Relevant ICS/timezone test suites
- Production build

## Additional Notes

The fix is intentionally minimal and consists of:
- one production mapping entry
- one new regression test

No generated files, documentation, lockfiles, version numbers, or unrelated code were modified.