### PR TITLE
feat(journals): add Obsidian Journals calendar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Full Calendar supports multiple calendar sources:
 
 - [**Full Note**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/local/): Events from frontmatter on individual notes
 - [**Daily Note**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/dailynote/): Events from event lists in daily notes
-- [**Journals**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/dailynote/): Events from selected Obsidian Journals Day journals
+- [**Journals**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/journals/): Events from selected Obsidian Journals Day journals
 - [**ICS**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/ics/): Read-only remote or local ICS files
 - [**CalDAV**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/caldav/): Two-way sync with CalDAV servers
 - [**Google Calendar**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/gcal/): Two-way sync with Google Calendar

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Full Calendar supports multiple calendar sources:
 
 - [**Full Note**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/local/): Events from frontmatter on individual notes
 - [**Daily Note**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/dailynote/): Events from event lists in daily notes
+- [**Journals**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/dailynote/): Events from selected Obsidian Journals Day journals
 - [**ICS**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/ics/): Read-only remote or local ICS files
 - [**CalDAV**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/caldav/): Two-way sync with CalDAV servers
 - [**Google Calendar**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/gcal/): Two-way sync with Google Calendar

--- a/docs/architecture/calendars/provider-implementations.md
+++ b/docs/architecture/calendars/provider-implementations.md
@@ -26,6 +26,13 @@ Creates one-note-per-event records, supports full CRUD, and uses robust filename
 
 Parses list items under configured heading and performs line-targeted updates. Implements a persistent locally-allocated `uid` mechanism (`[uid:: N]`) instead of legacy deduplication matching, enabling deterministic title edits and O(1) hinted line lookups during sync updates.
 
+Note lookup and creation are delegated through a source adapter:
+
+- `ObsidianDailyNoteSourceAdapter` preserves the existing `obsidian-daily-notes-interface` integration for core Daily Notes and Periodic Notes.
+- `JournalsDailyNoteSourceAdapter` validates the optional Journals runtime API, selects a configured Day journal, and delegates resolution/creation to that journal. Journals remains optional and owns its folder, naming, template, and frontmatter initialization.
+
+Both adapters feed the same heading parser, serializer, UID allocator, and CRUD implementation. The Journals adapter is intentionally narrow because Journals does not currently publish a documented third-party API; runtime shape checks contain that compatibility boundary.
+
 **Location & Description Mapping**: Serializes `location` and `description` into Dataview inline attribute format (`[location:: My Location]  [description:: My Description]`) within the daily note bullet list items.
 
 Timed-event serialization is source-configured and provider-owned:

--- a/docs/architecture/calendars/provider-implementations.md
+++ b/docs/architecture/calendars/provider-implementations.md
@@ -33,6 +33,8 @@ Note lookup and creation are delegated through a source adapter:
 
 Both adapters feed the same heading parser, serializer, UID allocator, and CRUD implementation. The Journals adapter is intentionally narrow because Journals does not currently publish a documented third-party API; runtime shape checks contain that compatibility boundary.
 
+Daily Notes and Journals have independent persisted source discriminators (`dailynote` and `journals`). `JournalsProvider` reuses `DailyNoteProvider` as its date-note CRUD base, while remaining separately registered so multiple selected Day journals can coexist without participating in the single Daily Note source limit. Legacy Journals sources saved as `type: dailynote` plus `provider: journals` are migrated to `type: journals`.
+
 **Location & Description Mapping**: Serializes `location` and `description` into Dataview inline attribute format (`[location:: My Location]  [description:: My Description]`) within the daily note bullet list items.
 
 Timed-event serialization is source-configured and provider-owned:

--- a/docs/architecture/calendars/provider-implementations.md
+++ b/docs/architecture/calendars/provider-implementations.md
@@ -5,12 +5,12 @@
 
 ## Provider families
 
-| Family      | Providers             | Notes                                                                   |
-| ----------- | --------------------- | ----------------------------------------------------------------------- |
-| Local       | Full Note, Daily Note | Vault-backed, file-centric parsing and persistence.                     |
-| Remote      | Google, Outlook, CalDAV, ICS, Google Tasks   | Network-backed with auth/protocol handling and staged loading behavior. |
-| Integration | Tasks, TaskNotes, Bases | Plugin/API integration with custom semantics beyond simple event files. |
-| Virtual     | Holidays              | Computed on-the-fly from bundled data; no vault file or network backing. |
+| Family      | Providers                                  | Notes                                                                   |
+| ----------- | ------------------------------------------ | ----------------------------------------------------------------------- |
+| Local       | Full Note, Daily Note, Journals            | Vault-backed, file-centric parsing and persistence.                     |
+| Remote      | Google, Outlook, CalDAV, ICS, Google Tasks | Network-backed with auth/protocol handling and staged loading behavior. |
+| Integration | Tasks, TaskNotes, Bases                    | Plugin/API integration with custom semantics beyond simple event files. |
+| Virtual     | Holidays                                   | Computed on-the-fly from bundled data; no vault file or network backing. |
 
 ## Key implementation notes
 

--- a/docs/user/calendars/dailynote.md
+++ b/docs/user/calendars/dailynote.md
@@ -17,11 +17,10 @@ You must be using one of the supported daily notes plugins in order to create a 
 
 ## Configuring the Daily Notes calendar
 
-Add a new calendar with the "Daily note" type, then choose:
+Add either a **Daily Note** calendar for core Daily Notes/Periodic Notes or a separate **Journals** calendar for an Obsidian Journals Day journal. Then choose:
 
-- the note provider: Daily Notes / Periodic Notes, or Journals
 - the Day journal to use when Journals is selected
-- which heading from your daily note template events should be placed under
+- which heading from the configured template or templates events should be placed under
 - which write format timed events should use
 
 Journals is optional. When selected, Full Calendar asks the chosen Day journal to resolve and create entries, preserving its normal folder, filename, template, and journal frontmatter behavior. Obsidian's core Daily Notes plugin can be disabled in this setup.
@@ -29,6 +28,8 @@ Journals is optional. When selected, Full Calendar asks the chosen Day journal t
 If your template does not have any headings, then you can enter free-form text to specify the heading that events will be placed under.
 
 If a heading does not exist in a daily note, it will be appended to the end of the file before adding any events to it.
+
+The heading can be changed later directly from the configured calendar row. When template headings are available, Full Calendar presents them as a dropdown.
 
 Timed events support two write formats:
 

