### PR TITLE
fix(ui): use hover modifier for today cell background

### DIFF
--- a/src/ui/settings/sections/calendars/styles/overrides.css
+++ b/src/ui/settings/sections/calendars/styles/overrides.css
@@ -56,7 +56,7 @@
     --fc-more-link-bg-color: var(--background-primary-alt);
     --fc-more-link-text-color: var(--text-accent);
 
-    --fc-today-bg-color: var(--background-modifier-cover);
+    --fc-today-bg-color: var(--background-modifier-hover);
 
     --fc-neutral-text-color: var(--text-muted);
     --fc-neutral-bg-color: var(--interactive-normal);


### PR DESCRIPTION
## Description

`--fc-today-bg-color` is mapped to `--background-modifier-cover`, which is Obsidian's **modal backdrop/scrim** variable, not a surface color. It is intentionally dark and semi-transparent in every theme (e.g. `rgba(0, 0, 0, 0.6)` / `rgba(0, 0, 0, 0.8)` in the Atom theme, and dark in the default theme too).

**Symptom:** on light themes, the current-day cell (`.fc-day-today`) renders as a near-black block over the calendar grid, making today's events hard to read.

**Why it went unnoticed:** on dark themes a dark overlay on top of an already dark background just reads as a subtle highlight, so the mapping looks fine there and only breaks in light mode.

**Fix:** map it to `--background-modifier-hover`, Obsidian's standard variable for subtle surface highlights. Every theme defines it appropriately for its own background (Atom uses `hsla(var(--accent-h), calc(var(--accent-s) - 35%), var(--accent-l), 0.06)`), so today's cell gets a gentle, theme-aware tint in both light and dark mode.

**Likely a typo:** the two variable names differ by two characters (`cover` / `hover`), both exist so no linter would flag it, and every other `--fc-*` mapping in this block picks a sensible surface variable (`--fc-more-link-bg-color: var(--background-primary-alt)`, `--fc-neutral-bg-color: var(--background-primary-alt)`, `--fc-list-event-hover-bg-color: var(--background-secondary)`). This one line is the odd one out.

**Tested on:** Obsidian 1.12.7, plugin v0.13.5, Atom theme in light mode.

Single-line change in `src/ui/settings/sections/calendars/styles/overrides.css`; no other lines touched.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance

## Code Quality Checklist (MANDATORY)

- **SOLID, DRY**:
  - [x] Designed polymorphically where appropriate. <!-- N/A: single CSS variable mapping -->
  - [x] Kept classes and UI views decoupled.
  - [x] Shared reusable helpers instead of copying/pasting logic. <!-- Reuses an existing Obsidian theme variable rather than a hardcoded color -->
- **Internationalization (i18n)**:
  - [x] No user-facing strings added or changed.
- **Documentation Sync**:
  - [x] No architectural documentation changes needed (no behavior or structural change).
  - [x] No user-facing documentation changes needed.
  - [x] N/A.
- **Code Integrity & Type Safety**:
  - [x] CSS-only, one-line change with no TypeScript, i18n or test surface. <!-- Not run locally; happy to run `pnpm run ra` if maintainers prefer. -->
- **Test Integrity**:
  - [x] Kept all existing `.test` files completely untouched.
  - [x] No new tests needed (CSS variable mapping).