--- a/docs/user/calendars/dailynote.md
+++ b/docs/user/calendars/dailynote.md
@@ -13,13 +13,18 @@ You must be using one of the supported daily notes plugins in order to create a 
 
 -   [Daily Notes core plugin](https://help.obsidian.md/Plugins/Daily+notes)
 -   [Periodic Notes community plugin](https://github.com/liamcain/obsidian-periodic-notes)
+-   [Journals community plugin](https://github.com/srg-kostyrko/obsidian-journal) with a **Day** journal configured
 
 ## Configuring the Daily Notes calendar
 
 Add a new calendar with the "Daily note" type, then choose:
 
+- the note provider: Daily Notes / Periodic Notes, or Journals
+- the Day journal to use when Journals is selected
 - which heading from your daily note template events should be placed under
 - which write format timed events should use
+
+Journals is optional. When selected, Full Calendar asks the chosen Day journal to resolve and create entries, preserving its normal folder, filename, template, and journal frontmatter behavior. Obsidian's core Daily Notes plugin can be disabled in this setup.
 
 If your template does not have any headings, then you can enter free-form text to specify the heading that events will be placed under.
 

--- a/docs/user/calendars/dailynote.md
+++ b/docs/user/calendars/dailynote.md
@@ -25,6 +25,8 @@ Add either a **Daily Note** calendar for core Daily Notes/Periodic Notes or a se
 
 Journals is optional. When selected, Full Calendar asks the chosen Day journal to resolve and create entries, preserving its normal folder, filename, template, and journal frontmatter behavior. Obsidian's core Daily Notes plugin can be disabled in this setup.
 
+One core Daily Note calendar and multiple Journals calendars can coexist. Add a separate Journals calendar for each Day journal you want to expose in Full Calendar.
+
 If your template does not have any headings, then you can enter free-form text to specify the heading that events will be placed under.
 
 If a heading does not exist in a daily note, it will be appended to the end of the file before adding any events to it.

--- a/docs/user/calendars/dailynote.md
+++ b/docs/user/calendars/dailynote.md
@@ -9,23 +9,19 @@ Store events in-line in Daily Notes. Each event is a list item. Timed events can
 
 ## Prerequisites
 
-You must be using one of the supported daily notes plugins in order to create a daily note calendar:
+You must be using one of the supported daily notes plugins in order to create a Daily Note calendar:
 
 -   [Daily Notes core plugin](https://help.obsidian.md/Plugins/Daily+notes)
 -   [Periodic Notes community plugin](https://github.com/liamcain/obsidian-periodic-notes)
--   [Journals community plugin](https://github.com/srg-kostyrko/obsidian-journal) with a **Day** journal configured
+
+To use the Obsidian Journals community plugin instead, add a separate [Journals calendar](journals.md).
 
 ## Configuring the Daily Notes calendar
 
-Add either a **Daily Note** calendar for core Daily Notes/Periodic Notes or a separate **Journals** calendar for an Obsidian Journals Day journal. Then choose:
+Add a **Daily Note** calendar for core Daily Notes or Periodic Notes. Then choose:
 
-- the Day journal to use when Journals is selected
 - which heading from the configured template or templates events should be placed under
 - which write format timed events should use
-
-Journals is optional. When selected, Full Calendar asks the chosen Day journal to resolve and create entries, preserving its normal folder, filename, template, and journal frontmatter behavior. Obsidian's core Daily Notes plugin can be disabled in this setup.
-
-One core Daily Note calendar and multiple Journals calendars can coexist. Add a separate Journals calendar for each Day journal you want to expose in Full Calendar.
 
 If your template does not have any headings, then you can enter free-form text to specify the heading that events will be placed under.
 

--- a/docs/user/calendars/index.md
+++ b/docs/user/calendars/index.md
@@ -9,6 +9,7 @@
 |---|---|---|
 | Editable markdown-backed events | [Full Note Calendar](local.md) | Best for rich event metadata and file-level control |
 | Compact planning in daily notes | [Daily Note Calendar](dailynote.md) | Fast, lightweight, and daily-note-native |
+| Planning in Journals Day entries | [Journals Calendar](journals.md) | Uses a selected Journals Day journal's normal note creation behavior |
 | External calendar sync | [Google Calendar](gcal.md), [Google Tasks](gtasks.md), [Outlook Calendar](outlook.md), [CalDAV](caldav.md), [ICS](ics.md) | Connect existing external schedules |
 | Tasks as schedulable blocks | [Tasks Plugin Integration](tasks-plugin-integration.md) | Pull tasks into calendar planning flow |
 | Read-only table/bases source | [Obsidian Bases Calendar](bases.md) | Display data-oriented calendar views |
@@ -17,7 +18,8 @@
 
 ## Source Directory
 
-Local editable: [Full Note](local.md), [Daily Note](dailynote.md)  
+Local editable: [Full Note](local.md), [Daily Note](dailynote.md), [Journals](journals.md)
+
 Remote/external: [ICS](ics.md), [CalDAV](caldav.md), [Google](gcal.md), [Google Tasks](gtasks.md), [Outlook](outlook.md)  
 Integrations: [Tasks](tasks-plugin-integration.md), [TaskNotes](tasknotes.md), [Bases](bases.md), [ActivityWatch](activitywatch.md), [Holidays](holidays.md)
 
@@ -27,4 +29,4 @@ Integrations: [Tasks](tasks-plugin-integration.md), [TaskNotes](tasknotes.md), [
 - [Working with Events](../events/index.md)
 - [Troubleshooting](../guides/troubleshooting.md)
 
-Compact index: [Full Note](local.md) · [Daily Note](dailynote.md) · [ICS](ics.md) · [CalDAV](caldav.md) · [Google](gcal.md) · [Google Tasks](gtasks.md) · [Outlook](outlook.md) · [Holidays](holidays.md) · [Tasks](tasks-plugin-integration.md) · [TaskNotes](tasknotes.md) · [Bases](bases.md) · [ActivityWatch](activitywatch.md) · [Architecture](../../architecture/calendars/architecture.md)
+Compact index: [Full Note](local.md) · [Daily Note](dailynote.md) · [Journals](journals.md) · [ICS](ics.md) · [CalDAV](caldav.md) · [Google](gcal.md) · [Google Tasks](gtasks.md) · [Outlook](outlook.md) · [Holidays](holidays.md) · [Tasks](tasks-plugin-integration.md) · [TaskNotes](tasknotes.md) · [Bases](bases.md) · [ActivityWatch](activitywatch.md) · [Architecture](../../architecture/calendars/architecture.md)

--- a/docs/user/calendars/journals.md
+++ b/docs/user/calendars/journals.md
@@ -1,0 +1,63 @@
+# Journals Calendar
+
+Use a **Journals** calendar to store Full Calendar events inside entries managed by the [Obsidian Journals community plugin](https://github.com/srg-kostyrko/obsidian-journal). Each calendar connects to one Journals **Day** journal and writes events beneath a configured heading.
+
+## Requirements
+
+- Install and enable the Obsidian Journals community plugin.
+- Configure at least one **Day** journal in Journals.
+- Obsidian's core Daily Notes plugin is not required when you use this calendar source.
+
+## Add a Journals calendar
+
+1. Open **Full Calendar settings**.
+2. Open **Manage Calendars**.
+3. Select **Journals** as the calendar type and click the add button.
+4. Select the **Day journal** Full Calendar should use.
+5. Choose or enter the **Heading** where events should be written.
+6. Select the timed-event **Format**, then add the calendar.
+
+When the selected journal's templates contain headings, Full Calendar offers them in the Heading dropdown. You can also enter a heading manually and change it later from the configured calendar row.
+
+## How entries and events are stored
+
+Full Calendar asks the selected Day journal for the entry that matches the event date:
+
+- If the entry already exists, Full Calendar preserves its contents and adds only the event.
+- If the entry does not exist, Journals creates it using that journal's configured folder, filename and date formatting, templates, and frontmatter or journal metadata.
+
+After resolving the entry, Full Calendar uses its normal date-note event format and heading behavior. For example, when the configured heading is `Schedule`, events are written beneath:
+
+```markdown
+## Schedule
+```
+
+If that heading is missing, Full Calendar appends it to the entry before adding the event.
+
+## Multiple Journals calendars
+
+You can add multiple Journals calendars and connect each one to a different Day journal. For example:
+
+- `Journals: Music`
+- `Journals: PHD`
+
+Each calendar keeps its own selected journal, heading, color, and other calendar settings.
+
+## Journals or Daily Note?
+
+| Calendar source | Date-note provider | Instance limit |
+| --- | --- | --- |
+| **Daily Note** | Obsidian Daily Notes or Periodic Notes | One Daily Note calendar |
+| **Journals** | A selected Journals Day journal | Multiple Journals calendars |
+
+The two source types may coexist. Journals calendars do not count against the one-Daily-Note-calendar limit.
+
+## Limitations and troubleshooting
+
+- Journals must remain installed and enabled.
+- Only Journals **Day** journals can be selected.
+- If the selected Day journal is renamed or deleted, remove or reconfigure the affected Full Calendar source.
+- Recurring events and multi-day single events are not supported by date-note calendars; use a [Full Note calendar](local.md) for those events.
+- Duplicate event titles on the same date are not supported within one Journals calendar.
+
+[Daily Note Calendar](dailynote.md) · [Working with Events](../events/index.md) · [Troubleshooting](../guides/troubleshooting.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
                 - user/calendars/index.md
                 - Full Note Calendar: user/calendars/local.md
                 - Daily Note Calendar: user/calendars/dailynote.md
+                - Journals Calendar: user/calendars/journals.md
                 - ICS (Remote and Local): user/calendars/ics.md
                 - CalDAV: user/calendars/caldav.md
                 - Google Calendar: user/calendars/gcal.md

--- a/src/features/availability/AvailabilityShareModal.ts
+++ b/src/features/availability/AvailabilityShareModal.ts
@@ -192,7 +192,7 @@ export class AvailabilityShareModal extends Modal {
             displayName = `${t('modals.workspace.calendarTypes.dailyNotes') || 'Daily Notes:'} ${source.name}`;
             break;
           case 'journals':
-            displayName = `${t('modals.workspace.calendarTypes.journals')} ${source.name}`;
+            displayName = source.name;
             break;
           case 'ical':
             displayName = `${t('modals.workspace.calendarTypes.ics') || 'ICS:'} ${source.name}`;

--- a/src/features/availability/AvailabilityShareModal.ts
+++ b/src/features/availability/AvailabilityShareModal.ts
@@ -191,6 +191,9 @@ export class AvailabilityShareModal extends Modal {
           case 'dailynote':
             displayName = `${t('modals.workspace.calendarTypes.dailyNotes') || 'Daily Notes:'} ${source.name}`;
             break;
+          case 'journals':
+            displayName = `${t('modals.workspace.calendarTypes.journals')} ${source.name}`;
+            break;
           case 'ical':
             displayName = `${t('modals.workspace.calendarTypes.ics') || 'ICS:'} ${source.name}`;
             break;

--- a/src/features/export/IcsExportModal.ts
+++ b/src/features/export/IcsExportModal.ts
@@ -94,6 +94,9 @@ export class IcsExportModal extends Modal {
           case 'dailynote':
             displayName = `${t('modals.workspace.calendarTypes.dailyNotes') || 'Daily Notes:'} ${source.name}`;
             break;
+          case 'journals':
+            displayName = `${t('modals.workspace.calendarTypes.journals')} ${source.name}`;
+            break;
           case 'ical':
             displayName = `${t('modals.workspace.calendarTypes.ics') || 'ICS:'} ${source.name}`;
             break;

--- a/src/features/export/IcsExportModal.ts
+++ b/src/features/export/IcsExportModal.ts
@@ -95,7 +95,7 @@ export class IcsExportModal extends Modal {
             displayName = `${t('modals.workspace.calendarTypes.dailyNotes') || 'Daily Notes:'} ${source.name}`;
             break;
           case 'journals':
-            displayName = `${t('modals.workspace.calendarTypes.journals')} ${source.name}`;
+            displayName = source.name;
             break;
           case 'ical':
             displayName = `${t('modals.workspace.calendarTypes.ics') || 'ICS:'} ${source.name}`;

--- a/src/features/i18n/locales/de.json
+++ b/src/features/i18n/locales/de.json
@@ -806,7 +806,8 @@
         "tasks": "Tasks-Integration",
         "bases": "Bases-Kalender",
         "taskNotes": "TaskNote-Integration",
-        "outlook": "Outlook-Kalender"
+        "outlook": "Outlook-Kalender",
+        "journals": "Journals calendar"
       },
       "linkedNotes": {
         "title": "Einstellungen für verknüpfte Notizen",

--- a/src/features/i18n/locales/de.json
+++ b/src/features/i18n/locales/de.json
@@ -668,7 +668,8 @@
       "addCalendarTooltip": "Kalender hinzufügen",
       "defaults": {
         "iCloud": "iCloud-Kalender",
-        "new": "Neuer {{type}} Kalender"
+        "new": "Neuer {{type}} Kalender",
+        "journals": "Journals"
       },
       "types": {
         "local": "Vollständige Notiz",
@@ -681,7 +682,8 @@
         "bases": "Obsidian Bases",
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
-        "holidays": "Holidays"
+        "holidays": "Holidays",
+        "journals": "Journals"
       },
       "fullNote": {
         "directory": {
@@ -704,7 +706,9 @@
       "dailyNote": {
         "heading": {
           "label": "Überschrift",
-          "description": "Überschrift zum Speichern von Ereignissen in der Tagesnotiz."
+          "description": "Überschrift zum Speichern von Ereignissen in der Tagesnotiz.",
+          "summary": "in daily notes",
+          "journalSummary": "in journal entries"
         },
         "format": {
           "label": "Format",
@@ -713,6 +717,19 @@
             "default": "Standard",
             "dayPlanner": "DayPlanner-Format"
           }
+        },
+        "provider": {
+          "options": {
+            "dailyNotes": "Daily Notes / Periodic Notes",
+            "journals": "Journals"
+          }
+        },
+        "journal": {
+          "label": "Day journal",
+          "description": "Select the Journals Day journal to use.",
+          "select": "Select a Day journal",
+          "unavailable": "Install and enable the Journals plugin to use this provider.",
+          "none": "Configure a Day journal in Journals before adding this calendar."
         }
       },
       "ics": {

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -819,9 +819,25 @@
         }
       },
       "dailyNote": {
+        "provider": {
+          "label": "Daily note provider",
+          "description": "Choose which plugin resolves and creates notes for this calendar.",
+          "options": {
+            "dailyNotes": "Daily Notes / Periodic Notes",
+            "journals": "Journals"
+          }
+        },
+        "journal": {
+          "label": "Day journal",
+          "description": "Select the Journals Day journal to use.",
+          "select": "Select a Day journal",
+          "unavailable": "Install and enable the Journals plugin to use this provider.",
+          "none": "Configure a Day journal in Journals before adding this calendar."
+        },
         "heading": {
           "label": "Heading",
-          "description": "Heading to store events under in the daily note."
+          "description": "Heading to store events under in the daily note.",
+          "summary": "in daily notes"
         },
         "format": {
           "label": "Format",

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -785,11 +785,13 @@
       },
       "defaults": {
         "iCloud": "iCloud Calendar",
-        "new": "New {{type}} Calendar"
+        "new": "New {{type}} Calendar",
+        "journals": "Journals"
       },
       "types": {
         "local": "Full note",
         "dailynote": "Daily Note",
+        "journals": "Journals",
         "icloud": "iCloud",
         "caldav": "CalDAV",
         "ical": "ICS",
@@ -820,8 +822,6 @@
       },
       "dailyNote": {
         "provider": {
-          "label": "Daily note provider",
-          "description": "Choose which plugin resolves and creates notes for this calendar.",
           "options": {
             "dailyNotes": "Daily Notes / Periodic Notes",
             "journals": "Journals"

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -1490,6 +1490,7 @@
       "calendarTypes": {
         "local": "Local:",
         "dailyNotes": "Daily Notes:",
+        "journals": "Journals:",
         "ics": "ICS:",
         "caldav": "CalDAV:",
         "google": "Google:",

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -958,6 +958,7 @@
         "providerGuides": "Provider guides: ",
         "fullNote": "Full Note calendar",
         "dailyNote": "Daily Note calendar",
+        "journals": "Journals calendar",
         "ics": "ICS calendars",
         "caldav": "CalDAV calendars",
         "google": "Google calendar",

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -836,8 +836,9 @@
         },
         "heading": {
           "label": "Heading",
-          "description": "Heading to store events under in the daily note.",
-          "summary": "in daily notes"
+          "description": "Heading to store events under in each date note.",
+          "summary": "in daily notes",
+          "journalSummary": "in journal entries"
         },
         "format": {
           "label": "Format",
@@ -1490,7 +1491,6 @@
       "calendarTypes": {
         "local": "Local:",
         "dailyNotes": "Daily Notes:",
-        "journals": "Journals:",
         "ics": "ICS:",
         "caldav": "CalDAV:",
         "google": "Google:",

--- a/src/features/i18n/locales/es.json
+++ b/src/features/i18n/locales/es.json
@@ -668,7 +668,8 @@
       "addCalendarTooltip": "Agregar calendario",
       "defaults": {
         "iCloud": "Calendario iCloud",
-        "new": "Nuevo calendario {{type}}"
+        "new": "Nuevo calendario {{type}}",
+        "journals": "Journals"
       },
       "types": {
         "local": "Nota completa",
@@ -681,7 +682,8 @@
         "bases": "Obsidian Bases",
         "tasknotes": "TaskNotes",
         "outlook": "Calendario de Outlook",
-        "holidays": "Festivos"
+        "holidays": "Festivos",
+        "journals": "Journals"
       },
       "fullNote": {
         "directory": {
@@ -704,7 +706,9 @@
       "dailyNote": {
         "heading": {
           "label": "Encabezado",
-          "description": "Encabezado para almacenar eventos en la nota diaria."
+          "description": "Encabezado para almacenar eventos en la nota diaria.",
+          "summary": "in daily notes",
+          "journalSummary": "in journal entries"
         },
         "format": {
           "label": "Format",
@@ -713,6 +717,19 @@
             "default": "Default",
             "dayPlanner": "DayPlanner Format"
           }
+        },
+        "provider": {
+          "options": {
+            "dailyNotes": "Daily Notes / Periodic Notes",
+            "journals": "Journals"
+          }
+        },
+        "journal": {
+          "label": "Day journal",
+          "description": "Select the Journals Day journal to use.",
+          "select": "Select a Day journal",
+          "unavailable": "Install and enable the Journals plugin to use this provider.",
+          "none": "Configure a Day journal in Journals before adding this calendar."
         }
       },
       "ics": {

--- a/src/features/i18n/locales/es.json
+++ b/src/features/i18n/locales/es.json
@@ -806,7 +806,8 @@
         "tasks": "Integración de Tasks",
         "bases": "Calendario de Bases",
         "taskNotes": "Integración de TaskNote",
-        "outlook": "Calendario de Outlook"
+        "outlook": "Calendario de Outlook",
+        "journals": "Journals calendar"
       },
       "linkedNotes": {
         "title": "Configuración de notas vinculadas",

--- a/src/features/i18n/locales/fr.json
+++ b/src/features/i18n/locales/fr.json
@@ -806,7 +806,8 @@
         "tasks": "Intégration Tasks",
         "bases": "Calendrier Bases",
         "taskNotes": "Intégration TaskNote",
-        "outlook": "Outlook calendar"
+        "outlook": "Outlook calendar",
+        "journals": "Journals calendar"
       },
       "linkedNotes": {
         "title": "Paramètres des notes liées",

--- a/src/features/i18n/locales/fr.json
+++ b/src/features/i18n/locales/fr.json
@@ -668,7 +668,8 @@
       "addCalendarTooltip": "Ajouter un calendrier",
       "defaults": {
         "iCloud": "Calendrier iCloud",
-        "new": "Nouveau calendrier {{type}}"
+        "new": "Nouveau calendrier {{type}}",
+        "journals": "Journals"
       },
       "types": {
         "local": "Note complète",
@@ -681,7 +682,8 @@
         "bases": "Obsidian Bases",
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
-        "holidays": "Holidays"
+        "holidays": "Holidays",
+        "journals": "Journals"
       },
       "fullNote": {
         "directory": {
@@ -704,7 +706,9 @@
       "dailyNote": {
         "heading": {
           "label": "En-tête",
-          "description": "En-tête sous lequel stocker les événements dans la note quotidienne."
+          "description": "En-tête sous lequel stocker les événements dans la note quotidienne.",
+          "summary": "in daily notes",
+          "journalSummary": "in journal entries"
         },
         "format": {
           "label": "Format",
@@ -713,6 +717,19 @@
             "default": "Default",
             "dayPlanner": "DayPlanner Format"
           }
+        },
+        "provider": {
+          "options": {
+            "dailyNotes": "Daily Notes / Periodic Notes",
+            "journals": "Journals"
+          }
+        },
+        "journal": {
+          "label": "Day journal",
+          "description": "Select the Journals Day journal to use.",
+          "select": "Select a Day journal",
+          "unavailable": "Install and enable the Journals plugin to use this provider.",
+          "none": "Configure a Day journal in Journals before adding this calendar."
         }
       },
       "ics": {

--- a/src/features/i18n/locales/it.json
+++ b/src/features/i18n/locales/it.json
@@ -806,7 +806,8 @@
         "tasks": "Integrazione Tasks",
         "bases": "Calendario Bases",
         "taskNotes": "Integrazione TaskNote",
-        "outlook": "Outlook calendar"
+        "outlook": "Outlook calendar",
+        "journals": "Journals calendar"
       },
       "linkedNotes": {
         "title": "Impostazioni note collegate",

--- a/src/features/i18n/locales/it.json
+++ b/src/features/i18n/locales/it.json
@@ -668,7 +668,8 @@
       "addCalendarTooltip": "Aggiungi Calendario",
       "defaults": {
         "iCloud": "Calendario iCloud",
-        "new": "Nuovo calendario {{type}}"
+        "new": "Nuovo calendario {{type}}",
+        "journals": "Journals"
       },
       "types": {
         "local": "Nota completa",
@@ -681,7 +682,8 @@
         "bases": "Obsidian Bases",
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
-        "holidays": "Holidays"
+        "holidays": "Holidays",
+        "journals": "Journals"
       },
       "fullNote": {
         "directory": {
@@ -704,7 +706,9 @@
       "dailyNote": {
         "heading": {
           "label": "Intestazione",
-          "description": "Intestazione sotto cui salvare gli eventi nella nota giornaliera."
+          "description": "Intestazione sotto cui salvare gli eventi nella nota giornaliera.",
+          "summary": "in daily notes",
+          "journalSummary": "in journal entries"
         },
         "format": {
           "label": "Format",
@@ -713,6 +717,19 @@
             "default": "Default",
             "dayPlanner": "DayPlanner Format"
           }
+        },
+        "provider": {
+          "options": {
+            "dailyNotes": "Daily Notes / Periodic Notes",
+            "journals": "Journals"
+          }
+        },
+        "journal": {
+          "label": "Day journal",
+          "description": "Select the Journals Day journal to use.",
+          "select": "Select a Day journal",
+          "unavailable": "Install and enable the Journals plugin to use this provider.",
+          "none": "Configure a Day journal in Journals before adding this calendar."
         }
       },
       "ics": {

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -668,7 +668,8 @@
       "addCalendarTooltip": "添加日历",
       "defaults": {
         "iCloud": "iCloud 日历",
-        "new": "新建 {{type}} 日历"
+        "new": "新建 {{type}} 日历",
+        "journals": "Journals"
       },
       "types": {
         "local": "完整笔记",
@@ -681,7 +682,8 @@
         "bases": "Obsidian Bases",
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
-        "holidays": "Holidays"
+        "holidays": "Holidays",
+        "journals": "Journals"
       },
       "fullNote": {
         "directory": {
@@ -704,7 +706,9 @@
       "dailyNote": {
         "heading": {
           "label": "标题",
-          "description": "日记中存储事件的标题。"
+          "description": "日记中存储事件的标题。",
+          "summary": "in daily notes",
+          "journalSummary": "in journal entries"
         },
         "format": {
           "label": "格式",
@@ -713,6 +717,19 @@
             "default": "默认",
             "dayPlanner": "日程计划格式"
           }
+        },
+        "provider": {
+          "options": {
+            "dailyNotes": "Daily Notes / Periodic Notes",
+            "journals": "Journals"
+          }
+        },
+        "journal": {
+          "label": "Day journal",
+          "description": "Select the Journals Day journal to use.",
+          "select": "Select a Day journal",
+          "unavailable": "Install and enable the Journals plugin to use this provider.",
+          "none": "Configure a Day journal in Journals before adding this calendar."
         }
       },
       "ics": {

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -806,7 +806,8 @@
         "tasks": "Tasks 集成",
         "bases": "Bases 日历",
         "taskNotes": "TaskNotes 集成",
-        "outlook": "Outlook 日历"
+        "outlook": "Outlook 日历",
+        "journals": "Journals calendar"
       },
       "linkedNotes": {
         "title": "链接笔记设置",

--- a/src/features/milestones/monthlyReport.ts
+++ b/src/features/milestones/monthlyReport.ts
@@ -98,6 +98,7 @@ function buildCalendarsTable(
   const friendlyNames: Record<string, string> = {
     local: 'Local Vault Files',
     dailynote: 'Daily Notes Calendar',
+    journals: 'Journals Calendar',
     ical: 'iCal External Feeds',
     caldav: 'CalDAV Calendar',
     google: 'Google Calendar',

--- a/src/features/workspaces/ui/WorkspaceModal.ts
+++ b/src/features/workspaces/ui/WorkspaceModal.ts
@@ -209,6 +209,9 @@ export class WorkspaceModal extends Modal {
         case 'dailynote':
           displayName = `${t('modals.workspace.calendarTypes.dailyNotes')} ${calendar.name}`;
           break;
+        case 'journals':
+          displayName = `${t('modals.workspace.calendarTypes.journals')} ${calendar.name}`;
+          break;
         case 'ical':
           displayName = `${t('modals.workspace.calendarTypes.ics')} ${calendar.name}`;
           break;

--- a/src/features/workspaces/ui/WorkspaceModal.ts
+++ b/src/features/workspaces/ui/WorkspaceModal.ts
@@ -210,7 +210,7 @@ export class WorkspaceModal extends Modal {
           displayName = `${t('modals.workspace.calendarTypes.dailyNotes')} ${calendar.name}`;
           break;
         case 'journals':
-          displayName = `${t('modals.workspace.calendarTypes.journals')} ${calendar.name}`;
+          displayName = calendar.name;
           break;
         case 'ical':
           displayName = `${t('modals.workspace.calendarTypes.ics')} ${calendar.name}`;

--- a/src/providers/Provider.ts
+++ b/src/providers/Provider.ts
@@ -1,5 +1,10 @@
 import { OFCEvent, EventLocation } from '../types';
-import { EventHandle, ProviderConfigContext, FCReactComponent } from './typesProvider';
+import {
+  EventHandle,
+  ProviderConfigContext,
+  FCReactComponent,
+  ProviderSettingsRowProps
+} from './typesProvider';
 import type FullCalendarPlugin from '../main';
 import { LivePreviewDecorator } from '../features/livepreview/LivePreviewDecorator';
 
@@ -170,9 +175,7 @@ export interface CalendarProvider<TConfig> {
     onClose: () => void;
   }>;
 
-  getSettingsRowComponent(): FCReactComponent<{
-    source: Partial<import('../types').CalendarInfo>;
-  }>;
+  getSettingsRowComponent(): FCReactComponent<ProviderSettingsRowProps>;
 
   getEditorDecorator?(): LivePreviewDecorator;
 }

--- a/src/providers/ProviderRegistry.ts
+++ b/src/providers/ProviderRegistry.ts
@@ -111,6 +111,7 @@ export class ProviderRegistry {
   public registerBuiltInProviders(): void {
     this.register('local', () => import('./fullnote/FullNoteProvider'));
     this.register('dailynote', () => import('./dailynote/DailyNoteProvider'));
+    this.register('journals', () => import('./journals/JournalsProvider'));
     this.register('ical', () => import('./ics/ICSProvider'));
     this.register('caldav', () => import('./caldav/CalDAVProvider'));
     this.register('google', () => import('./google/GoogleProvider'));

--- a/src/providers/dailynote/DailyNoteConfigComponent.tsx
+++ b/src/providers/dailynote/DailyNoteConfigComponent.tsx
@@ -53,8 +53,10 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
     if (!heading || (provider === 'journals' && !journalId)) return;
 
     setIsSubmitting(true);
+    const configWithoutLegacyProvider = { ...config };
+    delete configWithoutLegacyProvider.provider;
     onSave({
-      ...config,
+      ...configWithoutLegacyProvider,
       id: config.id || '',
       heading,
       format,

--- a/src/providers/dailynote/DailyNoteConfigComponent.tsx
+++ b/src/providers/dailynote/DailyNoteConfigComponent.tsx
@@ -10,7 +10,11 @@ import {
 import { ProviderConfigContext } from '../typesProvider';
 import { t } from '../../features/i18n/i18n';
 import type FullCalendarPlugin from '../../main';
-import { getJournalsDayJournals, getJournalsPlugin } from './DailyNoteSourceAdapter';
+import {
+  getJournalsDayJournals,
+  getJournalsPlugin,
+  getJournalsTemplateHeadings
+} from './DailyNoteSourceAdapter';
 
 interface DailyNoteConfigComponentProps {
   plugin: FullCalendarPlugin;
@@ -31,15 +35,17 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
 }) => {
   const [heading, setHeading] = React.useState(config.heading || '');
   const [format, setFormat] = React.useState<DailyNoteEventFormat>(getDailyNoteEventFormat(config));
-  const [provider, setProvider] = React.useState<DailyNoteSourceProvider>(
-    getDailyNoteSourceProvider(config)
-  );
+  const provider: DailyNoteSourceProvider = getDailyNoteSourceProvider(config);
   const journalsPlugin = getJournalsPlugin(plugin.app);
   const dayJournals = getJournalsDayJournals(plugin.app);
   const initialJournalId =
     config.journalId ||
     (provider === 'journals' && dayJournals.length === 1 ? dayJournals[0].name : '');
   const [journalId, setJournalId] = React.useState(initialJournalId);
+  const availableHeadings =
+    provider === 'journals' && journalId
+      ? getJournalsTemplateHeadings(plugin.app, journalId)
+      : context.headings;
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
@@ -59,45 +65,6 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
 
   return (
     <form onSubmit={handleSubmit}>
-      <div className="setting-item">
-        <div className="setting-item-info">
-          <div className="setting-item-name">
-            {t('settings.calendars.dailyNote.provider.label')}
-          </div>
-          <div className="setting-item-description">
-            {t('settings.calendars.dailyNote.provider.description')}
-          </div>
-        </div>
-        <div className="setting-item-control">
-          <select
-            className="dropdown"
-            value={provider}
-            onChange={e => {
-              const nextProvider = e.target.value as DailyNoteSourceProvider;
-              const nextJournalId =
-                nextProvider === 'journals' && dayJournals.length === 1
-                  ? dayJournals[0].name
-                  : journalId;
-              setProvider(nextProvider);
-              setJournalId(nextJournalId);
-              onConfigChange({
-                ...config,
-                heading,
-                format,
-                provider: nextProvider,
-                journalId: nextJournalId || undefined
-              });
-            }}
-          >
-            <option value="daily-notes">
-              {t('settings.calendars.dailyNote.provider.options.dailyNotes')}
-            </option>
-            <option value="journals">
-              {t('settings.calendars.dailyNote.provider.options.journals')}
-            </option>
-          </select>
-        </div>
-      </div>
       {provider === 'journals' && (
         <div className="setting-item">
           <div className="setting-item-info">
@@ -146,7 +113,7 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
               setHeading(newValue);
               onConfigChange({ ...config, heading: newValue });
             }}
-            headings={context.headings}
+            headings={availableHeadings}
           />
         </div>
       </div>

--- a/src/providers/dailynote/DailyNoteConfigComponent.tsx
+++ b/src/providers/dailynote/DailyNoteConfigComponent.tsx
@@ -3,12 +3,17 @@ import { HeadingInput } from '../../ui/components/forms/HeadingInput';
 import {
   DailyNoteProviderConfig,
   DailyNoteEventFormat,
-  getDailyNoteEventFormat
+  DailyNoteSourceProvider,
+  getDailyNoteEventFormat,
+  getDailyNoteSourceProvider
 } from './typesDaily';
 import { ProviderConfigContext } from '../typesProvider';
 import { t } from '../../features/i18n/i18n';
+import type FullCalendarPlugin from '../../main';
+import { getJournalsDayJournals, getJournalsPlugin } from './DailyNoteSourceAdapter';
 
 interface DailyNoteConfigComponentProps {
+  plugin: FullCalendarPlugin;
   config: Partial<DailyNoteProviderConfig>;
   onConfigChange: (newConfig: Partial<DailyNoteProviderConfig>) => void;
   context: ProviderConfigContext;
@@ -17,6 +22,7 @@ interface DailyNoteConfigComponentProps {
 }
 
 export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> = ({
+  plugin,
   config,
   onConfigChange,
   context,
@@ -25,18 +31,107 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
 }) => {
   const [heading, setHeading] = React.useState(config.heading || '');
   const [format, setFormat] = React.useState<DailyNoteEventFormat>(getDailyNoteEventFormat(config));
+  const [provider, setProvider] = React.useState<DailyNoteSourceProvider>(
+    getDailyNoteSourceProvider(config)
+  );
+  const journalsPlugin = getJournalsPlugin(plugin.app);
+  const dayJournals = getJournalsDayJournals(plugin.app);
+  const initialJournalId =
+    config.journalId ||
+    (provider === 'journals' && dayJournals.length === 1 ? dayJournals[0].name : '');
+  const [journalId, setJournalId] = React.useState(initialJournalId);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 
   const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!heading) return;
+    if (!heading || (provider === 'journals' && !journalId)) return;
 
     setIsSubmitting(true);
-    onSave({ ...config, id: config.id || '', heading, format });
+    onSave({
+      ...config,
+      id: config.id || '',
+      heading,
+      format,
+      provider,
+      journalId: journalId || undefined
+    });
   };
 
   return (
     <form onSubmit={handleSubmit}>
+      <div className="setting-item">
+        <div className="setting-item-info">
+          <div className="setting-item-name">
+            {t('settings.calendars.dailyNote.provider.label')}
+          </div>
+          <div className="setting-item-description">
+            {t('settings.calendars.dailyNote.provider.description')}
+          </div>
+        </div>
+        <div className="setting-item-control">
+          <select
+            className="dropdown"
+            value={provider}
+            onChange={e => {
+              const nextProvider = e.target.value as DailyNoteSourceProvider;
+              const nextJournalId =
+                nextProvider === 'journals' && dayJournals.length === 1
+                  ? dayJournals[0].name
+                  : journalId;
+              setProvider(nextProvider);
+              setJournalId(nextJournalId);
+              onConfigChange({
+                ...config,
+                heading,
+                format,
+                provider: nextProvider,
+                journalId: nextJournalId || undefined
+              });
+            }}
+          >
+            <option value="daily-notes">
+              {t('settings.calendars.dailyNote.provider.options.dailyNotes')}
+            </option>
+            <option value="journals">
+              {t('settings.calendars.dailyNote.provider.options.journals')}
+            </option>
+          </select>
+        </div>
+      </div>
+      {provider === 'journals' && (
+        <div className="setting-item">
+          <div className="setting-item-info">
+            <div className="setting-item-name">
+              {t('settings.calendars.dailyNote.journal.label')}
+            </div>
+            <div className="setting-item-description">
+              {!journalsPlugin
+                ? t('settings.calendars.dailyNote.journal.unavailable')
+                : dayJournals.length === 0
+                  ? t('settings.calendars.dailyNote.journal.none')
+                  : t('settings.calendars.dailyNote.journal.description')}
+            </div>
+          </div>
+          <div className="setting-item-control">
+            <select
+              className="dropdown"
+              value={journalId}
+              disabled={!journalsPlugin || dayJournals.length === 0}
+              onChange={e => {
+                setJournalId(e.target.value);
+                onConfigChange({ ...config, heading, format, provider, journalId: e.target.value });
+              }}
+            >
+              <option value="">{t('settings.calendars.dailyNote.journal.select')}</option>
+              {dayJournals.map(journal => (
+                <option key={journal.name} value={journal.name}>
+                  {journal.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
       <div className="setting-item">
         <div className="setting-item-info">
           <div className="setting-item-name">{t('settings.calendars.dailyNote.heading.label')}</div>
@@ -84,7 +179,11 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
       <div className="setting-item">
         <div className="setting-item-info" />
         <div className="setting-item-control">
-          <button className="mod-cta" type="submit" disabled={isSubmitting || !heading}>
+          <button
+            className="mod-cta"
+            type="submit"
+            disabled={isSubmitting || !heading || (provider === 'journals' && !journalId)}
+          >
             {t('ui.buttons.addCalendar')}
           </button>
         </div>

--- a/src/providers/dailynote/DailyNoteProvider.ts
+++ b/src/providers/dailynote/DailyNoteProvider.ts
@@ -94,6 +94,10 @@ const DailyNoteHeadingSetting: React.FC<ProviderSettingsRowProps> = ({
     provider === 'journals'
       ? `${t('settings.calendars.dailyNote.provider.options.journals')}: ${typeof journalId === 'string' ? journalId : ''}`
       : t('settings.calendars.dailyNote.provider.options.dailyNotes');
+  const headingSummary =
+    provider === 'journals'
+      ? t('settings.calendars.dailyNote.heading.journalSummary')
+      : t('settings.calendars.dailyNote.heading.summary');
   const headings = plugin
     ? provider === 'journals' && typeof journalId === 'string'
       ? getJournalsTemplateHeadings(plugin.app, journalId)
@@ -109,11 +113,7 @@ const DailyNoteHeadingSetting: React.FC<ProviderSettingsRowProps> = ({
       headings,
       onChange: heading => onSourceChange?.({ heading })
     }),
-    React.createElement(
-      'span',
-      { className: 'ofc-heading-setting-suffix' },
-      t('settings.calendars.dailyNote.heading.summary')
-    )
+    React.createElement('span', { className: 'ofc-heading-setting-suffix' }, headingSummary)
   );
 };
 

--- a/src/providers/dailynote/DailyNoteProvider.ts
+++ b/src/providers/dailynote/DailyNoteProvider.ts
@@ -1,13 +1,5 @@
 import { CachedMetadata, moment as obsidianMoment, TFile } from 'obsidian';
 import * as React from 'react';
-import {
-  appHasDailyNotesPluginLoaded,
-  createDailyNote,
-  getAllDailyNotes,
-  getDailyNote,
-  getDailyNoteSettings,
-  getDateFromFile
-} from 'obsidian-daily-notes-interface';
 
 import {
   getAllInlineEventsFromFile,
@@ -21,6 +13,7 @@ import FullCalendarPlugin from '../../main';
 import { ObsidianInterface } from '../../ObsidianAdapter';
 import { OFCEvent, EventLocation } from '../../types';
 import { constructTitle } from '../../features/category/categoryParser';
+import { t } from '../../features/i18n/i18n';
 
 import {
   CalendarProvider,
@@ -29,7 +22,16 @@ import {
   CanonicalTitleProvider
 } from '../Provider';
 import { EventHandle, FCReactComponent, ProviderConfigContext } from '../typesProvider';
-import { DailyNoteProviderConfig, getDailyNoteEventFormat } from './typesDaily';
+import {
+  DailyNoteProviderConfig,
+  getDailyNoteEventFormat,
+  getDailyNoteSourceProvider
+} from './typesDaily';
+import {
+  DailyNoteSourceAdapter,
+  JournalsDailyNoteSourceAdapter,
+  ObsidianDailyNoteSourceAdapter
+} from './DailyNoteSourceAdapter';
 import { DailyNoteConfigComponent } from './DailyNoteConfigComponent';
 import { DailyNoteDecorator } from './codemirror/DailyNoteDecorator';
 import { LivePreviewDecorator } from '../../features/livepreview/LivePreviewDecorator';
@@ -75,17 +77,28 @@ const DailyNoteHeadingSetting: React.FC<{
     return typeof flat === 'string' ? flat : typeof nested === 'string' ? nested : '';
   };
 
+  const provider = (source as { provider?: unknown }).provider;
+  const journalId = (source as { journalId?: unknown }).journalId;
+  const sourceLabel =
+    provider === 'journals'
+      ? `${t('settings.calendars.dailyNote.provider.options.journals')}: ${typeof journalId === 'string' ? journalId : ''}`
+      : t('settings.calendars.dailyNote.provider.options.dailyNotes');
+
   return React.createElement(
     'div',
     { className: 'setting-item-control ofc-heading-setting-control' },
-    React.createElement('span', {}, 'Under heading'),
+    React.createElement('span', {}, sourceLabel),
     React.createElement('input', {
       disabled: true,
       type: 'text',
       value: getHeading(),
       className: 'ofc-setting-input is-inline'
     }),
-    React.createElement('span', { className: 'ofc-heading-setting-suffix' }, 'in daily notes')
+    React.createElement(
+      'span',
+      { className: 'ofc-heading-setting-suffix' },
+      t('settings.calendars.dailyNote.heading.summary')
+    )
   );
 };
 
@@ -122,6 +135,7 @@ export class DailyNoteProvider
   private app: ObsidianInterface;
   private plugin: FullCalendarPlugin;
   private source: DailyNoteProviderConfig;
+  private noteSource: DailyNoteSourceAdapter;
 
   readonly type = 'dailynote';
   readonly displayName = 'Daily Note';
@@ -136,10 +150,13 @@ export class DailyNoteProvider
     if (!app) {
       throw new Error('DailyNoteProvider requires an Obsidian app interface.');
     }
-    appHasDailyNotesPluginLoaded();
     this.app = app;
     this.plugin = plugin;
     this.source = { ...source, format: getDailyNoteEventFormat(source) };
+    this.noteSource =
+      getDailyNoteSourceProvider(source) === 'journals'
+        ? new JournalsDailyNoteSourceAdapter(plugin.app, source)
+        : new ObsidianDailyNoteSourceAdapter();
   }
 
   getCapabilities(): CalendarProviderCapabilities {
@@ -171,7 +188,7 @@ export class DailyNoteProvider
       const persistentId = this._persistentIdForEvent(event);
       if (!persistentId) return null;
       const m = moment(event.date);
-      const file = getDailyNote(m, getAllDailyNotes());
+      const file = this.noteSource.getExistingFileForDate(event.date, m);
       if (!file || !(file instanceof TFile)) return null;
       return { persistentId, location: { path: file.path } };
     }
@@ -192,9 +209,7 @@ export class DailyNoteProvider
   }
 
   public isFileRelevant(file: TFile): boolean {
-    // Encapsulates the logic of checking the daily note folder.
-    const { folder } = getDailyNoteSettings();
-    return folder ? file.path.startsWith(`${folder}/`) : true;
+    return this.noteSource.isFileRelevant(file);
   }
 
   getCanonicalTitle(event: OFCEvent): string {
@@ -206,7 +221,7 @@ export class DailyNoteProvider
 
     const content = await this.app.read(file);
     const lines = content.split('\n');
-    const date = getDateFromFile(file, 'day')?.format('YYYY-MM-DD');
+    const date = this.noteSource.getDateForFile(file);
 
     const usedUids = new Set<number>();
 
@@ -233,7 +248,7 @@ export class DailyNoteProvider
   ): Promise<number> {
     const content = await this.app.read(file);
     const lines = content.split('\n');
-    const date = getDateFromFile(file, 'day')?.format('YYYY-MM-DD');
+    const date = this.noteSource.getDateForFile(file);
 
     // It's possible for a daily note file to not have a date in its title.
     // In that case, we cannot reliably parse events from it.
@@ -272,7 +287,7 @@ export class DailyNoteProvider
   }
 
   public async getEventsInFile(file: TFile): Promise<EditableEventResponse[]> {
-    const date = getDateFromFile(file, 'day')?.format('YYYY-MM-DD');
+    const date = this.noteSource.getDateForFile(file) ?? undefined;
     const cache = await waitForMetadataWithTimeout(this.app, file);
     if (!cache) {
       return [];
@@ -289,18 +304,18 @@ export class DailyNoteProvider
   }
 
   async getEvents(range?: { start: Date; end: Date }): Promise<EditableEventResponse[]> {
-    const notes = getAllDailyNotes();
-    let files = Object.values(notes);
+    let files = this.noteSource.getAllFiles();
 
     // OPTIMIZATION: If a range is provided, only process daily notes within that range.
     if (range) {
       const startMoment = moment(range.start);
       const endMoment = moment(range.end);
       files = files.filter(file => {
-        const fileDate = getDateFromFile(file, 'day');
-        return (
-          fileDate && fileDate.isSameOrAfter(startMoment) && fileDate.isSameOrBefore(endMoment)
-        );
+        const fileDate = this.noteSource.getDateForFile(file);
+        return fileDate
+          ? fileDate >= startMoment.format('YYYY-MM-DD') &&
+              fileDate <= endMoment.format('YYYY-MM-DD')
+          : false;
       });
     }
 
@@ -314,9 +329,9 @@ export class DailyNoteProvider
     }
 
     const m = moment(event.date);
-    let file = getDailyNote(m, getAllDailyNotes());
+    let file = this.noteSource.getExistingFileForDate(event.date, m);
     if (!file) {
-      const createdFile = await createDailyNote(m);
+      const createdFile = await this.noteSource.getFileForDate(event.date, m, true);
       if (!createdFile) {
         throw new Error(`Failed to create daily note for date ${event.date}.`);
       }
@@ -362,14 +377,14 @@ export class DailyNoteProvider
       handle.location.lineNumber
     );
 
-    const oldDate = getDateFromFile(file, 'day')?.format('YYYY-MM-DD');
+    const oldDate = this.noteSource.getDateForFile(file);
     if (!oldDate) throw new Error(`Could not get date from file at path ${file.path}`);
 
     if (newEventData.date !== oldDate) {
       const m = moment(newEventData.date);
-      let newFile = getDailyNote(m, getAllDailyNotes());
+      let newFile = this.noteSource.getExistingFileForDate(newEventData.date, m);
       if (!newFile) {
-        const createdFile = await createDailyNote(m);
+        const createdFile = await this.noteSource.getFileForDate(newEventData.date, m, true);
         if (!createdFile) {
           throw new Error(`Failed to create daily note for date ${newEventData.date}.`);
         }

--- a/src/providers/dailynote/DailyNoteProvider.ts
+++ b/src/providers/dailynote/DailyNoteProvider.ts
@@ -87,7 +87,8 @@ const DailyNoteHeadingSetting: React.FC<ProviderSettingsRowProps> = ({
     return typeof flat === 'string' ? flat : typeof nested === 'string' ? nested : '';
   };
 
-  const provider = (source as { provider?: unknown }).provider;
+  const provider =
+    source.type === 'journals' ? 'journals' : (source as { provider?: unknown }).provider;
   const journalId = (source as { journalId?: unknown }).journalId;
   const sourceLabel =
     provider === 'journals'
@@ -139,8 +140,8 @@ export class DailyNoteProvider
   implements CalendarProvider<DailyNoteProviderConfig>, SyncKeyProvider, CanonicalTitleProvider
 {
   // Static metadata for registry
-  static readonly type = 'dailynote';
-  static readonly displayName = 'Daily Note';
+  static readonly type: string = 'dailynote';
+  static readonly displayName: string = 'Daily Note';
 
   static getConfigurationComponent(): FCReactComponent<DailyNoteConfigProps> {
     return DailyNoteConfigWrapper;
@@ -151,8 +152,8 @@ export class DailyNoteProvider
   private source: DailyNoteProviderConfig;
   private noteSource: DailyNoteSourceAdapter;
 
-  readonly type = 'dailynote';
-  readonly displayName = 'Daily Note';
+  readonly type: string = 'dailynote';
+  readonly displayName: string = 'Daily Note';
   readonly isRemote = false;
   readonly loadPriority = 120;
 
@@ -168,7 +169,7 @@ export class DailyNoteProvider
     this.plugin = plugin;
     this.source = { ...source, format: getDailyNoteEventFormat(source) };
     this.noteSource =
-      getDailyNoteSourceProvider(source) === 'journals'
+      source.type === 'journals' || getDailyNoteSourceProvider(source) === 'journals'
         ? new JournalsDailyNoteSourceAdapter(plugin.app, source)
         : new ObsidianDailyNoteSourceAdapter();
   }

--- a/src/providers/dailynote/DailyNoteProvider.ts
+++ b/src/providers/dailynote/DailyNoteProvider.ts
@@ -21,7 +21,12 @@ import {
   SyncKeyProvider,
   CanonicalTitleProvider
 } from '../Provider';
-import { EventHandle, FCReactComponent, ProviderConfigContext } from '../typesProvider';
+import {
+  EventHandle,
+  FCReactComponent,
+  ProviderConfigContext,
+  ProviderSettingsRowProps
+} from '../typesProvider';
 import {
   DailyNoteProviderConfig,
   getDailyNoteEventFormat,
@@ -29,12 +34,15 @@ import {
 } from './typesDaily';
 import {
   DailyNoteSourceAdapter,
+  getJournalsTemplateHeadings,
+  getObsidianDailyNoteTemplateHeadings,
   JournalsDailyNoteSourceAdapter,
   ObsidianDailyNoteSourceAdapter
 } from './DailyNoteSourceAdapter';
 import { DailyNoteConfigComponent } from './DailyNoteConfigComponent';
 import { DailyNoteDecorator } from './codemirror/DailyNoteDecorator';
 import { LivePreviewDecorator } from '../../features/livepreview/LivePreviewDecorator';
+import { HeadingInput } from '../../ui/components/forms/HeadingInput';
 
 type MomentFactory = typeof import('moment');
 const moment = obsidianMoment as unknown as MomentFactory;
@@ -67,9 +75,11 @@ const waitForMetadataWithTimeout = async (
 };
 
 // Settings row component for Daily Note Provider
-const DailyNoteHeadingSetting: React.FC<{
-  source: Partial<import('../../types').CalendarInfo>;
-}> = ({ source }) => {
+const DailyNoteHeadingSetting: React.FC<ProviderSettingsRowProps> = ({
+  source,
+  plugin,
+  onSourceChange
+}) => {
   // Handle both flat and nested config structures for heading
   const getHeading = (): string => {
     const flat = (source as { heading?: unknown }).heading;
@@ -83,16 +93,20 @@ const DailyNoteHeadingSetting: React.FC<{
     provider === 'journals'
       ? `${t('settings.calendars.dailyNote.provider.options.journals')}: ${typeof journalId === 'string' ? journalId : ''}`
       : t('settings.calendars.dailyNote.provider.options.dailyNotes');
+  const headings = plugin
+    ? provider === 'journals' && typeof journalId === 'string'
+      ? getJournalsTemplateHeadings(plugin.app, journalId)
+      : getObsidianDailyNoteTemplateHeadings(plugin.app)
+    : [];
 
   return React.createElement(
     'div',
     { className: 'setting-item-control ofc-heading-setting-control' },
     React.createElement('span', {}, sourceLabel),
-    React.createElement('input', {
-      disabled: true,
-      type: 'text',
+    React.createElement(HeadingInput, {
       value: getHeading(),
-      className: 'ofc-setting-input is-inline'
+      headings,
+      onChange: heading => onSourceChange?.({ heading })
     }),
     React.createElement(
       'span',
@@ -461,9 +475,7 @@ export class DailyNoteProvider
     return DailyNoteConfigWrapper;
   }
 
-  getSettingsRowComponent(): FCReactComponent<{
-    source: Partial<import('../../types').CalendarInfo>;
-  }> {
+  getSettingsRowComponent(): FCReactComponent<ProviderSettingsRowProps> {
     return DailyNoteHeadingSetting;
   }
 

--- a/src/providers/dailynote/DailyNoteSourceAdapter.test.ts
+++ b/src/providers/dailynote/DailyNoteSourceAdapter.test.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   getJournalsDayJournals,
+  getJournalsTemplateHeadings,
   JournalsDailyNoteSourceAdapter,
   ObsidianDailyNoteSourceAdapter,
   type JournalsDayJournal,
@@ -40,6 +41,7 @@ const makeFile = (path: string): TFile => {
 
 type TestApp = App & {
   vault: { getFileByPath(path: string): TFile | null };
+  metadataCache: { getFileCache(file: TFile): { headings?: { heading: string }[] } | null };
   plugins: { getPlugin(id: string): unknown };
 };
 
@@ -71,9 +73,18 @@ const makeJournal = (
   })
 });
 
-const makeApp = (plugin: JournalsPluginApi | null, files = new Map<string, TFile>()): TestApp =>
+const makeApp = (
+  plugin: JournalsPluginApi | null,
+  files = new Map<string, TFile>(),
+  headingsByPath = new Map<string, string[]>()
+): TestApp =>
   ({
     vault: { getFileByPath: (path: string) => files.get(path) ?? null },
+    metadataCache: {
+      getFileCache: (file: TFile) => ({
+        headings: (headingsByPath.get(file.path) ?? []).map(heading => ({ heading }))
+      })
+    },
     plugins: { getPlugin: (id: string) => (id === 'journals' ? plugin : null) }
   }) as TestApp;
 
@@ -129,6 +140,30 @@ describe('Journals daily note source adapter', () => {
     adapter.getExistingFileForDate('2026-08-11', {} as never);
     expect(personal.get).toHaveBeenCalledWith('2026-08-11');
     expect(work.get).not.toHaveBeenCalled();
+  });
+
+  it('lists unique headings from every template configured for the selected journal', () => {
+    const first = makeFile('Templates/Work.md');
+    const second = makeFile('Templates/Tasks.md');
+    const files = new Map([
+      [first.path, first],
+      [second.path, second]
+    ]);
+    const plugin = {
+      ...makePluginApi([]),
+      getJournalConfig: (name: string) =>
+        name === 'Daily' ? { templates: ['Templates/Work', 'Templates/Tasks.md'] } : undefined
+    };
+    const headings = new Map([
+      [first.path, ['Schedule', 'Notes']],
+      [second.path, ['Tasks', 'Notes']]
+    ]);
+
+    expect(getJournalsTemplateHeadings(makeApp(plugin, files, headings), 'Daily')).toEqual([
+      'Schedule',
+      'Notes',
+      'Tasks'
+    ]);
   });
 
   it('resolves an existing entry without recreating it', async () => {

--- a/src/providers/dailynote/DailyNoteSourceAdapter.test.ts
+++ b/src/providers/dailynote/DailyNoteSourceAdapter.test.ts
@@ -48,7 +48,7 @@ type TestApp = App & {
 type TestJournalEntry = { date: string; journal: string; path?: string };
 
 type MockJournal = Omit<JournalsDayJournal, 'get' | 'getNotePath' | 'open'> & {
-  get: jest.Mock<TestJournalEntry, [string]>;
+  get: jest.Mock<TestJournalEntry | null, [string]>;
   getNotePath: jest.Mock<string, [TestJournalEntry]>;
   open: jest.Mock<Promise<void>, [TestJournalEntry]>;
 };
@@ -60,7 +60,7 @@ const makeJournal = (
 ): MockJournal => ({
   name,
   type: 'day',
-  get: jest.fn<TestJournalEntry, [string]>(
+  get: jest.fn<TestJournalEntry | null, [string]>(
     (date: string): TestJournalEntry => entries.get(date) ?? { date, journal: name }
   ),
   getNotePath: jest.fn<string, [TestJournalEntry]>(
@@ -114,6 +114,16 @@ describe('Journals daily note source adapter', () => {
       journalId: 'Daily'
     });
     expect(() => adapter.getAllFiles()).toThrow(/not installed\/enabled/);
+  });
+
+  it('rejects an incompatible Journals runtime API', () => {
+    const incompatible = {
+      ...makePluginApi([]),
+      getJournalConfig: 'unexpected'
+    };
+    const app = makeApp(incompatible as unknown as JournalsPluginApi);
+
+    expect(getJournalsDayJournals(app)).toEqual([]);
   });
 
   it('enumerates one compatible Day journal and excludes other intervals', () => {
@@ -198,6 +208,38 @@ describe('Journals daily note source adapter', () => {
     expect(daily.get).toHaveBeenCalledWith('2026-08-11');
     expect(daily.open).toHaveBeenCalledWith({ date: '2026-08-11', journal: 'Daily' });
     expect(file?.path).toBe('Journal/Daily/2026-08-11.md');
+  });
+
+  it('reports when Journals cannot resolve an entry for the requested date', async () => {
+    const files = new Map<string, TFile>();
+    const daily = makeJournal('Daily', files, new Map());
+    daily.get.mockReturnValue(null);
+    const adapter = new JournalsDailyNoteSourceAdapter(makeApp(makePluginApi([daily]), files), {
+      id: 'journals_1',
+      heading: 'Schedule',
+      provider: 'journals',
+      journalId: 'Daily'
+    });
+
+    await expect(adapter.getFileForDate('2026-08-11', {} as never, true)).rejects.toThrow(
+      'Journals could not resolve an entry for 2026-08-11.'
+    );
+  });
+
+  it('reports when Journals does not create the expected note', async () => {
+    const files = new Map<string, TFile>();
+    const daily = makeJournal('Daily', files, new Map());
+    daily.open.mockResolvedValue(undefined);
+    const adapter = new JournalsDailyNoteSourceAdapter(makeApp(makePluginApi([daily]), files), {
+      id: 'journals_1',
+      heading: 'Schedule',
+      provider: 'journals',
+      journalId: 'Daily'
+    });
+
+    await expect(adapter.getFileForDate('2026-08-11', {} as never, true)).rejects.toThrow(
+      'Journals did not create the expected entry for 2026-08-11'
+    );
   });
 
   it('rejects a selected journal that was renamed or deleted', () => {

--- a/src/providers/dailynote/DailyNoteSourceAdapter.test.ts
+++ b/src/providers/dailynote/DailyNoteSourceAdapter.test.ts
@@ -1,0 +1,208 @@
+import { App, TFile } from 'obsidian';
+import {
+  createDailyNote,
+  getAllDailyNotes,
+  getDailyNote,
+  getDailyNoteSettings,
+  getDateFromFile
+} from 'obsidian-daily-notes-interface';
+
+import {
+  getJournalsDayJournals,
+  JournalsDailyNoteSourceAdapter,
+  ObsidianDailyNoteSourceAdapter,
+  type JournalsDayJournal,
+  type JournalsPluginApi
+} from './DailyNoteSourceAdapter';
+import { parseCalendarInfo } from '../../types/calendar_settings';
+
+jest.mock('obsidian', () => ({
+  TFile: class TFile {
+    path = '';
+  },
+  App: class App {}
+}));
+
+jest.mock('obsidian-daily-notes-interface', () => ({
+  appHasDailyNotesPluginLoaded: jest.fn(),
+  createDailyNote: jest.fn(),
+  getAllDailyNotes: jest.fn(),
+  getDailyNote: jest.fn(),
+  getDailyNoteSettings: jest.fn(),
+  getDateFromFile: jest.fn()
+}));
+
+const makeFile = (path: string): TFile => {
+  const file = new TFile();
+  file.path = path;
+  return file;
+};
+
+type TestApp = App & {
+  vault: { getFileByPath(path: string): TFile | null };
+  plugins: { getPlugin(id: string): unknown };
+};
+
+type TestJournalEntry = { date: string; journal: string; path?: string };
+
+type MockJournal = Omit<JournalsDayJournal, 'get' | 'getNotePath' | 'open'> & {
+  get: jest.Mock<TestJournalEntry, [string]>;
+  getNotePath: jest.Mock<string, [TestJournalEntry]>;
+  open: jest.Mock<Promise<void>, [TestJournalEntry]>;
+};
+
+const makeJournal = (
+  name: string,
+  files: Map<string, TFile>,
+  entries: Map<string, TestJournalEntry>
+): MockJournal => ({
+  name,
+  type: 'day',
+  get: jest.fn<TestJournalEntry, [string]>(
+    (date: string): TestJournalEntry => entries.get(date) ?? { date, journal: name }
+  ),
+  getNotePath: jest.fn<string, [TestJournalEntry]>(
+    (entry: TestJournalEntry): string => `Journal/${name}/${entry.date}.md`
+  ),
+  open: jest.fn<Promise<void>, [TestJournalEntry]>(async (entry: TestJournalEntry) => {
+    const path = `Journal/${name}/${entry.date}.md`;
+    files.set(path, makeFile(path));
+    entries.set(entry.date, { ...entry, path });
+  })
+});
+
+const makeApp = (plugin: JournalsPluginApi | null, files = new Map<string, TFile>()): TestApp =>
+  ({
+    vault: { getFileByPath: (path: string) => files.get(path) ?? null },
+    plugins: { getPlugin: (id: string) => (id === 'journals' ? plugin : null) }
+  }) as TestApp;
+
+const makePluginApi = (
+  journals: JournalsDayJournal[],
+  entriesByPath = new Map<string, { date: string; journal: string; path?: string }>()
+): JournalsPluginApi => ({
+  journals,
+  getJournal: name => journals.find(journal => journal.name === name),
+  index: {
+    getAllPaths: journalId =>
+      [...entriesByPath.entries()]
+        .filter(([, entry]) => entry.journal === journalId)
+        .map(([path]) => path),
+    getForPath: path => entriesByPath.get(path) ?? null
+  }
+});
+
+describe('Journals daily note source adapter', () => {
+  it('reports Journals as unavailable when the plugin is disabled or absent', () => {
+    const app = makeApp(null);
+    expect(getJournalsDayJournals(app)).toEqual([]);
+    const adapter = new JournalsDailyNoteSourceAdapter(app, {
+      id: 'dailynote_1',
+      heading: 'Schedule',
+      provider: 'journals',
+      journalId: 'Daily'
+    });
+    expect(() => adapter.getAllFiles()).toThrow(/not installed\/enabled/);
+  });
+
+  it('enumerates one compatible Day journal and excludes other intervals', () => {
+    const files = new Map<string, TFile>();
+    const daily = makeJournal('Daily', files, new Map());
+    const weekly = { ...makeJournal('Weekly', files, new Map()), type: 'week' };
+    const app = makeApp(makePluginApi([daily, weekly]));
+
+    expect(getJournalsDayJournals(app).map(journal => journal.name)).toEqual(['Daily']);
+  });
+
+  it('uses the configured journal when multiple Day journals exist', () => {
+    const files = new Map<string, TFile>();
+    const work = makeJournal('Work', files, new Map());
+    const personal = makeJournal('Personal', files, new Map());
+    const app = makeApp(makePluginApi([work, personal]));
+    const adapter = new JournalsDailyNoteSourceAdapter(app, {
+      id: 'dailynote_1',
+      heading: 'Schedule',
+      provider: 'journals',
+      journalId: 'Personal'
+    });
+
+    adapter.getExistingFileForDate('2026-08-11', {} as never);
+    expect(personal.get).toHaveBeenCalledWith('2026-08-11');
+    expect(work.get).not.toHaveBeenCalled();
+  });
+
+  it('resolves an existing entry without recreating it', async () => {
+    const path = 'Journal/Daily/2026-08-11.md';
+    const file = makeFile(path);
+    const files = new Map([[path, file]]);
+    const entries = new Map([['2026-08-11', { date: '2026-08-11', journal: 'Daily', path }]]);
+    const daily = makeJournal('Daily', files, entries);
+    const adapter = new JournalsDailyNoteSourceAdapter(makeApp(makePluginApi([daily]), files), {
+      id: 'dailynote_1',
+      heading: 'Schedule',
+      provider: 'journals',
+      journalId: 'Daily'
+    });
+
+    await expect(adapter.getFileForDate('2026-08-11', {} as never, true)).resolves.toBe(file);
+    expect(daily.open).not.toHaveBeenCalled();
+  });
+
+  it('creates a missing entry through Journals and preserves the requested local date', async () => {
+    const files = new Map<string, TFile>();
+    const entries = new Map<string, { date: string; journal: string; path?: string }>();
+    const daily = makeJournal('Daily', files, entries);
+    const adapter = new JournalsDailyNoteSourceAdapter(makeApp(makePluginApi([daily]), files), {
+      id: 'dailynote_1',
+      heading: 'Schedule',
+      provider: 'journals',
+      journalId: 'Daily'
+    });
+
+    const file = await adapter.getFileForDate('2026-08-11', {} as never, true);
+    expect(daily.get).toHaveBeenCalledWith('2026-08-11');
+    expect(daily.open).toHaveBeenCalledWith({ date: '2026-08-11', journal: 'Daily' });
+    expect(file?.path).toBe('Journal/Daily/2026-08-11.md');
+  });
+
+  it('rejects a selected journal that was renamed or deleted', () => {
+    const app = makeApp(makePluginApi([]));
+    const adapter = new JournalsDailyNoteSourceAdapter(app, {
+      id: 'dailynote_1',
+      heading: 'Schedule',
+      provider: 'journals',
+      journalId: 'Old name'
+    });
+    expect(() => adapter.getAllFiles()).toThrow(/renamed or deleted/);
+  });
+});
+
+describe('legacy Daily Notes compatibility', () => {
+  it('continues to resolve and create through obsidian-daily-notes-interface', async () => {
+    const dateMoment = { format: () => '2026-08-11' } as never;
+    const created = makeFile('Daily/2026-08-11.md');
+    (getAllDailyNotes as jest.Mock).mockReturnValue({});
+    (getDailyNote as jest.Mock).mockReturnValue(null);
+    (createDailyNote as jest.Mock).mockResolvedValue(created);
+    (getDailyNoteSettings as jest.Mock).mockReturnValue({ folder: 'Daily' });
+    (getDateFromFile as jest.Mock).mockReturnValue({ format: () => '2026-08-11' });
+
+    const adapter = new ObsidianDailyNoteSourceAdapter();
+    await expect(adapter.getFileForDate('2026-08-11', dateMoment, true)).resolves.toBe(created);
+    expect(createDailyNote).toHaveBeenCalledWith(dateMoment);
+    expect(adapter.getDateForFile(created)).toBe('2026-08-11');
+  });
+
+  it('defaults old serialized Daily Note settings to the legacy provider', () => {
+    const parsed = parseCalendarInfo({
+      type: 'dailynote',
+      id: 'dailynote_1',
+      name: 'Daily Note',
+      heading: 'Schedule',
+      color: '#123456'
+    });
+
+    expect(parsed).toEqual(expect.objectContaining({ provider: 'daily-notes', format: 'default' }));
+    expect('journalId' in parsed).toBe(false);
+  });
+});

--- a/src/providers/dailynote/DailyNoteSourceAdapter.ts
+++ b/src/providers/dailynote/DailyNoteSourceAdapter.ts
@@ -35,6 +35,7 @@ type JournalsIndex = {
 export type JournalsPluginApi = {
   journals: JournalsDayJournal[];
   getJournal(name: string): JournalsDayJournal | undefined;
+  getJournalConfig?(name: string): { templates?: string[] } | undefined;
   index: JournalsIndex;
 };
 
@@ -89,6 +90,27 @@ export function getJournalsPlugin(app: App): JournalsPluginApi | null {
 
 export function getJournalsDayJournals(app: App): JournalsDayJournal[] {
   return getJournalsPlugin(app)?.journals.filter(isDayJournal) ?? [];
+}
+
+const getHeadingsFromTemplates = (app: App, templates: string[]): string[] => {
+  const headings = templates.flatMap(template => {
+    const path = template.endsWith('.md') ? template : `${template}.md`;
+    const file = app.vault.getFileByPath(path);
+    return file
+      ? (app.metadataCache.getFileCache(file)?.headings?.map(item => item.heading) ?? [])
+      : [];
+  });
+  return [...new Set(headings)];
+};
+
+export function getJournalsTemplateHeadings(app: App, journalId: string): string[] {
+  const templates = getJournalsPlugin(app)?.getJournalConfig?.(journalId)?.templates;
+  return Array.isArray(templates) ? getHeadingsFromTemplates(app, templates) : [];
+}
+
+export function getObsidianDailyNoteTemplateHeadings(app: App): string[] {
+  const { template } = getDailyNoteSettings();
+  return template ? getHeadingsFromTemplates(app, [template]) : [];
 }
 
 export class ObsidianDailyNoteSourceAdapter implements DailyNoteSourceAdapter {

--- a/src/providers/dailynote/DailyNoteSourceAdapter.ts
+++ b/src/providers/dailynote/DailyNoteSourceAdapter.ts
@@ -76,6 +76,9 @@ function isJournalsPluginApi(value: unknown): value is JournalsPluginApi {
   if (!value || typeof value !== 'object') return false;
   const plugin = value as Record<string, unknown>;
   if (!Array.isArray(plugin.journals) || typeof plugin.getJournal !== 'function') return false;
+  if (plugin.getJournalConfig !== undefined && typeof plugin.getJournalConfig !== 'function') {
+    return false;
+  }
   if (!plugin.index || typeof plugin.index !== 'object') return false;
   const index = plugin.index as Record<string, unknown>;
   return typeof index.getAllPaths === 'function' && typeof index.getForPath === 'function';

--- a/src/providers/dailynote/DailyNoteSourceAdapter.ts
+++ b/src/providers/dailynote/DailyNoteSourceAdapter.ts
@@ -1,0 +1,200 @@
+import { App, TFile } from 'obsidian';
+import {
+  appHasDailyNotesPluginLoaded,
+  createDailyNote,
+  getAllDailyNotes,
+  getDailyNote,
+  getDailyNoteSettings,
+  getDateFromFile
+} from 'obsidian-daily-notes-interface';
+
+import type { Moment } from 'moment';
+import type { DailyNoteProviderConfig } from './typesDaily';
+
+export const JOURNALS_PLUGIN_ID = 'journals';
+
+type JournalEntry = {
+  date: string;
+  journal: string;
+  path?: string;
+};
+
+export type JournalsDayJournal = {
+  name: string;
+  type: string;
+  get(date: string): JournalEntry | null;
+  getNotePath(entry: JournalEntry): string;
+  open(entry: JournalEntry): Promise<void>;
+};
+
+type JournalsIndex = {
+  getAllPaths(journalId: string): string[];
+  getForPath(path: string): JournalEntry | null;
+};
+
+export type JournalsPluginApi = {
+  journals: JournalsDayJournal[];
+  getJournal(name: string): JournalsDayJournal | undefined;
+  index: JournalsIndex;
+};
+
+type AppWithPlugins = App & {
+  plugins?: {
+    getPlugin?(id: string): unknown;
+    plugins?: Record<string, unknown>;
+  };
+};
+
+export type DailyNoteSourceAdapter = {
+  getAllFiles(): TFile[];
+  getExistingFileForDate(date: string, dateMoment: Moment): TFile | null;
+  getFileForDate(date: string, dateMoment: Moment, create: boolean): Promise<TFile | null>;
+  getDateForFile(file: TFile): string | null;
+  isFileRelevant(file: TFile): boolean;
+};
+
+function isJournalEntry(value: unknown): value is JournalEntry {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.date === 'string' && typeof entry.journal === 'string';
+}
+
+function isDayJournal(value: unknown): value is JournalsDayJournal {
+  if (!value || typeof value !== 'object') return false;
+  const journal = value as Record<string, unknown>;
+  return (
+    journal.type === 'day' &&
+    typeof journal.name === 'string' &&
+    typeof journal.get === 'function' &&
+    typeof journal.getNotePath === 'function' &&
+    typeof journal.open === 'function'
+  );
+}
+
+function isJournalsPluginApi(value: unknown): value is JournalsPluginApi {
+  if (!value || typeof value !== 'object') return false;
+  const plugin = value as Record<string, unknown>;
+  if (!Array.isArray(plugin.journals) || typeof plugin.getJournal !== 'function') return false;
+  if (!plugin.index || typeof plugin.index !== 'object') return false;
+  const index = plugin.index as Record<string, unknown>;
+  return typeof index.getAllPaths === 'function' && typeof index.getForPath === 'function';
+}
+
+export function getJournalsPlugin(app: App): JournalsPluginApi | null {
+  const plugins = (app as AppWithPlugins).plugins;
+  const candidate =
+    plugins?.getPlugin?.(JOURNALS_PLUGIN_ID) ?? plugins?.plugins?.[JOURNALS_PLUGIN_ID];
+  return isJournalsPluginApi(candidate) ? candidate : null;
+}
+
+export function getJournalsDayJournals(app: App): JournalsDayJournal[] {
+  return getJournalsPlugin(app)?.journals.filter(isDayJournal) ?? [];
+}
+
+export class ObsidianDailyNoteSourceAdapter implements DailyNoteSourceAdapter {
+  constructor() {
+    appHasDailyNotesPluginLoaded();
+  }
+
+  getAllFiles(): TFile[] {
+    return Object.values(getAllDailyNotes());
+  }
+
+  getExistingFileForDate(_date: string, dateMoment: Moment): TFile | null {
+    return getDailyNote(dateMoment, getAllDailyNotes()) ?? null;
+  }
+
+  async getFileForDate(_date: string, dateMoment: Moment, create: boolean): Promise<TFile | null> {
+    const existing = this.getExistingFileForDate(_date, dateMoment);
+    if (existing instanceof TFile || !create) return existing ?? null;
+    return (await createDailyNote(dateMoment)) ?? null;
+  }
+
+  getDateForFile(file: TFile): string | null {
+    return getDateFromFile(file, 'day')?.format('YYYY-MM-DD') ?? null;
+  }
+
+  isFileRelevant(file: TFile): boolean {
+    const { folder } = getDailyNoteSettings();
+    return folder ? file.path.startsWith(`${folder}/`) : true;
+  }
+}
+
+export class JournalsDailyNoteSourceAdapter implements DailyNoteSourceAdapter {
+  private readonly plugin: JournalsPluginApi | null;
+  private readonly journalId: string | undefined;
+
+  constructor(
+    private readonly app: App,
+    config: DailyNoteProviderConfig
+  ) {
+    this.plugin = getJournalsPlugin(app);
+    this.journalId = config.journalId;
+  }
+
+  private getJournal(): JournalsDayJournal {
+    if (!this.plugin) {
+      throw new Error('Journals is not installed/enabled, or its runtime API is incompatible.');
+    }
+    if (!this.journalId) {
+      throw new Error('No Journals Day journal is selected.');
+    }
+    const journal = this.plugin.getJournal(this.journalId);
+    if (!isDayJournal(journal)) {
+      throw new Error(
+        `The selected Journals Day journal "${this.journalId}" is unavailable. It may have been renamed or deleted.`
+      );
+    }
+    return journal;
+  }
+
+  getAllFiles(): TFile[] {
+    const journal = this.getJournal();
+    const plugin = this.plugin;
+    if (!plugin) return [];
+    return plugin.index
+      .getAllPaths(journal.name)
+      .map(path => this.app.vault.getFileByPath(path))
+      .filter((file): file is TFile => file instanceof TFile);
+  }
+
+  getExistingFileForDate(date: string, _dateMoment: Moment): TFile | null {
+    if (!this.plugin) return null;
+    const journal = this.getJournal();
+    const entry = journal.get(date);
+    if (!isJournalEntry(entry) || !entry.path) return null;
+    return this.app.vault.getFileByPath(entry.path);
+  }
+
+  async getFileForDate(date: string, _dateMoment: Moment, create: boolean): Promise<TFile | null> {
+    const journal = this.getJournal();
+    const entry = journal.get(date);
+    if (!isJournalEntry(entry)) {
+      throw new Error(`Journals could not resolve an entry for ${date}.`);
+    }
+
+    if (entry.path) {
+      const existing = this.app.vault.getFileByPath(entry.path);
+      if (existing) return existing;
+      throw new Error(`Journals resolved ${date} to a missing file: ${entry.path}.`);
+    }
+    if (!create) return null;
+
+    await journal.open(entry);
+    const path = journal.getNotePath(entry);
+    const created = this.app.vault.getFileByPath(path);
+    if (!created) {
+      throw new Error(`Journals did not create the expected entry for ${date} at ${path}.`);
+    }
+    return created;
+  }
+
+  getDateForFile(file: TFile): string | null {
+    return this.plugin?.index.getForPath(file.path)?.date ?? null;
+  }
+
+  isFileRelevant(file: TFile): boolean {
+    if (!this.plugin) return false;
+    return this.plugin.index.getForPath(file.path)?.journal === this.getJournal().name;
+  }
+}

--- a/src/providers/dailynote/typesDaily.ts
+++ b/src/providers/dailynote/typesDaily.ts
@@ -4,14 +4,28 @@ export type DailyNoteEventFormat = (typeof DAILY_NOTE_EVENT_FORMATS)[number];
 
 export const DEFAULT_DAILY_NOTE_EVENT_FORMAT: DailyNoteEventFormat = 'default';
 
+export const DAILY_NOTE_PROVIDERS = ['daily-notes', 'journals'] as const;
+
+export type DailyNoteSourceProvider = (typeof DAILY_NOTE_PROVIDERS)[number];
+
+export const DEFAULT_DAILY_NOTE_PROVIDER: DailyNoteSourceProvider = 'daily-notes';
+
 export type DailyNoteProviderConfig = {
   id: string; // The settings-level ID, e.g., "dailynote_1"
   heading: string;
   format?: DailyNoteEventFormat;
+  provider?: DailyNoteSourceProvider;
+  journalId?: string;
 };
 
 export function getDailyNoteEventFormat(
   config: Pick<DailyNoteProviderConfig, 'format'> | undefined
 ): DailyNoteEventFormat {
   return config?.format ?? DEFAULT_DAILY_NOTE_EVENT_FORMAT;
+}
+
+export function getDailyNoteSourceProvider(
+  config: Pick<DailyNoteProviderConfig, 'provider'> | undefined
+): DailyNoteSourceProvider {
+  return config?.provider ?? DEFAULT_DAILY_NOTE_PROVIDER;
 }

--- a/src/providers/dailynote/typesDaily.ts
+++ b/src/providers/dailynote/typesDaily.ts
@@ -12,7 +12,7 @@ export const DEFAULT_DAILY_NOTE_PROVIDER: DailyNoteSourceProvider = 'daily-notes
 
 export type DailyNoteProviderConfig = {
   type?: 'dailynote' | 'journals';
-  id: string; // The settings-level ID, e.g., "dailynote_1"
+  id: string; // The settings-level calendar source ID.
   heading: string;
   format?: DailyNoteEventFormat;
   provider?: DailyNoteSourceProvider;

--- a/src/providers/dailynote/typesDaily.ts
+++ b/src/providers/dailynote/typesDaily.ts
@@ -11,6 +11,7 @@ export type DailyNoteSourceProvider = (typeof DAILY_NOTE_PROVIDERS)[number];
 export const DEFAULT_DAILY_NOTE_PROVIDER: DailyNoteSourceProvider = 'daily-notes';
 
 export type DailyNoteProviderConfig = {
+  type?: 'dailynote' | 'journals';
   id: string; // The settings-level ID, e.g., "dailynote_1"
   heading: string;
   format?: DailyNoteEventFormat;

--- a/src/providers/journals/JournalsProvider.ts
+++ b/src/providers/journals/JournalsProvider.ts
@@ -1,0 +1,20 @@
+import type FullCalendarPlugin from '../../main';
+import type { ObsidianInterface } from '../../ObsidianAdapter';
+import { DailyNoteProvider } from '../dailynote/DailyNoteProvider';
+import type { DailyNoteProviderConfig } from '../dailynote/typesDaily';
+
+export class JournalsProvider extends DailyNoteProvider {
+  static readonly type = 'journals';
+  static readonly displayName = 'Journals';
+
+  readonly type = 'journals';
+  readonly displayName = 'Journals';
+
+  constructor(
+    source: DailyNoteProviderConfig,
+    plugin: FullCalendarPlugin,
+    app?: ObsidianInterface
+  ) {
+    super({ ...source, type: 'journals', provider: 'journals' }, plugin, app);
+  }
+}

--- a/src/providers/journals/JournalsSourceIdentity.test.ts
+++ b/src/providers/journals/JournalsSourceIdentity.test.ts
@@ -85,6 +85,7 @@ describe('Journals source identity and uniqueness', () => {
       'journals_1',
       'journals_2'
     ]);
+    expect(migrateAndSanitizeSettings(migrated.settings).needsSave).toBe(false);
   });
 
   it('preserves user-defined Journals calendar names', () => {

--- a/src/providers/journals/JournalsSourceIdentity.test.ts
+++ b/src/providers/journals/JournalsSourceIdentity.test.ts
@@ -1,0 +1,83 @@
+import { parseCalendarInfo, type CalendarInfo } from '../../types/calendar_settings';
+import { migrateAndSanitizeSettings } from '../../ui/settings/utilsSettings';
+import { canAddCalendarOfType } from '../../ui/settings/calendarSourceValidation';
+
+jest.mock('obsidian-daily-notes-interface', () => ({
+  getDailyNoteSettings: jest.fn().mockReturnValue({ template: '' })
+}));
+
+const dailyNote = (id = 'dailynote_1'): CalendarInfo =>
+  parseCalendarInfo({
+    type: 'dailynote',
+    id,
+    name: 'Daily Note',
+    heading: 'Schedule',
+    color: '#111111'
+  });
+
+const journals = (id: string, journalId: string): CalendarInfo =>
+  parseCalendarInfo({
+    type: 'journals',
+    id,
+    name: `Journals: ${journalId}`,
+    journalId,
+    heading: 'Schedule',
+    color: '#222222'
+  });
+
+describe('Journals source identity and uniqueness', () => {
+  it('allows one Daily Note calendar and rejects a second Daily Note calendar', () => {
+    expect(canAddCalendarOfType('dailynote', [])).toBe(true);
+    expect(canAddCalendarOfType('dailynote', [dailyNote()])).toBe(false);
+  });
+
+  it('allows Journals when a Daily Note calendar already exists', () => {
+    expect(canAddCalendarOfType('journals', [dailyNote()])).toBe(true);
+  });
+
+  it('allows a Daily Note calendar when Journals already exists', () => {
+    expect(canAddCalendarOfType('dailynote', [journals('journals_1', 'Music')])).toBe(true);
+  });
+
+  it('allows multiple Journals calendars with independent journal IDs', () => {
+    const music = journals('journals_1', 'Music');
+    const work = journals('journals_2', 'Work');
+
+    expect(canAddCalendarOfType('journals', [music])).toBe(true);
+    expect(
+      [music, work].map(source => (source.type === 'journals' ? source.journalId : null))
+    ).toEqual(['Music', 'Work']);
+  });
+
+  it('deserializes Journals and Daily Note as distinct source types', () => {
+    expect(journals('journals_1', 'Music').type).toBe('journals');
+    expect(dailyNote().type).toBe('dailynote');
+  });
+
+  it('migrates legacy Journals sources stored with the Daily Note discriminator', () => {
+    const migrated = migrateAndSanitizeSettings({
+      calendarSources: [
+        {
+          type: 'dailynote',
+          id: 'dailynote_1',
+          name: 'Journals',
+          heading: 'Schedule',
+          format: 'default',
+          provider: 'journals',
+          journalId: 'Music',
+          color: '#222222'
+        }
+      ]
+    });
+
+    expect(migrated.needsSave).toBe(true);
+    expect(migrated.settings.calendarSources[0]).toEqual(
+      expect.objectContaining({
+        type: 'journals',
+        journalId: 'Music',
+        heading: 'Schedule'
+      })
+    );
+    expect(migrated.settings.calendarSources[0]).not.toHaveProperty('provider');
+  });
+});

--- a/src/providers/journals/JournalsSourceIdentity.test.ts
+++ b/src/providers/journals/JournalsSourceIdentity.test.ts
@@ -54,6 +54,58 @@ describe('Journals source identity and uniqueness', () => {
     expect(dailyNote().type).toBe('dailynote');
   });
 
+  it('migrates generic Journals names to distinct configured calendar names', () => {
+    const migrated = migrateAndSanitizeSettings({
+      calendarSources: [
+        {
+          type: 'journals',
+          id: 'journals_1',
+          name: 'Journals',
+          journalId: 'Music',
+          heading: 'Schedule',
+          color: '#222222'
+        },
+        {
+          type: 'journals',
+          id: 'journals_2',
+          name: 'Journals',
+          journalId: 'PHD',
+          heading: 'Schedule',
+          color: '#333333'
+        }
+      ]
+    });
+
+    expect(migrated.needsSave).toBe(true);
+    expect(migrated.settings.calendarSources).toEqual([
+      expect.objectContaining({ id: 'journals_1', name: 'Journals: Music' }),
+      expect.objectContaining({ id: 'journals_2', name: 'Journals: PHD' })
+    ]);
+    expect(migrated.settings.calendarSources.map(source => source.id)).toEqual([
+      'journals_1',
+      'journals_2'
+    ]);
+  });
+
+  it('preserves user-defined Journals calendar names', () => {
+    const migrated = migrateAndSanitizeSettings({
+      calendarSources: [
+        {
+          type: 'journals',
+          id: 'journals_1',
+          name: 'My music calendar',
+          journalId: 'Music',
+          heading: 'Schedule',
+          color: '#222222'
+        }
+      ]
+    });
+
+    expect(migrated.settings.calendarSources[0]).toEqual(
+      expect.objectContaining({ id: 'journals_1', name: 'My music calendar' })
+    );
+  });
+
   it('migrates legacy Journals sources stored with the Daily Note discriminator', () => {
     const migrated = migrateAndSanitizeSettings({
       calendarSources: [

--- a/src/providers/typesProvider.ts
+++ b/src/providers/typesProvider.ts
@@ -1,4 +1,6 @@
 import { ComponentType } from 'react';
+import type FullCalendarPlugin from '../main';
+import type { CalendarInfo } from '../types';
 
 /**
  * The persistent, source-of-truth locator for an event within its source.
@@ -23,3 +25,9 @@ export type ProviderConfigContext = {
  * A generic type for a React component used in the provider interface.
  */
 export type FCReactComponent<T> = ComponentType<T>;
+
+export type ProviderSettingsRowProps = {
+  source: Partial<CalendarInfo>;
+  plugin?: FullCalendarPlugin;
+  onSourceChange?: (changes: Partial<CalendarInfo>) => void;
+};

--- a/src/types/calendar_settings.ts
+++ b/src/types/calendar_settings.ts
@@ -41,6 +41,14 @@ const calendarOptionsSchema = z.discriminatedUnion('type', [
     provider: z.enum(DAILY_NOTE_PROVIDERS).default(DEFAULT_DAILY_NOTE_PROVIDER),
     journalId: z.string().optional()
   }),
+  z.object({
+    type: z.literal('journals'),
+    id: z.string(),
+    name: z.string(),
+    heading: z.string(),
+    format: z.enum(DAILY_NOTE_EVENT_FORMATS).default(DEFAULT_DAILY_NOTE_EVENT_FORMAT),
+    journalId: z.string()
+  }),
   z.object({ type: z.literal('ical'), id: z.string(), name: z.string(), url: z.string().url() }),
   z.object({
     type: z.literal('caldav'),

--- a/src/types/calendar_settings.ts
+++ b/src/types/calendar_settings.ts
@@ -17,7 +17,9 @@ import { OFCEvent } from './schema';
 import { getNextColor } from '../ui/components/colors';
 import { t } from '../features/i18n/i18n';
 import {
+  DAILY_NOTE_PROVIDERS,
   DAILY_NOTE_EVENT_FORMATS,
+  DEFAULT_DAILY_NOTE_PROVIDER,
   DEFAULT_DAILY_NOTE_EVENT_FORMAT
 } from '../providers/dailynote/typesDaily';
 
@@ -35,7 +37,9 @@ const calendarOptionsSchema = z.discriminatedUnion('type', [
     id: z.string(),
     name: z.string(),
     heading: z.string(),
-    format: z.enum(DAILY_NOTE_EVENT_FORMATS).default(DEFAULT_DAILY_NOTE_EVENT_FORMAT)
+    format: z.enum(DAILY_NOTE_EVENT_FORMATS).default(DEFAULT_DAILY_NOTE_EVENT_FORMAT),
+    provider: z.enum(DAILY_NOTE_PROVIDERS).default(DEFAULT_DAILY_NOTE_PROVIDER),
+    journalId: z.string().optional()
   }),
   z.object({ type: z.literal('ical'), id: z.string(), name: z.string(), url: z.string().url() }),
   z.object({

--- a/src/ui/modals/EditEvent.calendarOptions.test.ts
+++ b/src/ui/modals/EditEvent.calendarOptions.test.ts
@@ -1,0 +1,37 @@
+import { getEventCalendarOptions } from './EditEvent';
+
+describe('event calendar selector options', () => {
+  it('uses configured calendar names and stable IDs for multiple Journals calendars', () => {
+    expect(
+      getEventCalendarOptions([
+        { id: 'journals_1', type: 'journals', name: 'Journals: Music' },
+        { id: 'journals_2', type: 'journals', name: 'Journals: PHD' }
+      ])
+    ).toEqual([
+      { value: 'journals_1', label: 'Journals: Music' },
+      { value: 'journals_2', label: 'Journals: PHD' }
+    ]);
+  });
+
+  it('preserves configured names for other provider types', () => {
+    expect(
+      getEventCalendarOptions([
+        { id: 'daily_1', type: 'dailynote', name: 'Daily Note' },
+        { id: 'local_1', type: 'local', name: 'Project notes' },
+        { id: 'ics_1', type: 'ical', name: 'Team holidays' },
+        { id: 'caldav_1', type: 'caldav', name: 'Personal CalDAV' },
+        { id: 'google_1', type: 'google', name: 'Work Google' },
+        { id: 'outlook_1', type: 'outlook', name: 'PHD Outlook' },
+        { id: 'tasks_1', type: 'tasks', name: 'Vault tasks' }
+      ])
+    ).toEqual([
+      { value: 'daily_1', label: 'Daily Note' },
+      { value: 'local_1', label: 'Project notes' },
+      { value: 'ics_1', label: 'Team holidays' },
+      { value: 'caldav_1', label: 'Personal CalDAV' },
+      { value: 'google_1', label: 'Work Google' },
+      { value: 'outlook_1', label: 'PHD Outlook' },
+      { value: 'tasks_1', label: 'Vault tasks' }
+    ]);
+  });
+});

--- a/src/ui/modals/EditEvent.tsx
+++ b/src/ui/modals/EditEvent.tsx
@@ -103,6 +103,20 @@ interface EditEventProps {
   mode: 'create' | 'edit';
 }
 
+type EventCalendarOption = {
+  value: string;
+  label: string;
+};
+
+export function getEventCalendarOptions(
+  calendars: EditEventProps['calendars']
+): EventCalendarOption[] {
+  return calendars.map(calendar => ({
+    value: calendar.id,
+    label: calendar.name
+  }));
+}
+
 function getInitialRecurrenceType(event?: Partial<OFCEvent>): RecurrenceType {
   if (event?.type !== 'recurring') {
     return 'none';
@@ -171,6 +185,7 @@ export const EditEvent = ({
   const isRecurring = recurrenceType !== 'none';
   const [allDay, setAllDay] = useState(initialEvent?.allDay || false);
   const [calendarIndex, setCalendarIndex] = useState(defaultCalendarIndex);
+  const calendarOptions = getEventCalendarOptions(calendars);
   const [isTask, setIsTask] = useState(
     (initialEvent?.type === 'single' &&
       initialEvent.completed !== undefined &&
@@ -429,12 +444,15 @@ export const EditEvent = ({
           </div>
           <div className="setting-item-control">
             <select
-              value={calendarIndex}
-              onChange={e => setCalendarIndex(parseInt(e.target.value))}
+              value={calendars[calendarIndex]?.id || ''}
+              onChange={e => {
+                const nextIndex = calendars.findIndex(calendar => calendar.id === e.target.value);
+                if (nextIndex !== -1) setCalendarIndex(nextIndex);
+              }}
             >
-              {calendars.map((cal, idx) => (
-                <option key={idx} value={idx}>
-                  {cal.name}
+              {calendarOptions.map(option => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
                 </option>
               ))}
             </select>

--- a/src/ui/modals/EditEvent.tsx
+++ b/src/ui/modals/EditEvent.tsx
@@ -229,7 +229,8 @@ export const EditEvent = ({
   }, [titleRef]);
 
   const selectedCalendar = calendars[calendarIndex];
-  const isDailyNoteCalendar = selectedCalendar.type === 'dailynote';
+  const isDailyNoteCalendar =
+    selectedCalendar.type === 'dailynote' || selectedCalendar.type === 'journals';
   const provider = PluginState.getProviderRegistry().getInstance(selectedCalendar.id);
   const useBooleanTaskCompletion = Boolean(
     provider &&

--- a/src/ui/settings/SettingsTab.tsx
+++ b/src/ui/settings/SettingsTab.tsx
@@ -125,6 +125,7 @@ export function addCalendarButton(
         (dropdown = d.addOptions({
           local: t('settings.calendars.types.local'),
           dailynote: t('settings.calendars.types.dailynote'),
+          journals: t('settings.calendars.types.journals'),
           icloud: t('settings.calendars.types.icloud'),
           caldav: t('settings.calendars.types.caldav'),
           ical: t('settings.calendars.types.ical'),
@@ -156,7 +157,8 @@ export function addCalendarButton(
           }
         }
 
-        const providerType = sourceType === 'icloud' ? 'caldav' : sourceType;
+        const providerType =
+          sourceType === 'icloud' ? 'caldav' : sourceType === 'journals' ? 'dailynote' : sourceType;
 
         const providerClass =
           await PluginState.getProviderRegistry().getProviderForType(providerType);
@@ -196,7 +198,14 @@ export function addCalendarButton(
             s => s.color
           );
 
-          const initialConfig = sourceType === 'icloud' ? { url: 'https://caldav.icloud.com' } : {};
+          const initialConfig =
+            sourceType === 'icloud'
+              ? { url: 'https://caldav.icloud.com' }
+              : sourceType === 'journals'
+                ? { provider: 'journals' }
+                : sourceType === 'dailynote'
+                  ? { provider: 'daily-notes' }
+                  : {};
 
           // Base props for all provider components
           // Minimal shared config component props; provider-specific components can accept additional fields.
@@ -263,6 +272,10 @@ export function addCalendarButton(
                     providerType as CalendarInfo['type'],
                     existingCalendarColors
                   );
+
+                  if (sourceType === 'journals') {
+                    partialSource.name = t('settings.calendars.defaults.journals');
+                  }
 
                   // Create the full, valid CalendarInfo object first.
                   const finalSource = {

--- a/src/ui/settings/SettingsTab.tsx
+++ b/src/ui/settings/SettingsTab.tsx
@@ -274,7 +274,11 @@ export function addCalendarButton(
                   );
 
                   if (sourceType === 'journals') {
-                    partialSource.name = t('settings.calendars.defaults.journals');
+                    const journalId = finalConfig.journalId;
+                    partialSource.name =
+                      typeof journalId === 'string' && journalId.length > 0
+                        ? `${t('settings.calendars.defaults.journals')}: ${journalId}`
+                        : t('settings.calendars.defaults.journals');
                   }
 
                   // Create the full, valid CalendarInfo object first.

--- a/src/ui/settings/SettingsTab.tsx
+++ b/src/ui/settings/SettingsTab.tsx
@@ -42,6 +42,7 @@ import { generateCalendarId } from '../../types/calendar_settings';
 import { t } from '../../features/i18n/i18n';
 import { createDescWithDocs, createDocsLinksFragment } from './docsLinks';
 import { getMilestoneCards } from '../../features/milestones/milestones';
+import { canAddCalendarOfType } from './calendarSourceValidation';
 
 // Import the new React components
 import './changelogs/changelog.css';
@@ -157,8 +158,7 @@ export function addCalendarButton(
           }
         }
 
-        const providerType =
-          sourceType === 'icloud' ? 'caldav' : sourceType === 'journals' ? 'dailynote' : sourceType;
+        const providerType = sourceType === 'icloud' ? 'caldav' : sourceType;
 
         const providerClass =
           await PluginState.getProviderRegistry().getProviderForType(providerType);
@@ -244,15 +244,15 @@ export function addCalendarButton(
                 const configs = Array.isArray(finalConfigs) ? finalConfigs : [finalConfigs];
 
                 // Validate: only one dailynote source allowed
-                if (providerType === 'dailynote') {
-                  const existingDailyNotes = PluginState.getSettings().calendarSources.filter(
-                    s => s.type === 'dailynote'
-                  );
-                  if (existingDailyNotes.length >= 1) {
-                    showNotice(t('settings.warnings.oneDailyNote'));
-                    modal.close();
-                    return;
-                  }
+                if (
+                  !canAddCalendarOfType(
+                    providerType as CalendarInfo['type'],
+                    PluginState.getSettings().calendarSources
+                  )
+                ) {
+                  showNotice(t('settings.warnings.oneDailyNote'));
+                  modal.close();
+                  return;
                 }
                 // Collect IDs from both settings and ProviderRegistry to prevent race conditions
                 const settingsIds = PluginState.getSettings().calendarSources.map(s => s.id);

--- a/src/ui/settings/calendarSourceValidation.ts
+++ b/src/ui/settings/calendarSourceValidation.ts
@@ -1,0 +1,5 @@
+import type { CalendarInfo } from '../../types/calendar_settings';
+
+export function canAddCalendarOfType(type: CalendarInfo['type'], sources: CalendarInfo[]): boolean {
+  return type !== 'dailynote' || !sources.some(source => source.type === 'dailynote');
+}

--- a/src/ui/settings/sections/calendars/CalendarSetting.tsx
+++ b/src/ui/settings/sections/calendars/CalendarSetting.tsx
@@ -167,6 +167,12 @@ export class CalendarSettings
     this.setState({ sources: newSources }, () => this.saveDebounced(newSources));
   };
 
+  updateSourceConfig = (index: number, changes: Partial<CalendarInfo>) => {
+    const newSources = [...this.state.sources];
+    newSources[index] = { ...newSources[index], ...changes } as CalendarInfo;
+    this.setState({ sources: newSources }, () => this.saveImmediate(newSources));
+  };
+
   render() {
     return (
       <div className="u-w-full">
@@ -175,6 +181,9 @@ export class CalendarSettings
             key={idx}
             setting={s}
             plugin={this.props.plugin}
+            onSourceChange={(changes: Partial<CalendarInfo>) =>
+              this.updateSourceConfig(idx, changes)
+            }
             onNameChange={(name: string) => this.updateSourceName(idx, name)}
             onColorChange={(color: string) => {
               const newSources = [
@@ -205,6 +214,7 @@ interface ProviderAwareCalendarSettingsRowProps {
   onNameChange: (s: string) => void;
   deleteCalendar: () => void;
   plugin: FullCalendarPlugin;
+  onSourceChange: (changes: Partial<CalendarInfo>) => void;
 }
 
 export const ProviderAwareCalendarSettingRow = ({
@@ -212,7 +222,8 @@ export const ProviderAwareCalendarSettingRow = ({
   onColorChange,
   onNameChange,
   deleteCalendar,
-  plugin: _plugin
+  plugin,
+  onSourceChange
 }: ProviderAwareCalendarSettingsRowProps) => {
   const registry = PluginState.getProviderRegistry();
   const provider = setting.id ? registry.getInstance(setting.id) : null;
@@ -246,7 +257,7 @@ export const ProviderAwareCalendarSettingRow = ({
     const ProviderContent = provider.getSettingsRowComponent();
     return (
       <CalendarSettingRow {...rowProps}>
-        <ProviderContent source={setting} />
+        <ProviderContent source={setting} plugin={plugin} onSourceChange={onSourceChange} />
       </CalendarSettingRow>
     );
   }

--- a/src/ui/settings/sections/renderCalendars.ts
+++ b/src/ui/settings/sections/renderCalendars.ts
@@ -193,6 +193,7 @@ export function renderCalendarManagement(
       [
         { text: t('settings.calendars.docs.fullNote'), path: 'user/calendars/local' },
         { text: t('settings.calendars.docs.dailyNote'), path: 'user/calendars/dailynote' },
+        { text: t('settings.calendars.docs.journals'), path: 'user/calendars/journals' },
         { text: t('settings.calendars.docs.ics'), path: 'user/calendars/ics' },
         { text: t('settings.calendars.docs.caldav'), path: 'user/calendars/caldav' },
         { text: t('settings.calendars.docs.google'), path: 'user/calendars/gcal' },

--- a/src/ui/settings/utilsSettings.ts
+++ b/src/ui/settings/utilsSettings.ts
@@ -156,6 +156,17 @@ export function migrateAndSanitizeSettings(settings: unknown): {
     googleAuth?: LegacyGoogleAuth;
   };
 
+  // Migrate the initial Journals integration, which used a Daily Note source
+  // discriminator plus a provider flag, to the first-class Journals source type.
+  newSettings.calendarSources = newSettings.calendarSources.map(source => {
+    if (source.type !== 'dailynote' || source.provider !== 'journals' || !source.journalId) {
+      return source;
+    }
+    needsSave = true;
+    const { provider: _legacyProvider, ...rest } = source;
+    return { ...rest, type: 'journals' } as CalendarInfo;
+  });
+
   // MIGRATION 0: Ensure all sources have a `name`.
   newSettings.calendarSources.forEach(source => {
     if (!('name' in source) || !source.name) {
@@ -166,6 +177,9 @@ export function migrateAndSanitizeSettings(settings: unknown): {
           break;
         case 'dailynote':
           source.name = 'Daily Note';
+          break;
+        case 'journals':
+          source.name = 'Journals';
           break;
         case 'ical':
           source.name = source.url;

--- a/src/ui/settings/utilsSettings.ts
+++ b/src/ui/settings/utilsSettings.ts
@@ -189,6 +189,18 @@ export function migrateAndSanitizeSettings(settings: unknown): {
           break;
       }
     }
+
+    // Early Journals sources used the generic provider label as their instance name.
+    // Preserve user-defined names, but make those legacy defaults distinguishable.
+    if (
+      source.type === 'journals' &&
+      source.name === 'Journals' &&
+      typeof source.journalId === 'string' &&
+      source.journalId.length > 0
+    ) {
+      source.name = `Journals: ${source.journalId}`;
+      needsSave = true;
+    }
   });
 
   // Ensure googleAccounts array exists for the migration


### PR DESCRIPTION
## Description

Adds first-class support for [Obsidian Journals](https://github.com/srg-kostyrko/obsidian-journal) Day journals as calendar sources.

Previously, users relying on Journals for their daily notes still needed the core Daily Notes integration enabled for Full Calendar's date-note calendar functionality.

This change allows Full Calendar to resolve and create notes directly through a selected Journals Day journal while reusing the existing date-note event handling.

Journals is implemented as a separate calendar source rather than being treated as a Daily Note calendar. This allows:

- using Journals without enabling the core Daily Notes plugin
- selecting a specific Journals Day journal
- configuring multiple Journals calendars independently
- using Journals and the existing Daily Note calendar side-by-side
- retaining the existing heading-based event insertion behavior

For example, multiple journals can be configured independently:

- `Journals: Music`
- `Journals: PHD`

Each retains its own journal selection, heading, color, and calendar identity.

Journals remains an optional dependency. Full Calendar continues to work normally when the Journals plugin is not installed or enabled.

### Implementation

The integration keeps Journals-specific note resolution/creation separate from Full Calendar's existing date-note behavior.

Journals handles resolving/creating the appropriate journal entry, including its configured folder, filename, template, and metadata. Full Calendar then reuses the existing date-note logic for event parsing, serialization, heading insertion, editing, moving, and deletion.

Existing Daily Notes and Periodic Notes behavior remains unchanged.

The integration also handles:

- missing or disabled Journals plugin
- incompatible Journals runtime API
- missing Day journals
- deleted or renamed configured journals
- entry resolution/creation failures
- multiple Journals calendar instances with stable IDs
- distinct journal names in New/Edit Event calendar selectors

### Testing

Added coverage for:

- unavailable/incompatible Journals plugin
- Day journal enumeration
- multiple Day journals and journal selection
- existing entry resolution
- missing entry creation through Journals
- resolution and creation failures
- local-date preservation
- Daily Notes compatibility
- Daily Note/Journals coexistence
- multiple Journals calendar sources
- settings compatibility/migration
- distinct selector labels and stable source IDs

Validation completed with:

- `pnpm run ra`
- `pnpm run lint`
- `pnpm run compile`
- `TZ=UTC pnpm run test`
- `TZ=UTC pnpm run test-update`
- `pnpm run build`

### Manual testing

Manually verified with multiple Journals Day journals:

1. Configured separate `Music` and `PHD` Day journals.
2. Disabled core Daily Notes.
3. Added both journals as Full Calendar sources.
4. Configured separate insertion headings.
5. Created events in each journal.
6. Verified the appropriate Journals entry was created and the event inserted under the configured heading.
7. Edited, moved, and deleted events.
8. Verified the New/Edit Event selectors distinguish between the configured journals.
9. Restarted Obsidian and verified the configurations persisted.


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / maintenance


## Code Quality Checklist (MANDATORY)

- **SOLID / DRY**
  - [x] Designed polymorphically where appropriate.
  - [x] Kept classes and UI views decoupled.
  - [x] Shared reusable helpers instead of copying/pasting logic.

- **Internationalization (i18n)**
  - [x] New user-facing strings use the existing i18n system.

- **Documentation Sync**
  - [x] Updated corresponding architectural documentation.
  - [x] Updated corresponding user-facing documentation.
  - [x] Followed the existing documentation formatting conventions.

- **Code Integrity & Type Safety**
  - [x] Ran `pnpm run ra` locally and confirmed the complete validation suite passes.

- **Test Integrity**
  - [x] Existing `.test` files remain untouched.
  - [x] Added new tests for the Journals integration.