### PR TITLE
feat(caldav): add VTODO task support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Full Calendar supports multiple calendar sources:
 - [**Journals**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/journals/): Events from selected Obsidian Journals Day journals
 - [**ICS**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/ics/): Read-only remote or local ICS files
 - [**CalDAV**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/caldav/): Two-way sync with CalDAV servers
+- [**CalDAV Tasks**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/caldav-tasks/): Two-way VTODO task/reminder sync, tested with iCloud Reminders
 - [**Google Calendar**](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/user/calendars/gcal/): Two-way sync with Google Calendar
 
 Integrations include

--- a/docs/architecture/calendars/provider-implementations.md
+++ b/docs/architecture/calendars/provider-implementations.md
@@ -15,6 +15,7 @@
 | Integration | TaskNotes             | `40`  | Stage 0 local sync. Service/UI integration with provider-owned NLP endpoint. |
 | Virtual     | Holidays              | `5`   | Stage 0 virtual. Computed on-the-fly from bundled data; no vault/network backing. |
 | Remote      | CalDAV                | `110` | Stage 1 & 2 remote async. RFC 4791 protocol support with defensive fallback. |
+| Remote      | CalDAV Tasks          | `115` | Stage 1 & 2 remote async. CalDAV VTODO task collection synchronization. |
 | Remote      | Google                | `120` | Stage 1 & 2 remote async. OAuth authenticated sync with recurrence handling. |
 | Remote      | Google Tasks          | `125` | Stage 1 & 2 remote async. Tasks API integration with union OAuth scope preservation. |
 | Remote      | ICS                   | `140` | Stage 1 & 2 remote async. Read-only hybrid provider (HTTP URL & local file). |
@@ -70,11 +71,20 @@ Timezone and recurrence edge handling rationale is documented in [RRULE Timezone
 
 Uses direct `REPORT`/`GET` flow with robust XML namespace handling and fallback retrieval paths when calendar-data is not returned inline. This is intentionally defensive due to server variability.
 
-#### VTODO & VEVENT Dual-REPORT Architecture
+#### Legacy mixed VTODO & VEVENT dual-REPORT architecture
 - **Dual-REPORT Strategy:** Under the CalDAV RFC 4791 specification, time-range queries cannot filter for both `VEVENT` and `VTODO` components using a logical `OR` condition within a single `calendar-query` report, because sibling `comp-filter` elements are logically ANDed. To query both component types efficiently and standard-compliantly, the provider executes two sequential `REPORT` queries: one for `VEVENT` and one for `VTODO`.
 - **Fallback Avoidance:** If a server does not support standard `REPORT` queries and triggers a compatibility `PROPFIND` fallback (which fetches all files in the collection), the provider flags `fellBack = true` and skips the second `VTODO` `REPORT` query entirely, as the fallback has already fetched all objects (both events and tasks) in a single request.
 - **Content Deduplication:** All retrieved calendar objects are combined and deduplicated based on their raw ICS payload content to eliminate any overlaps.
-- **VTODO Parser/Formatter Mappings:** The ICS parser handles `VTODO` components by mapping them to `OFCEvent` structures (interpreting completion time or `COMPLETED` status, and mapping `due` as the end date). The ICS formatter serializes tasks into standard-compliant `VTODO` elements using `DUE` and `COMPLETED` properties.
+- **Compatibility:** Existing `caldav` sources keep this mixed read path so saved configurations require no migration.
+
+#### CalDAV Tasks provider
+
+- **Source isolation:** `caldavtasks` registers `CalDAVTaskProvider`, which requests only `VCALENDAR > VTODO`. Compatibility fallbacks are filtered through the VTODO codec so `VEVENT` resources cannot enter the task source.
+- **Shared infrastructure:** The provider subclasses the existing CalDAV provider and reuses Basic authentication, SecretStorage IDs, collection validation, XML parsing, REPORT/PROPFIND fallback retrieval, href resolution, backlog scheduling, and request handling.
+- **Protocol model:** `vtodo.ts` maps DTSTART-first placement while retaining DTSTART and DUE independently in `OFCEvent.icalTask`. It also retains status, percent complete, completion time, priority, RRULE, created, and last-modified metadata.
+- **Safe writes:** Create emits `VCALENDAR + VTODO`. Update performs GET → component patch → conditional PUT, preserving UID, resource href, ETag, RRULE, nested alarms, timezone components, and unmapped/X-properties. Completion writes `STATUS:COMPLETED`, `PERCENT-COMPLETE:100`, and `COMPLETED`; reopening removes `COMPLETED` and resets percent complete.
+- **Undated tasks:** The provider implements `TaskBacklogProvider`; VTODOs without valid DTSTART/DUE remain available in the unified backlog instead of entering FullCalendar rendering.
+- **Recurrence boundary:** Existing RRULEs render and survive unrelated edits. Recurrence creation/change and per-instance VTODO writes remain intentionally unsupported.
 
 
 ### Google Provider

--- a/docs/user/calendars/caldav-tasks.md
+++ b/docs/user/calendars/caldav-tasks.md
@@ -1,0 +1,76 @@
+# CalDAV Tasks
+
+**CalDAV Tasks** connects task or reminder collections stored as standard iCalendar `VTODO` resources. It is separate from the regular [CalDAV calendar](caldav.md) source so a task collection is never treated as an appointment calendar.
+
+Tested with iCloud Reminders via its CalDAV `VTODO` collection. This is observed interoperability, not an Apple API guarantee; the implementation uses only standard CalDAV/iCalendar requests.
+
+## Configuration
+
+1. Open **Settings → Full Calendar → Calendar Sources**.
+2. Select **CalDAV Tasks**, then add the source.
+3. Enter the direct task-list collection URL, username, and password.
+4. For iCloud, use the Apple Account email and an [Apple app-specific password](https://support.apple.com/en-us/HT204397). Do not use the normal Apple Account password.
+
+The collection URL must point to the task/reminder calendar itself, for example `https://example-caldav-server/<account>/calendars/tasks/`. Paths vary by server and account. Automatic principal and task-list discovery is not yet included.
+
+Passwords follow Full Calendar's existing CalDAV credential handling. When Obsidian SecretStorage is available, the saved password is removed from plugin settings and is not displayed in the calendar-source row.
+
+## Mapping and synchronization
+
+| VTODO data | Full Calendar behavior |
+| --- | --- |
+| `DTSTART` | Preferred calendar placement |
+| `DUE` without `DTSTART` | Calendar placement; retained as a due value, not an event end |
+| No usable date | Unified Task Backlog |
+| `STATUS:COMPLETED` or `COMPLETED` | Completed task |
+| `PERCENT-COMPLETE:100` | Completed task |
+| `NEEDS-ACTION` / `IN-PROCESS` | Active task |
+| `CANCELLED` | Kept out of the active calendar/backlog |
+| `RRULE` | Parsed for display and preserved during ordinary edits |
+
+Date-only, floating date/time, UTC, and `TZID` values are supported. When both `DTSTART` and `DUE` exist, moving the task shifts both while retaining their interval. Full Calendar does not invent a duration for a due-only reminder.
+
+The source supports:
+
+- Read and refresh without title/date-based duplication.
+- Create with a stable UID and conditional `PUT`.
+- Edit title, date/time, description, and completion.
+- Complete and reopen using `STATUS` plus `COMPLETED`.
+- Delete the exact CalDAV resource URL.
+- ETag conflict protection on updates.
+- Undated task creation and drag scheduling through the Task Backlog.
+
+Updates fetch and patch the original `VTODO`. Unmapped properties, including unknown `X-APPLE-*` extensions and existing recurrence rules, are retained.
+
+## Apple Reminders manual test
+
+Never place credentials or unredacted server responses in screenshots, logs, fixtures, issues, or commits.
+
+1. Generate an Apple app-specific password.
+2. Obtain the account's direct VTODO collection URL and add it as **CalDAV Tasks**.
+3. In Apple Reminders, create `Test reminder` with a due date and time.
+4. Refresh Full Calendar and verify the task, due time, and incomplete checkbox.
+5. Change its title and date/time in Full Calendar; verify both changes in Apple Reminders.
+6. Complete it in Full Calendar; verify it is completed in Apple Reminders.
+7. Reopen it in Full Calendar; verify it becomes active again.
+8. Create a dated task in Full Calendar; verify it appears in Apple Reminders.
+9. Create an undated task in the Full Calendar backlog, then drag it onto the calendar; verify the remote due/scheduled date.
+10. Delete a task from Full Calendar and verify removal in Apple Reminders.
+11. Refresh and restart Obsidian; verify no duplicate resources appear.
+12. Delete or change a task from Apple Reminders and verify the next refresh reflects the remote state.
+
+## Limitations
+
+- Entering an account root and automatically discovering task lists is not yet supported; use a direct collection URL.
+- Existing `RRULE` data is displayed and preserved, but creating/changing recurrence and editing or completing one recurring instance are not yet supported.
+- Cancelled tasks are not rendered because the shared task model has no separate cancelled visual state.
+- Server-side sync tokens are not yet used; refreshes query the VTODO collection and reconcile stable href/UID/ETag identity.
+
+## Troubleshooting
+
+- **Authentication failed (401):** verify the username and app-specific password.
+- **Permission denied (403):** the account can read the collection but cannot perform the requested operation.
+- **Not a calendar collection:** use the direct task-list collection URL rather than an account or principal root.
+- **No VTODO capability:** choose a collection that advertises or contains tasks/reminders.
+- **Conflict (409/412):** refresh first; the task changed remotely after it was loaded.
+- **Malformed iCalendar:** the invalid resource is skipped while other tasks continue loading.

--- a/docs/user/calendars/caldav.md
+++ b/docs/user/calendars/caldav.md
@@ -16,7 +16,7 @@ Calendars are automatically re-fetched from their source at most every five minu
 
 - **Two-Way Sync:** CalDAV calendars now support full two-way synchronization. Changes made in Obsidian are pushed to the server, and remote changes are pulled in periodically.
 - **Video Conferencing & Links:** Automatically parses the RFC 7986 `CONFERENCE` property and Microsoft Teams/Skype meeting URLs, mapping them into the event's location or description. All meeting links and general URLs are rendered as clickable hyperlinks in the [Event Details modal](../events/manage.md#video-conference--linkification-support). For details, see [Video Conference & Linkification Support](../events/manage.md#video-conference--linkification-support).
-- **Task Support (VTODO):** CalDAV calendars support synchronizing tasks (`VTODO` components) in addition to events (`VEVENT`). Completed tasks are synchronized with their completion timestamps, while pending/active tasks are managed with the `NEEDS-ACTION` status. Time-based, all-day, and recurring tasks are fully supported.
+- **Task Support (VTODO):** Existing mixed CalDAV sources retain their legacy VTODO reading and backlog behavior. For task-only collections and VTODO-native create/edit/complete/delete synchronization, use the dedicated [CalDAV Tasks](caldav-tasks.md) source.
 - **Timezones:** Events and tasks are parsed with their source timezone and converted to your Display Timezone for viewing.
 - **Cancellations:** Cancellations/exceptions present on the server are respected.
 

--- a/docs/user/calendars/index.md
+++ b/docs/user/calendars/index.md
@@ -10,7 +10,7 @@
 | Editable markdown-backed events | [Full Note Calendar](local.md) | Best for rich event metadata and file-level control |
 | Compact planning in daily notes | [Daily Note Calendar](dailynote.md) | Fast, lightweight, and daily-note-native |
 | Planning in Journals Day entries | [Journals Calendar](journals.md) | Uses a selected Journals Day journal's normal note creation behavior |
-| External calendar sync | [Google Calendar](gcal.md), [Google Tasks](gtasks.md), [Outlook Calendar](outlook.md), [CalDAV](caldav.md), [ICS](ics.md) | Connect existing external schedules |
+| External calendar sync | [Google Calendar](gcal.md), [Google Tasks](gtasks.md), [Outlook Calendar](outlook.md), [CalDAV](caldav.md), [CalDAV Tasks](caldav-tasks.md), [ICS](ics.md) | Connect existing external schedules and task lists |
 | Tasks as schedulable blocks | [Tasks Plugin Integration](tasks-plugin-integration.md) | Pull tasks into calendar planning flow |
 | Read-only table/bases source | [Obsidian Bases Calendar](bases.md) | Display data-oriented calendar views |
 | Tasks from TaskNotes | [TaskNotes Integration](tasknotes.md) | Sync scheduled tasks from the TaskNotes plugin |
@@ -20,7 +20,7 @@
 
 Local editable: [Full Note](local.md), [Daily Note](dailynote.md), [Journals](journals.md)
 
-Remote/external: [ICS](ics.md), [CalDAV](caldav.md), [Google](gcal.md), [Google Tasks](gtasks.md), [Outlook](outlook.md)  
+Remote/external: [ICS](ics.md), [CalDAV](caldav.md), [CalDAV Tasks](caldav-tasks.md), [Google](gcal.md), [Google Tasks](gtasks.md), [Outlook](outlook.md)
 Integrations: [Tasks](tasks-plugin-integration.md), [TaskNotes](tasknotes.md), [Bases](bases.md), [ActivityWatch](activitywatch.md), [Holidays](holidays.md)
 
 ## Related Sections
@@ -29,4 +29,4 @@ Integrations: [Tasks](tasks-plugin-integration.md), [TaskNotes](tasknotes.md), [
 - [Working with Events](../events/index.md)
 - [Troubleshooting](../guides/troubleshooting.md)
 
-Compact index: [Full Note](local.md) · [Daily Note](dailynote.md) · [Journals](journals.md) · [ICS](ics.md) · [CalDAV](caldav.md) · [Google](gcal.md) · [Google Tasks](gtasks.md) · [Outlook](outlook.md) · [Holidays](holidays.md) · [Tasks](tasks-plugin-integration.md) · [TaskNotes](tasknotes.md) · [Bases](bases.md) · [ActivityWatch](activitywatch.md) · [Architecture](../../architecture/calendars/architecture.md)
+Compact index: [Full Note](local.md) · [Daily Note](dailynote.md) · [Journals](journals.md) · [ICS](ics.md) · [CalDAV](caldav.md) · [CalDAV Tasks](caldav-tasks.md) · [Google](gcal.md) · [Google Tasks](gtasks.md) · [Outlook](outlook.md) · [Holidays](holidays.md) · [Tasks](tasks-plugin-integration.md) · [TaskNotes](tasknotes.md) · [Bases](bases.md) · [ActivityWatch](activitywatch.md) · [Architecture](../../architecture/calendars/architecture.md)

--- a/docs/user/reference/network_requests.md
+++ b/docs/user/reference/network_requests.md
@@ -30,9 +30,9 @@ This page acts as a complete, audited registry of all network communications per
 - **Purpose:** Authenticating accounts, fetching remote calendars, and uploading event modifications.
 - **Trigger:** Scheduled sync sweeps, calendar view updates, or manual interactions.
 
-### CalDAV Calendar
+### CalDAV Calendar and CalDAV Tasks
 - **Connection:** Inbound & Outbound (Internet)
-- **Related Guides:** [CalDAV Guide](../calendars/caldav.md)
+- **Related Guides:** [CalDAV Guide](../calendars/caldav.md) | [CalDAV Tasks](../calendars/caldav-tasks.md)
 - **Endpoints:** User-specified custom CalDAV host (e.g. Nextcloud, Fastmail, Apple iCloud, Synology, Radicale).
 - **Purpose:** Synchronizing calendar events and tasks (VTODO) using standard HTTP methods (`PROPFIND`, `REPORT`, `GET`, `PUT`, `DELETE`).
 - **Trigger:** Periodic background sync cycles or manual refresh.
@@ -89,5 +89,3 @@ This page acts as a complete, audited registry of all network communications per
 - **Endpoints:** User-configured local daemon API port (default: `http://127.0.0.1:45677`).
 - **Purpose:** Probing daemon status (`/status`) and pushing notification payloads (`/sync`) to trigger desktop notifications.
 - **Trigger:** Background timer pinging and sync cycles when reminders are enabled.
-
-

--- a/docs/user/settings/sources.md
+++ b/docs/user/settings/sources.md
@@ -20,6 +20,7 @@ Access these settings in **Full Calendar Settings → Calendar Sources**.
     *   **Standard Setup**: Connect using the built-in [OAuth flow](../calendars/gcal.md).
     *   **Custom Client**: Enable `Use custom Google client` to provide your own `Client ID` and `Client Secret` for increased privacy or rate-limit control.
 *   **CalDAV**: Connect to iCloud, Nextcloud, or Fastmail. See: [CalDAV Setup](../calendars/caldav.md).
+*   **CalDAV Tasks**: Connect a VTODO task/reminder collection, including iCloud Reminders. See: [CalDAV Tasks](../calendars/caldav-tasks.md).
 *   **ICS (Remote/Local)**: 
     *   **Remote**: Provide a public or secret `.ics` URL.
     *   **Local**: Provide a path to a `.ics` file stored within your Obsidian vault. See: [ICS Guide](../calendars/ics.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
                 - Journals Calendar: user/calendars/journals.md
                 - ICS (Remote and Local): user/calendars/ics.md
                 - CalDAV: user/calendars/caldav.md
+                - CalDAV Tasks: user/calendars/caldav-tasks.md
                 - Google Calendar: user/calendars/gcal.md
                 - Google Tasks: user/calendars/gtasks.md
                 - Outlook Calendar: user/calendars/outlook.md

--- a/src/features/credentials/CredentialStore.ts
+++ b/src/features/credentials/CredentialStore.ts
@@ -254,7 +254,7 @@ export class CredentialStore {
     if (this.useLegacy() || !this.isSecretStorageSupported()) {
       try {
         const source = PluginState.getSettings().calendarSources.find(s => s.id === sourceId);
-        if (source && source.type === 'caldav') {
+        if (source && (source.type === 'caldav' || source.type === 'caldavtasks')) {
           return source.password ?? null;
         }
       } catch {
@@ -270,7 +270,7 @@ export class CredentialStore {
     if (this.useLegacy() || !this.isSecretStorageSupported()) {
       try {
         const source = PluginState.getSettings().calendarSources.find(s => s.id === sourceId);
-        if (source && source.type === 'caldav') {
+        if (source && (source.type === 'caldav' || source.type === 'caldavtasks')) {
           source.password = password ?? '';
         }
       } catch {
@@ -281,7 +281,7 @@ export class CredentialStore {
       // Clear from settings
       try {
         const source = PluginState.getSettings().calendarSources.find(s => s.id === sourceId);
-        if (source && source.type === 'caldav') {
+        if (source && (source.type === 'caldav' || source.type === 'caldavtasks')) {
           source.password = '';
         }
       } catch {

--- a/src/features/i18n/locales/de.json
+++ b/src/features/i18n/locales/de.json
@@ -693,7 +693,8 @@
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
         "holidays": "Holidays",
-        "journals": "Journals"
+        "journals": "Journals",
+        "caldavTasks": "CalDAV Tasks"
       },
       "fullNote": {
         "directory": {
@@ -763,7 +764,14 @@
         },
         "importButton": "Kalender importieren",
         "importing": "Importiere...",
-        "importFailed": "Import des Kalenders fehlgeschlagen"
+        "importFailed": "Import des Kalenders fehlgeschlagen",
+        "errors": {
+          "authentication": "CalDAV authentication failed (HTTP 401).",
+          "permissionDenied": "CalDAV permission denied (HTTP 403).",
+          "invalidCollection": "The URL is not a valid CalDAV calendar collection. Enter the direct collection URL.",
+          "conflict": "The remote CalDAV resource changed (HTTP {{status}}). Refresh and try again.",
+          "requestFailed": "CalDAV request failed (HTTP {{status}}): {{statusText}}"
+        }
       },
       "tasks": {
         "zeroConfig": {
@@ -817,7 +825,8 @@
         "bases": "Bases-Kalender",
         "taskNotes": "TaskNote-Integration",
         "outlook": "Outlook-Kalender",
-        "journals": "Journals calendar"
+        "journals": "Journals calendar",
+        "caldavTasks": "CalDAV Tasks"
       },
       "linkedNotes": {
         "title": "Einstellungen für verknüpfte Notizen",
@@ -864,6 +873,28 @@
           }
         },
         "adding": "Wird hinzugefügt..."
+      },
+      "caldavTasks": {
+        "title": "CalDAV Tasks",
+        "description": "Connect VTODO-compatible CalDAV task lists, including Apple Reminders.",
+        "backlogTitle": "CalDAV Tasks backlog",
+        "untitledTask": "Untitled task",
+        "importButton": "Add task list",
+        "importFailed": "Failed to add CalDAV task list",
+        "errors": {
+          "importFailedDetails": "Failed to add CalDAV task list: {{message}}",
+          "invalidCollection": "The URL is not a valid CalDAV task collection. Enter the direct task-list collection URL.",
+          "noVtodoCapability": "This CalDAV collection does not advertise VTODO support. Choose a task or reminder collection.",
+          "skippedMalformed": "Skipped {{count}} malformed CalDAV task resource(s).",
+          "recurringCreation": "Creating recurring CalDAV tasks is not yet supported.",
+          "unsupportedType": "This CalDAV VTODO event type is not supported.",
+          "missingUid": "Cannot update a CalDAV task without a UID.",
+          "completionUpdate": "Failed to update CalDAV task completion.",
+          "recurringInstance": "Editing individual recurring CalDAV task instances is not yet supported.",
+          "vtodoNotFound": "CalDAV task {{uid}} was not found in its resource.",
+          "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
+          "malformedData": "Malformed iCalendar data: {{message}}"
+        }
       }
     },
     "categorization": {
@@ -1318,7 +1349,8 @@
       "tooltips": {
         "recurringTaskCompletion": "Die Fertigstellung für wiederkehrende Aufgaben kann für einzelne Instanzen in der Kalenderansicht umgeschaltet werden.",
         "dailyNoteRecurring": "Wiederkehrende Ereignisse werden in Tagesnotizen nicht unterstützt. Bitte verwenden Sie stattdessen einen 'Vollständige Notiz'-Kalender.",
-        "inheritedProperty": "Diese Eigenschaft wird vererbt. Klicken Sie, um das übergeordnete wiederkehrende Ereignis zu bearbeiten."
+        "inheritedProperty": "Diese Eigenschaft wird vererbt. Klicken Sie, um das übergeordnete wiederkehrende Ereignis zu bearbeiten.",
+        "caldavTaskRecurrence": "Existing VTODO recurrence is preserved, but creating or changing recurring CalDAV tasks is not yet supported."
       }
     },
     "deleteRecurring": {

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -804,6 +804,7 @@
         "journals": "Journals",
         "icloud": "iCloud",
         "caldav": "CalDAV",
+        "caldavTasks": "CalDAV Tasks",
         "ical": "ICS",
         "google": "Google Calendar",
         "outlook": "Outlook Calendar",
@@ -880,7 +881,36 @@
         },
         "importButton": "Import Calendars",
         "importing": "Importing...",
-        "importFailed": "Failed to import calendar"
+        "importFailed": "Failed to import calendar",
+        "errors": {
+          "authentication": "CalDAV authentication failed (HTTP 401).",
+          "permissionDenied": "CalDAV permission denied (HTTP 403).",
+          "invalidCollection": "The URL is not a valid CalDAV calendar collection. Enter the direct collection URL.",
+          "conflict": "The remote CalDAV resource changed (HTTP {{status}}). Refresh and try again.",
+          "requestFailed": "CalDAV request failed (HTTP {{status}}): {{statusText}}"
+        }
+      },
+      "caldavTasks": {
+        "title": "CalDAV Tasks",
+        "description": "Connect VTODO-compatible CalDAV task lists, including Apple Reminders.",
+        "backlogTitle": "CalDAV Tasks backlog",
+        "untitledTask": "Untitled task",
+        "importButton": "Add task list",
+        "importFailed": "Failed to add CalDAV task list",
+        "errors": {
+          "importFailedDetails": "Failed to add CalDAV task list: {{message}}",
+          "invalidCollection": "The URL is not a valid CalDAV task collection. Enter the direct task-list collection URL.",
+          "noVtodoCapability": "This CalDAV collection does not advertise VTODO support. Choose a task or reminder collection.",
+          "skippedMalformed": "Skipped {{count}} malformed CalDAV task resource(s).",
+          "recurringCreation": "Creating recurring CalDAV tasks is not yet supported.",
+          "unsupportedType": "This CalDAV VTODO event type is not supported.",
+          "missingUid": "Cannot update a CalDAV task without a UID.",
+          "completionUpdate": "Failed to update CalDAV task completion.",
+          "recurringInstance": "Editing individual recurring CalDAV task instances is not yet supported.",
+          "vtodoNotFound": "CalDAV task {{uid}} was not found in its resource.",
+          "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
+          "malformedData": "Malformed iCalendar data: {{message}}"
+        }
       },
       "tasks": {
         "zeroConfig": {
@@ -971,6 +1001,7 @@
         "journals": "Journals calendar",
         "ics": "ICS calendars",
         "caldav": "CalDAV calendars",
+        "caldavTasks": "CalDAV Tasks",
         "google": "Google calendar",
         "outlook": "Outlook calendar",
         "tasks": "Tasks integration",
@@ -1328,6 +1359,7 @@
       "tooltips": {
         "recurringTaskCompletion": "Completion for recurring tasks can be toggled on individual instances in the calendar view.",
         "dailyNoteRecurring": "Recurring events are not supported in Daily Notes. Please use a 'Full Note' calendar instead.",
+        "caldavTaskRecurrence": "Existing VTODO recurrence is preserved, but creating or changing recurring CalDAV tasks is not yet supported.",
         "inheritedProperty": "This property is inherited. Click to edit the parent recurring event."
       }
     },

--- a/src/features/i18n/locales/es.json
+++ b/src/features/i18n/locales/es.json
@@ -693,7 +693,8 @@
         "tasknotes": "TaskNotes",
         "outlook": "Calendario de Outlook",
         "holidays": "Festivos",
-        "journals": "Journals"
+        "journals": "Journals",
+        "caldavTasks": "CalDAV Tasks"
       },
       "fullNote": {
         "directory": {
@@ -763,7 +764,14 @@
         },
         "importButton": "Importar calendarios",
         "importing": "Importando...",
-        "importFailed": "No se pudo importar el calendario"
+        "importFailed": "No se pudo importar el calendario",
+        "errors": {
+          "authentication": "CalDAV authentication failed (HTTP 401).",
+          "permissionDenied": "CalDAV permission denied (HTTP 403).",
+          "invalidCollection": "The URL is not a valid CalDAV calendar collection. Enter the direct collection URL.",
+          "conflict": "The remote CalDAV resource changed (HTTP {{status}}). Refresh and try again.",
+          "requestFailed": "CalDAV request failed (HTTP {{status}}): {{statusText}}"
+        }
       },
       "tasks": {
         "zeroConfig": {
@@ -817,7 +825,8 @@
         "bases": "Calendario de Bases",
         "taskNotes": "Integración de TaskNote",
         "outlook": "Calendario de Outlook",
-        "journals": "Journals calendar"
+        "journals": "Journals calendar",
+        "caldavTasks": "CalDAV Tasks"
       },
       "linkedNotes": {
         "title": "Configuración de notas vinculadas",
@@ -864,6 +873,28 @@
           }
         },
         "adding": "Agregando..."
+      },
+      "caldavTasks": {
+        "title": "CalDAV Tasks",
+        "description": "Connect VTODO-compatible CalDAV task lists, including Apple Reminders.",
+        "backlogTitle": "CalDAV Tasks backlog",
+        "untitledTask": "Untitled task",
+        "importButton": "Add task list",
+        "importFailed": "Failed to add CalDAV task list",
+        "errors": {
+          "importFailedDetails": "Failed to add CalDAV task list: {{message}}",
+          "invalidCollection": "The URL is not a valid CalDAV task collection. Enter the direct task-list collection URL.",
+          "noVtodoCapability": "This CalDAV collection does not advertise VTODO support. Choose a task or reminder collection.",
+          "skippedMalformed": "Skipped {{count}} malformed CalDAV task resource(s).",
+          "recurringCreation": "Creating recurring CalDAV tasks is not yet supported.",
+          "unsupportedType": "This CalDAV VTODO event type is not supported.",
+          "missingUid": "Cannot update a CalDAV task without a UID.",
+          "completionUpdate": "Failed to update CalDAV task completion.",
+          "recurringInstance": "Editing individual recurring CalDAV task instances is not yet supported.",
+          "vtodoNotFound": "CalDAV task {{uid}} was not found in its resource.",
+          "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
+          "malformedData": "Malformed iCalendar data: {{message}}"
+        }
       }
     },
     "categorization": {
@@ -1318,7 +1349,8 @@
       "tooltips": {
         "recurringTaskCompletion": "La finalización de tareas recurrentes puede alternarse en instancias individuales en la vista de calendario.",
         "dailyNoteRecurring": "Los eventos recurrentes no son compatibles en Notas Diarias. Por favor usa un calendario de 'Nota completa'.",
-        "inheritedProperty": "Esta propiedad se hereda. Haz clic para editar el evento recurrente padre."
+        "inheritedProperty": "Esta propiedad se hereda. Haz clic para editar el evento recurrente padre.",
+        "caldavTaskRecurrence": "Existing VTODO recurrence is preserved, but creating or changing recurring CalDAV tasks is not yet supported."
       }
     },
     "deleteRecurring": {

--- a/src/features/i18n/locales/fr.json
+++ b/src/features/i18n/locales/fr.json
@@ -693,7 +693,8 @@
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
         "holidays": "Holidays",
-        "journals": "Journals"
+        "journals": "Journals",
+        "caldavTasks": "CalDAV Tasks"
       },
       "fullNote": {
         "directory": {
@@ -763,7 +764,14 @@
         },
         "importButton": "Importer les calendriers",
         "importing": "Importation...",
-        "importFailed": "Échec de l'importation du calendrier"
+        "importFailed": "Échec de l'importation du calendrier",
+        "errors": {
+          "authentication": "CalDAV authentication failed (HTTP 401).",
+          "permissionDenied": "CalDAV permission denied (HTTP 403).",
+          "invalidCollection": "The URL is not a valid CalDAV calendar collection. Enter the direct collection URL.",
+          "conflict": "The remote CalDAV resource changed (HTTP {{status}}). Refresh and try again.",
+          "requestFailed": "CalDAV request failed (HTTP {{status}}): {{statusText}}"
+        }
       },
       "tasks": {
         "zeroConfig": {
@@ -817,7 +825,8 @@
         "bases": "Calendrier Bases",
         "taskNotes": "Intégration TaskNote",
         "outlook": "Outlook calendar",
-        "journals": "Journals calendar"
+        "journals": "Journals calendar",
+        "caldavTasks": "CalDAV Tasks"
       },
       "linkedNotes": {
         "title": "Paramètres des notes liées",
@@ -864,6 +873,28 @@
           }
         },
         "adding": "Ajout..."
+      },
+      "caldavTasks": {
+        "title": "CalDAV Tasks",
+        "description": "Connect VTODO-compatible CalDAV task lists, including Apple Reminders.",
+        "backlogTitle": "CalDAV Tasks backlog",
+        "untitledTask": "Untitled task",
+        "importButton": "Add task list",
+        "importFailed": "Failed to add CalDAV task list",
+        "errors": {
+          "importFailedDetails": "Failed to add CalDAV task list: {{message}}",
+          "invalidCollection": "The URL is not a valid CalDAV task collection. Enter the direct task-list collection URL.",
+          "noVtodoCapability": "This CalDAV collection does not advertise VTODO support. Choose a task or reminder collection.",
+          "skippedMalformed": "Skipped {{count}} malformed CalDAV task resource(s).",
+          "recurringCreation": "Creating recurring CalDAV tasks is not yet supported.",
+          "unsupportedType": "This CalDAV VTODO event type is not supported.",
+          "missingUid": "Cannot update a CalDAV task without a UID.",
+          "completionUpdate": "Failed to update CalDAV task completion.",
+          "recurringInstance": "Editing individual recurring CalDAV task instances is not yet supported.",
+          "vtodoNotFound": "CalDAV task {{uid}} was not found in its resource.",
+          "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
+          "malformedData": "Malformed iCalendar data: {{message}}"
+        }
       }
     },
     "categorization": {
@@ -1318,7 +1349,8 @@
       "tooltips": {
         "recurringTaskCompletion": "La complétion des tâches récurrentes peut être activée sur chaque instance dans la vue calendrier.",
         "dailyNoteRecurring": "Les événements récurrents ne sont pas pris en charge dans les notes quotidiennes. Veuillez utiliser un calendrier 'Note complète' à la place.",
-        "inheritedProperty": "Cette propriété est héritée. Cliquez pour modifier l'événement récurrent parent."
+        "inheritedProperty": "Cette propriété est héritée. Cliquez pour modifier l'événement récurrent parent.",
+        "caldavTaskRecurrence": "Existing VTODO recurrence is preserved, but creating or changing recurring CalDAV tasks is not yet supported."
       }
     },
     "deleteRecurring": {

--- a/src/features/i18n/locales/it.json
+++ b/src/features/i18n/locales/it.json
@@ -693,7 +693,8 @@
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
         "holidays": "Holidays",
-        "journals": "Journals"
+        "journals": "Journals",
+        "caldavTasks": "CalDAV Tasks"
       },
       "fullNote": {
         "directory": {
@@ -763,7 +764,14 @@
         },
         "importButton": "Importa calendari",
         "importing": "Importazione...",
-        "importFailed": "Impossibile importare il calendario"
+        "importFailed": "Impossibile importare il calendario",
+        "errors": {
+          "authentication": "CalDAV authentication failed (HTTP 401).",
+          "permissionDenied": "CalDAV permission denied (HTTP 403).",
+          "invalidCollection": "The URL is not a valid CalDAV calendar collection. Enter the direct collection URL.",
+          "conflict": "The remote CalDAV resource changed (HTTP {{status}}). Refresh and try again.",
+          "requestFailed": "CalDAV request failed (HTTP {{status}}): {{statusText}}"
+        }
       },
       "tasks": {
         "zeroConfig": {
@@ -817,7 +825,8 @@
         "bases": "Calendario Bases",
         "taskNotes": "Integrazione TaskNote",
         "outlook": "Outlook calendar",
-        "journals": "Journals calendar"
+        "journals": "Journals calendar",
+        "caldavTasks": "CalDAV Tasks"
       },
       "linkedNotes": {
         "title": "Impostazioni note collegate",
@@ -864,6 +873,28 @@
           }
         },
         "adding": "Aggiunta..."
+      },
+      "caldavTasks": {
+        "title": "CalDAV Tasks",
+        "description": "Connect VTODO-compatible CalDAV task lists, including Apple Reminders.",
+        "backlogTitle": "CalDAV Tasks backlog",
+        "untitledTask": "Untitled task",
+        "importButton": "Add task list",
+        "importFailed": "Failed to add CalDAV task list",
+        "errors": {
+          "importFailedDetails": "Failed to add CalDAV task list: {{message}}",
+          "invalidCollection": "The URL is not a valid CalDAV task collection. Enter the direct task-list collection URL.",
+          "noVtodoCapability": "This CalDAV collection does not advertise VTODO support. Choose a task or reminder collection.",
+          "skippedMalformed": "Skipped {{count}} malformed CalDAV task resource(s).",
+          "recurringCreation": "Creating recurring CalDAV tasks is not yet supported.",
+          "unsupportedType": "This CalDAV VTODO event type is not supported.",
+          "missingUid": "Cannot update a CalDAV task without a UID.",
+          "completionUpdate": "Failed to update CalDAV task completion.",
+          "recurringInstance": "Editing individual recurring CalDAV task instances is not yet supported.",
+          "vtodoNotFound": "CalDAV task {{uid}} was not found in its resource.",
+          "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
+          "malformedData": "Malformed iCalendar data: {{message}}"
+        }
       }
     },
     "categorization": {
@@ -1318,7 +1349,8 @@
       "tooltips": {
         "recurringTaskCompletion": "Il completamento dei task ricorrenti può essere attivato sulle singole istanze nella vista calendario.",
         "dailyNoteRecurring": "Gli eventi ricorrenti non sono supportati nelle Note Giornaliere. Usa invece un calendario 'Nota completa'.",
-        "inheritedProperty": "Questa proprietà è ereditata. Clicca per modificare l'evento ricorrente genitore."
+        "inheritedProperty": "Questa proprietà è ereditata. Clicca per modificare l'evento ricorrente genitore.",
+        "caldavTaskRecurrence": "Existing VTODO recurrence is preserved, but creating or changing recurring CalDAV tasks is not yet supported."
       }
     },
     "deleteRecurring": {

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -693,7 +693,8 @@
         "tasknotes": "TaskNotes",
         "outlook": "Outlook Calendar",
         "holidays": "Holidays",
-        "journals": "Journals"
+        "journals": "Journals",
+        "caldavTasks": "CalDAV Tasks"
       },
       "fullNote": {
         "directory": {
@@ -763,7 +764,14 @@
         },
         "importButton": "导入日历",
         "importing": "正在导入...",
-        "importFailed": "导入日历失败"
+        "importFailed": "导入日历失败",
+        "errors": {
+          "authentication": "CalDAV authentication failed (HTTP 401).",
+          "permissionDenied": "CalDAV permission denied (HTTP 403).",
+          "invalidCollection": "The URL is not a valid CalDAV calendar collection. Enter the direct collection URL.",
+          "conflict": "The remote CalDAV resource changed (HTTP {{status}}). Refresh and try again.",
+          "requestFailed": "CalDAV request failed (HTTP {{status}}): {{statusText}}"
+        }
       },
       "tasks": {
         "zeroConfig": {
@@ -817,7 +825,8 @@
         "bases": "Bases 日历",
         "taskNotes": "TaskNotes 集成",
         "outlook": "Outlook 日历",
-        "journals": "Journals calendar"
+        "journals": "Journals calendar",
+        "caldavTasks": "CalDAV Tasks"
       },
       "linkedNotes": {
         "title": "链接笔记设置",
@@ -864,6 +873,28 @@
           }
         },
         "adding": "正在添加..."
+      },
+      "caldavTasks": {
+        "title": "CalDAV Tasks",
+        "description": "Connect VTODO-compatible CalDAV task lists, including Apple Reminders.",
+        "backlogTitle": "CalDAV Tasks backlog",
+        "untitledTask": "Untitled task",
+        "importButton": "Add task list",
+        "importFailed": "Failed to add CalDAV task list",
+        "errors": {
+          "importFailedDetails": "Failed to add CalDAV task list: {{message}}",
+          "invalidCollection": "The URL is not a valid CalDAV task collection. Enter the direct task-list collection URL.",
+          "noVtodoCapability": "This CalDAV collection does not advertise VTODO support. Choose a task or reminder collection.",
+          "skippedMalformed": "Skipped {{count}} malformed CalDAV task resource(s).",
+          "recurringCreation": "Creating recurring CalDAV tasks is not yet supported.",
+          "unsupportedType": "This CalDAV VTODO event type is not supported.",
+          "missingUid": "Cannot update a CalDAV task without a UID.",
+          "completionUpdate": "Failed to update CalDAV task completion.",
+          "recurringInstance": "Editing individual recurring CalDAV task instances is not yet supported.",
+          "vtodoNotFound": "CalDAV task {{uid}} was not found in its resource.",
+          "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
+          "malformedData": "Malformed iCalendar data: {{message}}"
+        }
       }
     },
     "categorization": {
@@ -1318,7 +1349,8 @@
       "tooltips": {
         "recurringTaskCompletion": "重复任务的完成状态可以在日历视图中切换单个实例。",
         "dailyNoteRecurring": "日记不支持重复事件。请改用 \"Full Note\" 日历。",
-        "inheritedProperty": "此属性是继承的。点击编辑父重复事件。"
+        "inheritedProperty": "此属性是继承的。点击编辑父重复事件。",
+        "caldavTaskRecurrence": "Existing VTODO recurrence is preserved, but creating or changing recurring CalDAV tasks is not yet supported."
       }
     },
     "deleteRecurring": {

--- a/src/providers/ProviderRegistry.ts
+++ b/src/providers/ProviderRegistry.ts
@@ -116,6 +116,7 @@ export class ProviderRegistry {
     this.register('journals', () => import('./journals/JournalsProvider'));
     this.register('ical', () => import('./ics/ICSProvider'));
     this.register('caldav', () => import('./caldav/CalDAVProvider'));
+    this.register('caldavtasks', () => import('./caldav/CalDAVTaskProvider'));
     this.register('google', () => import('./google/GoogleProvider'));
     this.register('googletasks', () => import('./googletasks/GoogleTasksProvider'));
     this.register('outlook', () => import('./outlook/OutlookProvider'));

--- a/src/providers/caldav/CalDAVConfigComponent.tsx
+++ b/src/providers/caldav/CalDAVConfigComponent.tsx
@@ -13,12 +13,14 @@ interface CalDAVConfigComponentProps {
   config: Partial<CalDAVProviderConfig>;
   onSave: (configs: CalDAVProviderConfig[]) => void;
   onClose: () => void;
+  mode?: 'events' | 'tasks';
 }
 
 export const CalDAVConfigComponent: React.FC<CalDAVConfigComponentProps> = ({
   config,
   onSave,
-  onClose
+  onClose,
+  mode = 'events'
 }) => {
   const [url, setUrl] = useState(config.url || '');
   const [username, setUsername] = useState(config.username || '');
@@ -29,7 +31,11 @@ export const CalDAVConfigComponent: React.FC<CalDAVConfigComponentProps> = ({
     return config.password || '';
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitText, setSubmitText] = useState(t('settings.calendars.caldav.importButton'));
+  const importButtonKey =
+    mode === 'tasks'
+      ? 'settings.calendars.caldavTasks.importButton'
+      : 'settings.calendars.caldav.importButton';
+  const [submitText, setSubmitText] = useState(t(importButtonKey));
 
   const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -40,17 +46,24 @@ export const CalDAVConfigComponent: React.FC<CalDAVConfigComponentProps> = ({
     let shouldResetFormState = true;
 
     try {
-      const sources = await importCalendars({ type: 'basic', username, password }, url, []);
+      const sources =
+        mode === 'tasks'
+          ? await importCalendars({ type: 'basic', username, password }, url, [], 'caldavtasks')
+          : await importCalendars({ type: 'basic', username, password }, url, []);
       onSave(sources);
       shouldResetFormState = false;
       onClose();
     } catch (error) {
-      console.error('Failed to import CalDAV calendars', error);
+      const errorKey =
+        mode === 'tasks'
+          ? 'settings.calendars.caldavTasks.importFailed'
+          : 'settings.calendars.caldav.importFailed';
+      console.error(t(errorKey), error);
       const details = error instanceof Error ? error.message : String(error);
-      showNotice(`${t('settings.calendars.caldav.importFailed')}: ${details}`);
+      showNotice(`${t(errorKey)}: ${details}`);
     } finally {
       if (shouldResetFormState) {
-        setSubmitText(t('settings.calendars.caldav.importButton'));
+        setSubmitText(t(importButtonKey));
         setIsSubmitting(false);
       }
     }
@@ -63,6 +76,16 @@ export const CalDAVConfigComponent: React.FC<CalDAVConfigComponentProps> = ({
         void handleSubmit(e);
       }}
     >
+      {mode === 'tasks' && (
+        <div className="setting-item">
+          <div className="setting-item-info">
+            <div className="setting-item-name">{t('settings.calendars.caldavTasks.title')}</div>
+            <div className="setting-item-description">
+              {t('settings.calendars.caldavTasks.description')}
+            </div>
+          </div>
+        </div>
+      )}
       <div className="setting-item">
         <div className="setting-item-info">
           <div className="setting-item-name">{t('settings.calendars.caldav.url.label')}</div>

--- a/src/providers/caldav/CalDAVProvider.ts
+++ b/src/providers/caldav/CalDAVProvider.ts
@@ -29,11 +29,12 @@ import { PluginState } from '../../core/PluginState';
 import { DateTime } from 'luxon';
 import { isTask } from '../../types/tasks';
 import { modifyFrontmatterString } from '../fullnote/frontmatter';
+import { t } from '../../features/i18n/i18n';
 
 import { fetchCalendarInfo } from './helper_caldav';
 
 // Helper function to ensure URL formatting is consistent.
-function canonCollection(u?: string): string {
+export function canonCollection(u?: string): string {
   return u ? (u.endsWith('/') ? u : `${u}/`) : (u as unknown as string);
 }
 
@@ -106,6 +107,7 @@ export type CalDAVTaskInboxItem = {
   status: string;
   completed: boolean;
   etag?: string;
+  href?: string;
 };
 
 export function encodeCalDAVTaskId(calendarId: string, uid: string): string {
@@ -148,6 +150,62 @@ function getSuccessfulPropNode(response: Element): Element | null {
   }
 
   return null;
+}
+
+function extractCalendarDataFromMultiStatus(doc: Document): CalendarObjectData[] {
+  const icsList: CalendarObjectData[] = [];
+  const responses = Array.from(doc.getElementsByTagNameNS('*', 'response'));
+
+  for (const response of responses) {
+    const hrefNode =
+      response.getElementsByTagNameNS('DAV:', 'href')[0] ||
+      response.getElementsByTagNameNS('*', 'href')[0];
+    const href = hrefNode?.textContent?.trim() || '';
+    const propstats = Array.from(response.getElementsByTagNameNS('*', 'propstat'));
+    const successfulProps: Element[] = [];
+
+    for (const propstat of propstats) {
+      const status = propstat.getElementsByTagNameNS('*', 'status')[0]?.textContent || '';
+      const statusCode = parseStatusCode(status);
+      if (statusCode === null || statusCode < 200 || statusCode >= 300) continue;
+
+      const prop = propstat.getElementsByTagNameNS('*', 'prop')[0];
+      if (prop) successfulProps.push(prop);
+    }
+
+    const calendarData = successfulProps
+      .flatMap(prop => {
+        const namespaced = Array.from(
+          prop.getElementsByTagNameNS('urn:ietf:params:xml:ns:caldav', 'calendar-data')
+        );
+        return namespaced.length > 0
+          ? namespaced
+          : Array.from(prop.getElementsByTagNameNS('*', 'calendar-data'));
+      })
+      .find(node => Boolean(node.textContent?.trim()));
+
+    // Apple includes the collection itself in a 207 response. Its calendar-data
+    // property is empty or belongs to a 404 propstat; neither is a task resource.
+    if (!calendarData?.textContent?.trim()) continue;
+
+    let etag: string | undefined;
+    for (const prop of successfulProps) {
+      etag =
+        prop.getElementsByTagNameNS('DAV:', 'getetag')[0]?.textContent?.trim() ||
+        prop.getElementsByTagNameNS('*', 'getetag')[0]?.textContent?.trim() ||
+        etag;
+    }
+
+    icsList.push({
+      href,
+      // Parsing stays resource-scoped in the provider so one malformed object
+      // cannot discard other valid resources from the same 207 response.
+      ics: calendarData.textContent.trim(),
+      etag: etag || undefined
+    });
+  }
+
+  return icsList;
 }
 
 function extractCalendarObjectRefs(doc: Document): CalendarObjectRef[] {
@@ -208,9 +266,11 @@ function isUnscheduledTodo(todo: ical.Component): boolean {
 }
 
 function isCompletedTodo(todo: ical.Component): boolean {
+  const percentComplete = Number(getTextProperty(todo, 'percent-complete'));
   return (
     getTextProperty(todo, 'status').toUpperCase() === 'COMPLETED' ||
-    Boolean(todo.getFirstProperty('completed'))
+    Boolean(todo.getFirstProperty('completed')) ||
+    percentComplete === 100
   );
 }
 
@@ -218,7 +278,7 @@ function parseVCalendar(ics: string): ical.Component {
   return new ical.Component(ical.parse(ics));
 }
 
-function createRandomUid(): string {
+export function createRandomUid(): string {
   if (typeof window !== 'undefined' && window.crypto?.randomUUID) {
     return window.crypto.randomUUID();
   }
@@ -236,6 +296,7 @@ function createUnscheduledTaskIcs(uid: string, title: string): string {
   todo.addPropertyWithValue('summary', title);
   todo.addPropertyWithValue('dtstamp', ical.Time.now());
   todo.addPropertyWithValue('status', 'NEEDS-ACTION');
+  todo.addPropertyWithValue('percent-complete', 0);
   vcalendar.addSubcomponent(todo);
 
   return (vcalendar as unknown as { toString(): string }).toString();
@@ -321,6 +382,9 @@ function parseUnscheduledTasksFromObject(
     if (!isUnscheduledTodo(todo)) {
       continue;
     }
+    if (getTextProperty(todo, 'status').toUpperCase() === 'CANCELLED') {
+      continue;
+    }
 
     const uid = getTaskUid(todo);
     if (!uid) {
@@ -338,7 +402,8 @@ function parseUnscheduledTasksFromObject(
       url: getTextProperty(todo, 'url'),
       status: getTextProperty(todo, 'status'),
       completed: isCompletedTodo(todo),
-      etag: object.etag
+      etag: object.etag,
+      href: object.href
     });
   }
 
@@ -587,7 +652,7 @@ async function fetchCalendarObjectsForComponent(
       const list = await fetchCalendarObjectsViaPropfindFallback(collectionUrl, authHeader);
       return { icsList: list, fellBack: true };
     }
-    console.error(`[CalDAVProvider] REPORT request failed`, reportRes.status, xml.slice(0, 800));
+    console.error(`[CalDAVProvider] REPORT request failed`, reportRes.status);
     throw new Error(`REPORT ${reportRes.status}`);
   }
 
@@ -595,60 +660,8 @@ async function fetchCalendarObjectsForComponent(
 
   // STEP 2: Parse the XML response using DOMParser
   const doc = ensureXmlDocument(xml, 'CalDAV REPORT');
-  const icsList: CalendarObjectData[] = [];
-
-  const responses = doc.getElementsByTagNameNS('*', 'response');
-  const allResponses = Array.from(responses);
-
-  for (const response of allResponses) {
-    const propstats = response.getElementsByTagNameNS('*', 'propstat');
-
-    for (let i = 0; i < propstats.length; i++) {
-      const propstat = propstats[i];
-      const status = propstat.getElementsByTagNameNS('*', 'status')[0]?.textContent || '';
-      const statusCode = parseStatusCode(status);
-      if (statusCode === null || statusCode < 200 || statusCode >= 300) continue;
-
-      const prop = propstat.getElementsByTagNameNS('*', 'prop')[0];
-      if (!prop) continue;
-
-      // Try to find calendar-data
-      let calendarData = prop.getElementsByTagNameNS(
-        'urn:ietf:params:xml:ns:caldav',
-        'calendar-data'
-      )[0];
-
-      if (!calendarData) {
-        const candidates = prop.getElementsByTagNameNS('*', 'calendar-data');
-        if (candidates.length > 0) {
-          calendarData = candidates[0];
-        }
-      }
-
-      if (calendarData) {
-        const calendarText = assertNonEmptyText(
-          calendarData.textContent || '',
-          'CalDAV REPORT returned empty calendar-data payload.'
-        );
-        let etag = prop.getElementsByTagNameNS('DAV:', 'getetag')[0]?.textContent;
-        if (!etag) {
-          const candidates = prop.getElementsByTagNameNS('*', 'getetag');
-          if (candidates.length > 0) etag = candidates[0].textContent;
-        }
-
-        const hrefNode =
-          response.getElementsByTagNameNS('DAV:', 'href')[0] ||
-          response.getElementsByTagNameNS('*', 'href')[0];
-        const href = hrefNode?.textContent?.trim() || '';
-
-        icsList.push({
-          href,
-          ics: assertIcsPayload(calendarText, 'CalDAV REPORT'),
-          etag: etag || undefined
-        });
-      }
-    }
-  }
+  const icsList = extractCalendarDataFromMultiStatus(doc);
+  const allResponses = Array.from(doc.getElementsByTagNameNS('*', 'response'));
 
   // STEP 3: Fallback - if no calendar-data was returned, fetch individual .ics files
   if (icsList.length === 0) {
@@ -683,7 +696,7 @@ async function fetchCalendarObjectsForComponent(
   return { icsList, fellBack: false };
 }
 
-async function fetchAllVTodoObjects(
+export async function fetchAllVTodoObjects(
   collectionUrl: string,
   authHeader?: string
 ): Promise<CalendarObjectData[]> {
@@ -723,49 +736,13 @@ async function fetchAllVTodoObjects(
       );
       return fetchCalendarObjectsViaPropfindFallback(collectionUrl, authHeader);
     }
-    console.error(
-      `[CalDAVProvider] VTODO REPORT request failed`,
-      reportRes.status,
-      xml.slice(0, 800)
-    );
+    console.error(`[CalDAVProvider] VTODO REPORT request failed`, reportRes.status);
     throw new Error(`REPORT ${reportRes.status}`);
   }
 
   assertNonEmptyText(xml, 'CalDAV VTODO REPORT returned an empty body.');
   const doc = ensureXmlDocument(xml, 'CalDAV VTODO REPORT');
-  const icsList: CalendarObjectData[] = [];
-  const responses = Array.from(doc.getElementsByTagNameNS('*', 'response'));
-
-  for (const response of responses) {
-    const prop = getSuccessfulPropNode(response);
-    if (!prop) continue;
-
-    const calendarData =
-      prop.getElementsByTagNameNS('urn:ietf:params:xml:ns:caldav', 'calendar-data')[0] ||
-      prop.getElementsByTagNameNS('*', 'calendar-data')[0];
-    if (!calendarData) continue;
-
-    const hrefNode =
-      response.getElementsByTagNameNS('DAV:', 'href')[0] ||
-      response.getElementsByTagNameNS('*', 'href')[0];
-    const href = hrefNode?.textContent?.trim() || '';
-    const etag =
-      prop.getElementsByTagNameNS('DAV:', 'getetag')[0]?.textContent ||
-      prop.getElementsByTagNameNS('*', 'getetag')[0]?.textContent ||
-      undefined;
-
-    icsList.push({
-      href,
-      ics: assertIcsPayload(
-        assertNonEmptyText(
-          calendarData.textContent || '',
-          'CalDAV VTODO REPORT returned empty calendar-data payload.'
-        ),
-        'CalDAV VTODO REPORT'
-      ),
-      etag: etag || undefined
-    });
-  }
+  const icsList = extractCalendarDataFromMultiStatus(doc);
 
   return icsList;
 }
@@ -888,24 +865,24 @@ const CalDAVConfigWrapper: React.FC<CalDAVConfigProps> = props => {
 export class CalDAVProvider
   implements CalendarProvider<CalDAVProviderConfig>, SyncKeyProvider, TaskBacklogProvider
 {
-  static readonly type = 'caldav';
-  static readonly displayName = 'CalDAV';
+  static readonly type: string = 'caldav';
+  static readonly displayName: string = 'CalDAV';
 
   static getConfigurationComponent(): FCReactComponent<CalDAVConfigProps> {
     return CalDAVConfigWrapper;
   }
 
   private plugin: FullCalendarPlugin;
-  private source: CalDAVProviderConfig;
+  protected source: CalDAVProviderConfig;
   public readonly linkedNoteIndex: LinkedNoteIndex;
   private undatedTaskCache: CalDAVTaskInboxItem[] = [];
   private undatedTaskLoadPromise: Promise<CalDAVTaskInboxItem[]> | null = null;
   private hasLoadedUndatedTasks = false;
 
-  readonly type = 'caldav';
-  readonly displayName = 'CalDAV';
+  readonly type: string = 'caldav';
+  readonly displayName: string = 'CalDAV';
   readonly isRemote = true;
-  readonly loadPriority = 110;
+  readonly loadPriority: number = 110;
 
   constructor(source: CalDAVProviderConfig, plugin: FullCalendarPlugin) {
     this.plugin = plugin;
@@ -913,7 +890,7 @@ export class CalDAVProvider
     this.linkedNoteIndex = new LinkedNoteIndex(plugin.app, source.id);
   }
 
-  private getPassword(): string | null {
+  protected getPassword(): string | null {
     return CredentialStore.getCalDAVPassword(this.source.id);
   }
 
@@ -1171,7 +1148,8 @@ export class CalDAVProvider
       taskUid = parsed.uid;
     }
 
-    await this.deleteEvent({ persistentId: taskUid });
+    const task = this.undatedTaskCache.find(candidate => candidate.uid === taskUid);
+    await this.deleteEvent({ persistentId: task?.href || taskUid });
     this.undatedTaskCache = this.undatedTaskCache.filter(task => task.uid !== taskUid);
     this.hasLoadedUndatedTasks = true;
   }
@@ -1197,6 +1175,7 @@ export class CalDAVProvider
       }
 
       todo.updatePropertyWithValue('status', isDone ? 'COMPLETED' : 'NEEDS-ACTION');
+      todo.updatePropertyWithValue('percent-complete', isDone ? 100 : 0);
       if (isDone) {
         todo.updatePropertyWithValue('completed', ical.Time.now());
       } else {
@@ -1276,7 +1255,8 @@ export class CalDAVProvider
       location: '',
       url: '',
       status: 'NEEDS-ACTION',
-      completed: false
+      completed: false,
+      href: url
     };
 
     this.undatedTaskCache = [
@@ -1662,7 +1642,7 @@ export class CalDAVProvider
   }
 
   // Helper to attach auth and fetch
-  private async doRequest(url: string, options: RequestInit) {
+  protected async doRequest(url: string, options: RequestInit) {
     const headers = (options.headers as Record<string, string>) || {};
     const authHeader = createBasicAuthHeader(this.source.username, this.getPassword() ?? undefined);
     if (authHeader) {
@@ -1672,12 +1652,26 @@ export class CalDAVProvider
 
     const res = await obsidianFetch(url, options);
     if (res.status >= 300) {
-      throw new Error(`CalDAV request failed: ${res.status} ${res.statusText}`);
+      if (res.status === 401) {
+        throw new Error(t('settings.calendars.caldav.errors.authentication'));
+      }
+      if (res.status === 403) {
+        throw new Error(t('settings.calendars.caldav.errors.permissionDenied'));
+      }
+      if (res.status === 409 || res.status === 412) {
+        throw new Error(t('settings.calendars.caldav.errors.conflict', { status: res.status }));
+      }
+      throw new Error(
+        t('settings.calendars.caldav.errors.requestFailed', {
+          status: res.status,
+          statusText: res.statusText || ''
+        }).trim()
+      );
     }
     return res;
   }
 
-  private resolveEventObjectUrl(persistentId: string): string {
+  protected resolveEventObjectUrl(persistentId: string): string {
     if (/^https?:\/\//i.test(persistentId)) {
       return persistentId;
     }

--- a/src/providers/caldav/CalDAVTaskConfiguration.test.ts
+++ b/src/providers/caldav/CalDAVTaskConfiguration.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import { parseCalendarInfo } from '../../types/calendar_settings';
+import { obsidianFetch } from './obsidian-fetch_caldav';
+import { importCalendars } from './import_caldav';
+
+jest.mock('./obsidian-fetch_caldav', () => ({ obsidianFetch: jest.fn() }));
+jest.mock('../../features/i18n/i18n', () => ({ t: (key: string) => key }));
+
+const mockFetch = obsidianFetch as jest.MockedFunction<typeof obsidianFetch>;
+
+function collectionResponse(component: 'VTODO' | 'VEVENT'): string {
+  return `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:ical="http://apple.com/ns/ical/">
+  <d:response><d:propstat><d:prop>
+    <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+    <d:displayname>Reminders</d:displayname>
+    <c:supported-calendar-component-set><c:comp name="${component}"/></c:supported-calendar-component-set>
+    <ical:calendar-color>#123456FF</ical:calendar-color>
+  </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+</d:multistatus>`;
+}
+
+describe('CalDAV Tasks configuration', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('imports a direct VTODO collection as a distinct source type', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 207,
+      text: () => Promise.resolve(collectionResponse('VTODO'))
+    } as Response);
+
+    const [source] = await importCalendars(
+      { type: 'basic', username: '', password: '' },
+      'https://caldav.example.com/principal/calendars/tasks',
+      [],
+      'caldavtasks'
+    );
+
+    expect(source).toMatchObject({
+      type: 'caldavtasks',
+      id: 'caldavtasks_1',
+      name: 'Reminders',
+      homeUrl: 'https://caldav.example.com/principal/calendars/tasks/',
+      color: '#123456',
+      username: '',
+      password: ''
+    });
+    expect(parseCalendarInfo(source)).toEqual(source);
+  });
+
+  it('rejects a collection that explicitly advertises VEVENT only', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 207,
+      text: () => Promise.resolve(collectionResponse('VEVENT'))
+    } as Response);
+
+    await expect(
+      importCalendars(
+        { type: 'basic', username: '', password: '' },
+        'https://caldav.example.com/principal/calendars/events/',
+        [],
+        'caldavtasks'
+      )
+    ).rejects.toThrow('noVtodoCapability');
+  });
+});

--- a/src/providers/caldav/CalDAVTaskProvider.test.ts
+++ b/src/providers/caldav/CalDAVTaskProvider.test.ts
@@ -1,0 +1,328 @@
+/**
+ * @jest-environment jsdom
+ */
+import { OFCEvent } from '../../types';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import FullCalendarPlugin from '../../main';
+import { CredentialStore } from '../../features/credentials/CredentialStore';
+import { PluginState } from '../../core/PluginState';
+import { obsidianFetch } from './obsidian-fetch_caldav';
+import { CalDAVTaskProvider } from './CalDAVTaskProvider';
+import { CalDAVTaskProviderConfig } from './typesCalDAV';
+
+jest.mock('./obsidian-fetch_caldav', () => ({ obsidianFetch: jest.fn() }));
+
+const mockFetch = obsidianFetch as jest.MockedFunction<typeof obsidianFetch>;
+
+const appleMultiStatus = readFileSync(
+  join(__dirname, 'fixtures', 'apple-vtodo-multistatus.xml'),
+  'utf8'
+);
+
+const config: CalDAVTaskProviderConfig = {
+  id: 'caldavtasks_1',
+  name: 'Reminders',
+  url: 'https://caldav.example.com/',
+  homeUrl: 'https://caldav.example.com/principal/calendars/tasks/',
+  username: '',
+  password: ''
+};
+
+const collectionInfo = `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response><d:propstat><d:prop>
+    <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+    <c:supported-calendar-component-set><c:comp name="VTODO"/></c:supported-calendar-component-set>
+  </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+</d:multistatus>`;
+
+function reportResponse(ics: string, href = '/principal/calendars/tasks/task.ics'): string {
+  return `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response><d:href>${href}</d:href><d:propstat><d:prop>
+    <d:getetag>"etag-1"</d:getetag><c:calendar-data><![CDATA[${ics}]]></c:calendar-data>
+  </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+</d:multistatus>`;
+}
+
+describe('CalDAVTaskProvider', () => {
+  let provider: CalDAVTaskProvider;
+
+  beforeEach(() => {
+    provider = new CalDAVTaskProvider(config, {} as FullCalendarPlugin);
+    mockFetch.mockReset();
+    jest.spyOn(CredentialStore, 'getCalDAVPassword').mockReturnValue(config.password);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('fetches only VTODO resources and maps stable href/UID/ETag identity', async () => {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:remote-task
+SUMMARY:Remote reminder
+DUE:20260816T180000Z
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`;
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(collectionInfo)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(reportResponse(ics))
+      } as Response);
+
+    const events = await provider.getEvents({
+      start: new Date('2026-08-01T00:00:00Z'),
+      end: new Date('2026-09-01T00:00:00Z')
+    });
+
+    expect(mockFetch.mock.calls[1][1]?.body).toEqual(
+      expect.stringContaining('<c:comp-filter name="VTODO"/>')
+    );
+    expect(mockFetch.mock.calls[1][1]?.body).not.toEqual(expect.stringContaining('VEVENT'));
+    expect(mockFetch.mock.calls[1][1]?.body).not.toEqual(expect.stringContaining('<c:time-range'));
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toMatchObject({
+      uid: 'remote-task',
+      caldavHref: '/principal/calendars/tasks/task.ics',
+      etag: 'etag-1',
+      completed: false
+    });
+  });
+
+  it('extracts and parses multiple Apple VTODO resources from a sanitized 207 response', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(collectionInfo)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(appleMultiStatus)
+      } as Response);
+
+    const events = await provider.getEvents();
+
+    const reportRequest = mockFetch.mock.calls[1][1];
+    expect(reportRequest?.method).toBe('REPORT');
+    expect(reportRequest?.headers as Record<string, string>).toMatchObject({
+      Depth: '1',
+      'Content-Type': 'application/xml; charset=utf-8'
+    });
+    expect(mockFetch.mock.calls[1][1]?.body).toEqual(
+      expect.stringContaining('<c:comp-filter name="VTODO"/>')
+    );
+    expect(mockFetch.mock.calls[1][1]?.body).toEqual(expect.stringContaining('<c:calendar-data/>'));
+    expect(mockFetch.mock.calls[1][1]?.body).not.toEqual(expect.stringContaining('<c:time-range'));
+    expect(events.length).toBeGreaterThan(0);
+    expect(events).toHaveLength(2);
+    expect(events.map(([event]) => event.uid)).toEqual([
+      'COMPLETED-REMINDER-UID',
+      'ACTIVE-APPLE-REMINDER-UID'
+    ]);
+    expect(events[0][0]).toMatchObject({
+      title: 'Completed reminder',
+      date: '2023-01-09',
+      startTime: '09:00',
+      timezone: 'Asia/Nicosia',
+      caldavHref: '/sanitized-principal/calendars/tasks/completed-reminder.ics',
+      etag: 'completed-etag'
+    });
+    expect(events[0][0].type === 'single' && events[0][0].completed).toBeTruthy();
+    expect(events[1][0]).toMatchObject({
+      title: 'Active reminder',
+      date: '2026-08-16',
+      startTime: '09:00',
+      timezone: 'Asia/Nicosia',
+      completed: false,
+      caldavHref: '/sanitized-principal/calendars/tasks/active-reminder.ics',
+      etag: 'active-etag'
+    });
+  });
+
+  it('does not parse VEVENT data returned by a compatibility fallback', async () => {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-only
+SUMMARY:Meeting
+DTSTART:20260816T180000Z
+DTEND:20260816T190000Z
+END:VEVENT
+END:VCALENDAR`;
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(collectionInfo)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(reportResponse(ics))
+      } as Response);
+
+    await expect(provider.getEvents()).resolves.toEqual([]);
+  });
+
+  it('creates a VTODO with a conditional PUT', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 201,
+      statusText: 'Created',
+      headers: new Headers({ etag: '"created-etag"' })
+    } as Response);
+    const event = {
+      type: 'single',
+      title: 'Created in Full Calendar',
+      date: '2026-08-20',
+      endDate: null,
+      allDay: true,
+      completed: false
+    } as OFCEvent;
+
+    const [[created]] = await Promise.all([provider.createEvent(event)]);
+    const request = mockFetch.mock.calls[0][1];
+    expect(request?.method).toBe('PUT');
+    expect((request?.headers as Record<string, string>)['If-None-Match']).toBe('*');
+    expect(request?.body).toEqual(expect.stringContaining('BEGIN:VTODO'));
+    expect(request?.body).toEqual(expect.stringContaining('DUE;VALUE=DATE:20260820'));
+    expect(request?.body).not.toEqual(expect.stringContaining('BEGIN:VEVENT'));
+    expect(created).toMatchObject({ completed: false, etag: 'created-etag' });
+  });
+
+  it('updates and completes the original VTODO while preserving Apple extensions', async () => {
+    const original = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:remote-task
+SUMMARY:Original
+DUE;VALUE=DATE:20260820
+STATUS:NEEDS-ACTION
+X-APPLE-SOMETHING:preserve-me
+END:VTODO
+END:VCALENDAR`;
+    mockFetch
+      .mockResolvedValueOnce({ status: 200, text: () => Promise.resolve(original) } as Response)
+      .mockResolvedValueOnce({
+        status: 204,
+        statusText: 'No Content',
+        headers: new Headers({ etag: '"etag-2"' })
+      } as Response);
+    const oldEvent = {
+      type: 'single',
+      uid: 'remote-task',
+      caldavHref: '/principal/calendars/tasks/task.ics',
+      etag: 'etag-1',
+      title: 'Original',
+      date: '2026-08-20',
+      endDate: null,
+      allDay: true,
+      completed: false
+    } as OFCEvent;
+    const newEvent = {
+      ...oldEvent,
+      title: 'Updated',
+      date: '2026-08-21',
+      completed: '2026-08-15T14:00:00Z'
+    } as OFCEvent;
+
+    await provider.updateEvent(provider.getEventHandle(oldEvent)!, oldEvent, newEvent);
+
+    const put = mockFetch.mock.calls[1][1];
+    expect(put?.method).toBe('PUT');
+    expect((put?.headers as Record<string, string>)['If-Match']).toBe('"etag-1"');
+    expect(put?.body).toEqual(expect.stringContaining('SUMMARY:Updated'));
+    expect(put?.body).toEqual(expect.stringContaining('DUE;VALUE=DATE:20260821'));
+    expect(put?.body).toEqual(expect.stringContaining('STATUS:COMPLETED'));
+    expect(put?.body).toEqual(expect.stringContaining('PERCENT-COMPLETE:100'));
+    expect(put?.body).toEqual(expect.stringContaining('COMPLETED:20260815T140000Z'));
+    expect(put?.body).toEqual(expect.stringContaining('X-APPLE-SOMETHING:preserve-me'));
+    expect(newEvent.etag).toBe('etag-2');
+  });
+
+  it('deletes the exact CalDAV resource href', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response);
+    await provider.deleteEvent({ persistentId: '/principal/calendars/tasks/server-name.ics' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://caldav.example.com/principal/calendars/tasks/server-name.ics',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('preserves the resource href when deleting an undated backlog task', async () => {
+    const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:undated-task
+SUMMARY:Call dentist
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`;
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(collectionInfo)
+      } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () =>
+          Promise.resolve(
+            reportResponse(ics, '/principal/calendars/tasks/server-generated-name.ics')
+          )
+      } as Response)
+      .mockResolvedValueOnce({ status: 204, statusText: 'No Content' } as Response);
+
+    const [task] = await provider.getTaskBacklogItems();
+    await provider.deleteTaskBacklogItem(task.id);
+
+    expect(mockFetch.mock.calls[2][0]).toBe(
+      'https://caldav.example.com/principal/calendars/tasks/server-generated-name.ics'
+    );
+    expect(mockFetch.mock.calls[2][1]).toEqual(expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  it('routes the calendar checkbox through provider-owned completion sync', async () => {
+    const event = {
+      type: 'single',
+      uid: 'remote-task',
+      caldavHref: '/principal/calendars/tasks/task.ics',
+      title: 'Checkbox task',
+      date: '2026-08-20',
+      endDate: null,
+      allDay: true,
+      completed: false
+    } as OFCEvent;
+    type ProviderUpdatePayload = Parameters<
+      ReturnType<typeof PluginState.getProviderRegistry>['processProviderUpdates']
+    >[1];
+    const processProviderUpdates = jest
+      .fn<Promise<void>, [string, ProviderUpdatePayload]>()
+      .mockResolvedValue(undefined);
+    jest.spyOn(PluginState, 'getCache').mockReturnValue({
+      store: {
+        getEventDetails: () => ({
+          id: 'session-id',
+          event,
+          calendarId: config.id,
+          location: null
+        })
+      }
+    } as unknown as ReturnType<typeof PluginState.getCache>);
+    jest.spyOn(PluginState, 'getProviderRegistry').mockReturnValue({
+      processProviderUpdates
+    } as unknown as ReturnType<typeof PluginState.getProviderRegistry>);
+    const updateEventSpy = jest.spyOn(provider, 'updateEvent').mockResolvedValue(null);
+
+    await expect(provider.toggleComplete('session-id', true)).resolves.toBe(true);
+    const [handle, previousEvent, completedEvent] = updateEventSpy.mock.calls[0];
+    expect(handle.persistentId).toBe('/principal/calendars/tasks/task.ics');
+    expect(previousEvent).toBe(event);
+    expect(completedEvent.type).toBe('single');
+    expect(completedEvent.type === 'single' && typeof completedEvent.completed).toBe('string');
+    expect(processProviderUpdates.mock.calls[0][0]).toBe(config.id);
+    expect(processProviderUpdates.mock.calls[0][1].updates).toHaveLength(1);
+    expect(processProviderUpdates.mock.calls[0][1].updates[0].event).toBe(completedEvent);
+  });
+});

--- a/src/providers/caldav/CalDAVTaskProvider.ts
+++ b/src/providers/caldav/CalDAVTaskProvider.ts
@@ -1,0 +1,248 @@
+import * as React from 'react';
+import { DateTime } from 'luxon';
+import { PluginState } from '../../core/PluginState';
+import { t } from '../../features/i18n/i18n';
+import FullCalendarPlugin from '../../main';
+import { EventLocation, OFCEvent } from '../../types';
+import { isTask } from '../../types/tasks';
+import { CalendarProviderCapabilities, TaskBacklogInfo } from '../Provider';
+import { EventHandle, FCReactComponent, ProviderConfigContext } from '../typesProvider';
+import { createBasicAuthHeader } from './auth_caldav';
+import { CalDAVConfigComponent } from './CalDAVConfigComponent';
+import {
+  CalDAVProvider,
+  canonCollection,
+  createRandomUid,
+  fetchAllVTodoObjects
+} from './CalDAVProvider';
+import { fetchCalendarInfo } from './helper_caldav';
+import { CalDAVTaskProviderConfig } from './typesCalDAV';
+import { createVTodoCalendar, parseVTodoCalendar, updateVTodoCalendar } from './vtodo';
+
+type CalDAVTaskConfigProps = {
+  plugin: FullCalendarPlugin;
+  config: Partial<CalDAVTaskProviderConfig>;
+  onConfigChange: (newConfig: Partial<CalDAVTaskProviderConfig>) => void;
+  context: ProviderConfigContext;
+  onSave: (finalConfig: CalDAVTaskProviderConfig | CalDAVTaskProviderConfig[]) => void;
+  onClose: () => void;
+};
+
+const CalDAVTaskConfigWrapper: React.FC<CalDAVTaskConfigProps> = props =>
+  React.createElement(CalDAVConfigComponent, {
+    config: props.config,
+    onSave: configs => props.onSave(configs),
+    onClose: props.onClose,
+    mode: 'tasks'
+  });
+
+function quotedEtag(etag: string): string {
+  return etag.startsWith('"') ? etag : `"${etag}"`;
+}
+
+export class CalDAVTaskProvider extends CalDAVProvider {
+  static readonly type = 'caldavtasks';
+
+  static get displayName(): string {
+    return t('settings.calendars.caldavTasks.title');
+  }
+
+  static getConfigurationComponent(): FCReactComponent<CalDAVTaskConfigProps> {
+    return CalDAVTaskConfigWrapper;
+  }
+
+  readonly type: string = 'caldavtasks';
+  readonly displayName: string = t('settings.calendars.caldavTasks.title');
+  readonly loadPriority = 115;
+
+  getCapabilities(): CalendarProviderCapabilities {
+    return {
+      canCreate: true,
+      canEdit: true,
+      canDelete: true,
+      ownsRecurringInstanceOverrides: false,
+      contextMenu: {
+        allowGenericTaskActions: false,
+        providesNativeTaskSemantics: true
+      }
+    };
+  }
+
+  getTaskBacklogInfo(): TaskBacklogInfo {
+    return {
+      id: this.source.id,
+      name: this.source.name,
+      title: t('settings.calendars.caldavTasks.backlogTitle'),
+      supportsCreate: true
+    };
+  }
+
+  async getEvents(_range?: {
+    start: Date;
+    end: Date;
+  }): Promise<[OFCEvent, EventLocation | null][]> {
+    const password = this.getPassword() ?? undefined;
+    const info = await fetchCalendarInfo(this.source.homeUrl, {
+      username: this.source.username,
+      password
+    });
+    if (!info.isCalendar) {
+      throw new Error(info.error || t('settings.calendars.caldav.errors.invalidCollection'));
+    }
+    if (
+      info.supportedComponents &&
+      info.supportedComponents.length > 0 &&
+      !info.supportedComponents.includes('VTODO')
+    ) {
+      throw new Error(t('settings.calendars.caldavTasks.errors.noVtodoCapability'));
+    }
+
+    const authHeader = createBasicAuthHeader(this.source.username, password);
+    const icsList = await fetchAllVTodoObjects(this.source.homeUrl, authHeader);
+
+    const results: [OFCEvent, EventLocation | null][] = [];
+    let malformedResources = 0;
+    for (const object of icsList) {
+      try {
+        const tasks = parseVTodoCalendar(object.ics);
+        for (const task of tasks) {
+          if (!task.event || task.cancelled || !isTask(task.event)) continue;
+          const event: OFCEvent = {
+            ...task.event,
+            caldavHref: object.href,
+            ...(object.etag ? { etag: object.etag.replace(/"/g, '') } : {})
+          };
+          const linkedFile = this.linkedNoteIndex.getFileForEvent(event.uid || '');
+          results.push([
+            event,
+            linkedFile ? { file: { path: linkedFile.path }, lineNumber: undefined } : null
+          ]);
+        }
+      } catch {
+        malformedResources += 1;
+      }
+    }
+
+    if (malformedResources > 0) {
+      console.warn(
+        t('settings.calendars.caldavTasks.errors.skippedMalformed', {
+          count: malformedResources
+        })
+      );
+    }
+    return results;
+  }
+
+  async createEvent(event: OFCEvent): Promise<[OFCEvent, EventLocation | null]> {
+    if (event.type === 'recurring') {
+      throw new Error(t('settings.calendars.caldavTasks.errors.recurringCreation'));
+    }
+
+    const uid = event.uid || createRandomUid();
+    const taskEvent: OFCEvent =
+      event.type === 'single'
+        ? { ...event, uid, completed: event.completed ?? false }
+        : { ...event, uid, isTask: true };
+    const url = `${canonCollection(this.source.homeUrl)}${encodeURIComponent(uid)}.ics`;
+    const body = createVTodoCalendar(taskEvent, uid);
+
+    const response = await this.doRequest(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'text/calendar; charset=utf-8',
+        'If-None-Match': '*'
+      },
+      body
+    });
+    const parsed = parseVTodoCalendar(body)[0]?.event || taskEvent;
+    const etag = response.headers?.get?.('etag')?.replace(/"/g, '');
+    const created = {
+      ...parsed,
+      uid,
+      caldavHref: url,
+      ...(etag ? { etag } : {})
+    } as OFCEvent;
+    return [created, null];
+  }
+
+  async updateEvent(
+    handle: EventHandle,
+    oldEvent: OFCEvent,
+    newEvent: OFCEvent
+  ): Promise<EventLocation | null> {
+    if (oldEvent.type !== 'single' && oldEvent.type !== 'rrule') {
+      throw new Error(t('settings.calendars.caldavTasks.errors.unsupportedType'));
+    }
+    const uid = oldEvent.uid || newEvent.uid;
+    if (!uid) throw new Error(t('settings.calendars.caldavTasks.errors.missingUid'));
+
+    const url = this.resolveEventObjectUrl(handle.persistentId);
+    const response = await this.doRequest(url, { method: 'GET' });
+    const originalIcs = await response.text();
+    const taskEvent: OFCEvent =
+      newEvent.type === 'single'
+        ? { ...newEvent, uid, completed: newEvent.completed ?? false }
+        : { ...newEvent, uid, isTask: true };
+    const updatedIcs = updateVTodoCalendar(originalIcs, uid, oldEvent, taskEvent);
+
+    const putResponse = await this.doRequest(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'text/calendar; charset=utf-8',
+        ...(oldEvent.etag ? { 'If-Match': quotedEtag(oldEvent.etag) } : {})
+      },
+      body: updatedIcs
+    });
+    const authoritative = parseVTodoCalendar(updatedIcs)[0]?.event;
+    if (authoritative) {
+      Object.assign(newEvent, authoritative, {
+        uid,
+        caldavHref: handle.persistentId,
+        etag: putResponse.headers?.get?.('etag')?.replace(/"/g, '') || oldEvent.etag
+      });
+    }
+    return null;
+  }
+
+  async toggleComplete(eventId: string, isDone: boolean): Promise<boolean> {
+    try {
+      const details = PluginState.getCache().store.getEventDetails(eventId);
+      if (!details || details.event.type !== 'single') return false;
+      const event = details.event;
+      const handle = this.getEventHandle(event);
+      if (!handle) return false;
+
+      const completed = isDone ? DateTime.utc().toISO() || true : false;
+      const updatedEvent: OFCEvent = { ...event, completed };
+      await this.updateEvent(handle, event, updatedEvent);
+      await PluginState.getProviderRegistry().processProviderUpdates(this.source.id, {
+        additions: [],
+        updates: [
+          {
+            persistentId: handle.persistentId,
+            event: updatedEvent,
+            location: details.location
+              ? {
+                  file: { path: details.location.path },
+                  lineNumber: details.location.lineNumber
+                }
+              : null
+          }
+        ],
+        deletions: []
+      });
+      return true;
+    } catch (error) {
+      console.error(t('settings.calendars.caldavTasks.errors.completionUpdate'), error);
+      return false;
+    }
+  }
+
+  async createInstanceOverride(): Promise<[OFCEvent, EventLocation | null]> {
+    throw new Error(t('settings.calendars.caldavTasks.errors.recurringInstance'));
+  }
+
+  getConfigurationComponent(): FCReactComponent<CalDAVTaskConfigProps> {
+    return CalDAVTaskConfigWrapper;
+  }
+}

--- a/src/providers/caldav/CalDAVVEventRegression.test.ts
+++ b/src/providers/caldav/CalDAVVEventRegression.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import FullCalendarPlugin from '../../main';
+import { CalDAVProvider } from './CalDAVProvider';
+import { obsidianFetch } from './obsidian-fetch_caldav';
+import { CalDAVProviderConfig } from './typesCalDAV';
+
+jest.mock('./obsidian-fetch_caldav', () => ({ obsidianFetch: jest.fn() }));
+
+const mockFetch = obsidianFetch as jest.MockedFunction<typeof obsidianFetch>;
+
+const config: CalDAVProviderConfig = {
+  id: 'caldav_vevent_regression',
+  name: 'Calendar',
+  url: 'https://caldav.example.com/',
+  homeUrl: 'https://caldav.example.com/calendars/events/',
+  username: '',
+  password: ''
+};
+
+const collectionInfo = `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response><d:propstat><d:prop>
+    <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+    <c:supported-calendar-component-set><c:comp name="VEVENT"/></c:supported-calendar-component-set>
+  </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+</d:multistatus>`;
+
+const eventReport = `<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response><d:href>/calendars/events/meeting.ics</d:href><d:propstat><d:prop>
+    <d:getetag>"event-etag"</d:getetag>
+    <c:calendar-data><![CDATA[BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:existing-event
+SUMMARY:Team meeting
+DTSTART:20260820T100000Z
+DTEND:20260820T110000Z
+END:VEVENT
+END:VCALENDAR]]></c:calendar-data>
+  </d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response>
+</d:multistatus>`;
+
+describe('CalDAV VEVENT regression', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('keeps the existing VEVENT CalDAV read path unchanged', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve(collectionInfo)
+      } as Response)
+      .mockResolvedValueOnce({ status: 207, text: () => Promise.resolve(eventReport) } as Response)
+      .mockResolvedValueOnce({
+        status: 207,
+        text: () => Promise.resolve('<d:multistatus xmlns:d="DAV:"/>')
+      } as Response);
+
+    const provider = new CalDAVProvider(config, {} as FullCalendarPlugin);
+    const events = await provider.getEvents({
+      start: new Date('2026-08-01T00:00:00Z'),
+      end: new Date('2026-09-01T00:00:00Z')
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0][0]).toMatchObject({
+      uid: 'existing-event',
+      title: 'Team meeting',
+      caldavHref: '/calendars/events/meeting.ics',
+      etag: 'event-etag'
+    });
+    expect(mockFetch.mock.calls[1][1]?.body).toEqual(
+      expect.stringContaining('<c:comp-filter name="VEVENT">')
+    );
+  });
+});

--- a/src/providers/caldav/fixtures/apple-vtodo-multistatus.xml
+++ b/src/providers/caldav/fixtures/apple-vtodo-multistatus.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/sanitized-principal/calendars/tasks/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+    <d:propstat>
+      <d:prop><c:calendar-data/></d:prop>
+      <d:status>HTTP/1.1 404 Not Found</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/sanitized-principal/calendars/tasks/completed-reminder.ics</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>"completed-etag"</d:getetag>
+        <c:calendar-data><![CDATA[BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Apple Inc.//macOS 15.6//EN
+BEGIN:VTODO
+COMPLETED:20230109T075245Z
+CREATED:20221018T082557Z
+DTSTAMP:20260815T141655Z
+DTSTART;TZID=Asia/Nicosia:20230109T090000
+DUE;TZID=Asia/Nicosia:20230109T090000
+LAST-MODIFIED:20230109T075245Z
+PERCENT-COMPLETE:100
+PRIORITY:1
+STATUS:COMPLETED
+SUMMARY:Completed reminder
+UID:COMPLETED-REMINDER-UID
+X-APPLE-SORT-ORDER:100
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:Reminder
+TRIGGER;VALUE=DATE-TIME:20230109T070000Z
+UID:REMINDER-ALARM-UID
+X-WR-ALARMUID:REMINDER-ALARM-UID
+END:VALARM
+END:VTODO
+BEGIN:VTIMEZONE
+TZID:Asia/Nicosia
+X-LIC-LOCATION:Asia/Nicosia
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0300
+TZNAME:EEST
+DTSTART:19700329T030000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0300
+TZOFFSETTO:+0200
+TZNAME:EET
+DTSTART:19701025T040000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR]]></c:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/sanitized-principal/calendars/tasks/active-reminder.ics</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>"active-etag"</d:getetag>
+        <c:calendar-data><![CDATA[BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+PRODID:-//Apple Inc.//macOS 15.6//EN
+BEGIN:VTODO
+CREATED:20260815T120000Z
+DTSTAMP:20260815T141655Z
+DTSTART;TZID=Asia/Nicosia:20260816T090000
+DUE;TZID=Asia/Nicosia:20260816T090000
+LAST-MODIFIED:20260815T141655Z
+PERCENT-COMPLETE:0
+PRIORITY:0
+STATUS:NEEDS-ACTION
+SUMMARY:Active reminder
+UID:ACTIVE-APPLE-REMINDER-UID
+X-APPLE-SORT-ORDER:200
+END:VTODO
+BEGIN:VTIMEZONE
+TZID:Asia/Nicosia
+BEGIN:STANDARD
+TZOFFSETFROM:+0300
+TZOFFSETTO:+0200
+TZNAME:EET
+DTSTART:19701025T040000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR]]></c:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>

--- a/src/providers/caldav/helper_caldav.ts
+++ b/src/providers/caldav/helper_caldav.ts
@@ -19,7 +19,13 @@ export function eqUrl(a: string, b: string) {
 export async function fetchCalendarInfo(
   url: string,
   auth?: { username?: string; password?: string }
-): Promise<{ isCalendar: boolean; displayName?: string; color?: string; error?: string }> {
+): Promise<{
+  isCalendar: boolean;
+  displayName?: string;
+  color?: string;
+  supportedComponents?: string[];
+  error?: string;
+}> {
   const headers: Record<string, string> = {
     Depth: '0',
     'Content-Type': 'application/xml; charset=utf-8',
@@ -32,10 +38,11 @@ export async function fetchCalendarInfo(
   }
 
   const body = `<?xml version="1.0" encoding="utf-8" ?>
-<d:propfind xmlns:d="DAV:" xmlns:ical="http://apple.com/ns/ical/">
+<d:propfind xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav" xmlns:ical="http://apple.com/ns/ical/">
   <d:prop>
     <d:resourcetype/>
     <d:displayname/>
+    <c:supported-calendar-component-set/>
     <ical:calendar-color/>
   </d:prop>
 </d:propfind>`;
@@ -78,7 +85,19 @@ export async function fetchCalendarInfo(
       ?.replace(/^(?!#)/, '#')
       ?.match(/^.{7}/)?.[0];
 
-    return { isCalendar, displayName, color };
+    const componentSet =
+      /<[^:]*:?supported-calendar-component-set\b[^>]*>([\s\S]*?)<\/[^:]*:?supported-calendar-component-set>/i.exec(
+        xml
+      );
+    const supportedComponents = componentSet
+      ? Array.from(
+          componentSet[1].matchAll(
+            /<(?:[a-zA-Z0-9]+:)?comp\b[^>]*\bname=["']([^"']+)["'][^>]*\/?\s*>/gi
+          )
+        ).map(match => match[1].toUpperCase())
+      : undefined;
+
+    return { isCalendar, displayName, color, supportedComponents };
   } catch (e) {
     console.error(`[CalDAV] Error fetching calendar info for ${url}`, e);
     const message = e instanceof Error ? e.message : String(e);

--- a/src/providers/caldav/import_caldav.ts
+++ b/src/providers/caldav/import_caldav.ts
@@ -1,5 +1,6 @@
 // import_caldav.ts
-import { Authentication, CalDAVSource } from '../../types';
+import { Authentication, CalDAVSource, CalDAVTaskSource } from '../../types';
+import { t } from '../../features/i18n/i18n';
 import { generateCalendarId } from '../../types/calendar_settings';
 import { splitCalDAVUrl, ensureTrailingSlash, fetchCalendarInfo } from './helper_caldav';
 
@@ -7,35 +8,72 @@ import { splitCalDAVUrl, ensureTrailingSlash, fetchCalendarInfo } from './helper
  * Imports a CalDAV calendar by validating the URL using PROPFIND,
  * and auto-populates name and color from server-provided metadata.
  */
+export type CalDAVImportSourceType = 'caldav' | 'caldavtasks';
+
 export async function importCalendars(
   auth: Authentication,
   inputUrl: string,
-  existingIds: string[]
-): Promise<CalDAVSource[]> {
+  existingIds: string[],
+  sourceType: 'caldavtasks'
+): Promise<CalDAVTaskSource[]>;
+export async function importCalendars(
+  auth: Authentication,
+  inputUrl: string,
+  existingIds: string[],
+  sourceType?: 'caldav'
+): Promise<CalDAVSource[]>;
+export async function importCalendars(
+  auth: Authentication,
+  inputUrl: string,
+  existingIds: string[],
+  sourceType: CalDAVImportSourceType = 'caldav'
+): Promise<(CalDAVSource | CalDAVTaskSource)[]> {
   const { serverUrl, collectionUrl } = splitCalDAVUrl(inputUrl);
 
-  const { isCalendar, displayName, color, error } = await fetchCalendarInfo(collectionUrl, {
-    username: auth.username,
-    password: auth.password
-  });
+  const { isCalendar, displayName, color, supportedComponents, error } = await fetchCalendarInfo(
+    collectionUrl,
+    {
+      username: auth.username,
+      password: auth.password
+    }
+  );
 
   if (!isCalendar) {
     if (error) {
-      throw new Error(`Failed to import CalDAV calendar: ${error}`);
+      throw new Error(
+        sourceType === 'caldavtasks'
+          ? t('settings.calendars.caldavTasks.errors.importFailedDetails', { message: error })
+          : `Failed to import CalDAV calendar: ${error}`
+      );
     }
     throw new Error(
-      'The provided URL does not appear to be a valid CalDAV calendar collection. Please ensure it points directly to a calendar.'
+      sourceType === 'caldavtasks'
+        ? t('settings.calendars.caldavTasks.errors.invalidCollection')
+        : 'The provided URL does not appear to be a valid CalDAV calendar collection. Please ensure it points directly to a calendar.'
     );
   }
 
-  const id = generateCalendarId('caldav', existingIds);
+  if (
+    sourceType === 'caldavtasks' &&
+    supportedComponents &&
+    supportedComponents.length > 0 &&
+    !supportedComponents.includes('VTODO')
+  ) {
+    throw new Error(t('settings.calendars.caldavTasks.errors.noVtodoCapability'));
+  }
+
+  const id = generateCalendarId(sourceType, existingIds);
   existingIds.push(id);
 
   return [
     {
-      type: 'caldav',
+      type: sourceType,
       id,
-      name: displayName ?? 'CalDAV Calendar',
+      name:
+        displayName ??
+        (sourceType === 'caldavtasks'
+          ? t('settings.calendars.caldavTasks.title')
+          : 'CalDAV Calendar'),
       url: ensureTrailingSlash(serverUrl),
       homeUrl: ensureTrailingSlash(collectionUrl),
       color: color ?? '#888888',

--- a/src/providers/caldav/typesCalDAV.ts
+++ b/src/providers/caldav/typesCalDAV.ts
@@ -6,3 +6,5 @@ export type CalDAVProviderConfig = {
   username: string;
   password: string;
 };
+
+export type CalDAVTaskProviderConfig = CalDAVProviderConfig;

--- a/src/providers/caldav/vtodo.test.ts
+++ b/src/providers/caldav/vtodo.test.ts
@@ -1,0 +1,280 @@
+import { OFCEvent } from '../../types';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { createVTodoCalendar, parseVTodoCalendar, updateVTodoCalendar } from './vtodo';
+
+const appleMultiStatus = readFileSync(
+  join(__dirname, 'fixtures', 'apple-vtodo-multistatus.xml'),
+  'utf8'
+);
+
+function calendarDataPayloads(xml: string): string[] {
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
+  return Array.from(doc.getElementsByTagNameNS('urn:ietf:params:xml:ns:caldav', 'calendar-data'))
+    .map(node => node.textContent || '')
+    .filter(payload => payload.includes('BEGIN:VCALENDAR'));
+}
+
+describe('CalDAV VTODO codec', () => {
+  it('parses a simple due-date reminder without treating DUE as an event end', () => {
+    const [task] = parseVTodoCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-1
+SUMMARY:Buy groceries
+DUE:20260816T180000Z
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`);
+
+    expect(task.event).toMatchObject({
+      type: 'single',
+      uid: 'test-1',
+      title: 'Buy groceries',
+      date: '2026-08-16',
+      endDate: null,
+      allDay: false,
+      startTime: '18:00',
+      endTime: '18:00',
+      completed: false
+    });
+    expect(task.due).toMatchObject({ allDay: false });
+    expect(task.start).toBeUndefined();
+  });
+
+  it('maps STATUS and COMPLETED to a completed task', () => {
+    const [task] = parseVTodoCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-2
+SUMMARY:Finished task
+DUE:20260815T180000Z
+STATUS:COMPLETED
+COMPLETED:20260815T140000Z
+END:VTODO
+END:VCALENDAR`);
+
+    expect(task.completed).toBe(true);
+    expect(task.completedAt).toContain('2026-08-15T14:00:00');
+    expect(task.event?.type === 'single' && task.event.completed).toBeTruthy();
+  });
+
+  it('parses Apple VTODO with VTIMEZONE and nested VALARM without using the alarm UID', () => {
+    const [completedPayload] = calendarDataPayloads(appleMultiStatus);
+    const [task] = parseVTodoCalendar(completedPayload);
+
+    expect(completedPayload).toContain('PERCENT-COMPLETE:100');
+    expect(completedPayload).toContain('X-APPLE-SORT-ORDER:100');
+    expect(completedPayload).toContain('BEGIN:VALARM');
+    expect(completedPayload).toContain('BEGIN:VTIMEZONE');
+    expect(task).toMatchObject({
+      uid: 'COMPLETED-REMINDER-UID',
+      title: 'Completed reminder',
+      status: 'COMPLETED',
+      completed: true,
+      percentComplete: 100,
+      priority: 1,
+      start: { timezone: 'Asia/Nicosia', allDay: false },
+      due: { timezone: 'Asia/Nicosia', allDay: false }
+    });
+    expect(task.uid).not.toBe('REMINDER-ALARM-UID');
+    expect(task.event).toMatchObject({
+      date: '2023-01-09',
+      startTime: '09:00',
+      timezone: 'Asia/Nicosia'
+    });
+  });
+
+  it('maps PERCENT-COMPLETE:100 to completion when STATUS is absent', () => {
+    const [task] = parseVTodoCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:percent-complete-task
+SUMMARY:Submit report
+DUE;VALUE=DATE:20260820
+PERCENT-COMPLETE:100
+END:VTODO
+END:VCALENDAR`);
+
+    expect(task.completed).toBe(true);
+    expect(task.percentComplete).toBe(100);
+    expect(task.event?.type === 'single' && task.event.completed).toBe(true);
+  });
+
+  it('parses a date-only reminder as an all-day task', () => {
+    const [task] = parseVTodoCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-3
+SUMMARY:Submit documents
+DUE;VALUE=DATE:20260820
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`);
+
+    expect(task.event).toMatchObject({
+      type: 'single',
+      date: '2026-08-20',
+      allDay: true,
+      endDate: null
+    });
+  });
+
+  it('uses DTSTART for placement while preserving both DTSTART and DUE', () => {
+    const [task] = parseVTodoCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-4
+SUMMARY:Windowed task
+DTSTART;TZID=Europe/Nicosia:20260820T100000
+DUE;TZID=Europe/Nicosia:20260820T120000
+STATUS:IN-PROCESS
+END:VTODO
+END:VCALENDAR`);
+
+    expect(task.event).toMatchObject({
+      date: '2026-08-20',
+      startTime: '10:00',
+      endTime: '10:00',
+      completed: false,
+      icalTask: {
+        status: 'IN-PROCESS',
+        start: { timezone: 'Europe/Nicosia' },
+        due: { timezone: 'Europe/Nicosia' }
+      }
+    });
+  });
+
+  it('keeps an undated task available without creating a calendar event', () => {
+    const [task] = parseVTodoCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-5
+SUMMARY:Someday
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR`);
+
+    expect(task.uid).toBe('test-5');
+    expect(task.event).toBeNull();
+  });
+
+  it('ignores VEVENT and unknown Apple extensions safely', () => {
+    const tasks = parseVTodoCalendar(`BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-1
+SUMMARY:Meeting
+DTSTART:20260820T100000Z
+DTEND:20260820T110000Z
+END:VEVENT
+BEGIN:VTODO
+UID:test-6
+SUMMARY:Generic reminder
+DUE;VALUE=DATE:20260821
+X-APPLE-SOMETHING:opaque-value
+END:VTODO
+END:VCALENDAR`);
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].title).toBe('Generic reminder');
+  });
+
+  it('round-trips essential task data and preserves unknown extensions', () => {
+    const original = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-7
+SUMMARY:Original title
+DESCRIPTION:Original notes
+DTSTART;TZID=Europe/Nicosia:20260820T100000
+DUE;TZID=Europe/Nicosia:20260820T120000
+STATUS:NEEDS-ACTION
+PRIORITY:3
+PERCENT-COMPLETE:50
+RRULE:FREQ=WEEKLY
+CREATED:20260801T080000Z
+LAST-MODIFIED:20260810T090000Z
+X-APPLE-SOMETHING:preserve-me
+END:VTODO
+END:VCALENDAR`;
+    const oldEvent = parseVTodoCalendar(original)[0].event;
+    if (!oldEvent) throw new Error('Expected a dated task');
+    const movedEvent = {
+      ...oldEvent,
+      title: 'Updated title',
+      description: 'Updated notes',
+      type: 'rrule',
+      startDate: '2026-08-21'
+    } as OFCEvent;
+
+    const serialized = updateVTodoCalendar(original, 'test-7', oldEvent, movedEvent);
+    const [roundTripped] = parseVTodoCalendar(serialized);
+
+    expect(serialized).toContain('X-APPLE-SOMETHING:preserve-me');
+    expect(serialized).toContain('RRULE:FREQ=WEEKLY');
+    expect(serialized).toContain('STATUS:NEEDS-ACTION');
+    expect(serialized).toContain('PERCENT-COMPLETE:50');
+    expect(roundTripped).toMatchObject({
+      uid: 'test-7',
+      title: 'Updated title',
+      description: 'Updated notes',
+      priority: 3,
+      percentComplete: 50,
+      rrule: 'FREQ=WEEKLY'
+    });
+    expect(roundTripped.start?.value).toContain('2026-08-21T10:00:00');
+    expect(roundTripped.due?.value).toContain('2026-08-21T12:00:00');
+  });
+
+  it('creates a standards-based VTODO rather than a VEVENT', () => {
+    const event = {
+      type: 'single',
+      uid: 'new-task',
+      title: 'Created reminder',
+      description: 'Notes',
+      date: '2026-08-22',
+      endDate: null,
+      allDay: true,
+      completed: false
+    } as OFCEvent;
+
+    const serialized = createVTodoCalendar(event, 'new-task');
+    expect(serialized).toContain('PRODID:-//Full Calendar Remastered//CalDAV VTODO//EN');
+    expect(serialized).toContain('BEGIN:VTODO');
+    expect(serialized).toContain('DUE;VALUE=DATE:20260822');
+    expect(serialized).toContain('STATUS:NEEDS-ACTION');
+    expect(serialized).toContain('PERCENT-COMPLETE:0');
+    expect(serialized).not.toContain('BEGIN:VEVENT');
+  });
+
+  it('reopens a completed task by removing COMPLETED and restoring an active status', () => {
+    const original = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:completed-task
+SUMMARY:Completed
+DUE;VALUE=DATE:20260822
+STATUS:COMPLETED
+COMPLETED:20260815T140000Z
+END:VTODO
+END:VCALENDAR`;
+    const oldEvent = parseVTodoCalendar(original)[0].event;
+    if (!oldEvent || oldEvent.type !== 'single') throw new Error('Expected a single task');
+
+    const serialized = updateVTodoCalendar(original, 'completed-task', oldEvent, {
+      ...oldEvent,
+      completed: false
+    });
+    expect(serialized).toContain('STATUS:NEEDS-ACTION');
+    expect(serialized).toContain('PERCENT-COMPLETE:0');
+    expect(serialized).not.toContain('COMPLETED:');
+  });
+
+  it('rejects malformed iCalendar input', () => {
+    expect(() => parseVTodoCalendar('BEGIN:VTODO\nUID:broken')).toThrow();
+    expect(() =>
+      parseVTodoCalendar('BEGIN:VCALENDAR\nBEGIN:VTODO\nUID:broken\nEND:VCALENDAR')
+    ).toThrow();
+  });
+});

--- a/src/providers/caldav/vtodo.ts
+++ b/src/providers/caldav/vtodo.ts
@@ -1,0 +1,421 @@
+import ical from 'ical.js';
+import { DateTime } from 'luxon';
+import { OFCEvent, validateEvent } from '../../types';
+import { t } from '../../features/i18n/i18n';
+import { parseTimezoneAwareString } from '../../features/timezone/Timezone';
+
+export type VTodoDateValue = {
+  value: string;
+  allDay: boolean;
+  timezone?: string;
+};
+
+export type ParsedVTodo = {
+  uid: string;
+  title: string;
+  description: string;
+  status: string;
+  completed: boolean;
+  cancelled: boolean;
+  percentComplete?: number;
+  priority?: number;
+  rrule?: string;
+  created?: string;
+  lastModified?: string;
+  completedAt?: string;
+  start?: VTodoDateValue;
+  due?: VTodoDateValue;
+  event: OFCEvent | null;
+};
+
+const PRODID = '-//Full Calendar Remastered//CalDAV VTODO//EN';
+
+function textValue(component: ical.Component, name: string): string {
+  return String(component.getFirstPropertyValue(name) || '');
+}
+
+function readPercentComplete(component: ical.Component): number | undefined {
+  const rawValue = textValue(component, 'percent-complete').trim();
+  if (!rawValue) return undefined;
+
+  const value = Number(rawValue);
+  return Number.isInteger(value) && value >= 0 && value <= 100 ? value : undefined;
+}
+
+function readDateValue(component: ical.Component, name: string): VTodoDateValue | undefined {
+  const property = component.getFirstProperty(name);
+  if (!property) return undefined;
+
+  try {
+    const time = property.getFirstValue();
+    if (!(time instanceof ical.Time)) return undefined;
+    const dateTime = parseTimezoneAwareString(time);
+    if (!dateTime.isValid) return undefined;
+
+    const allDay = Boolean(time.isDate);
+    const parameterTimezone = (
+      property as unknown as { getParameter(name: string): string | undefined }
+    ).getParameter('tzid');
+    const timezone =
+      allDay === false
+        ? String(parameterTimezone || dateTime.zoneName || '').replace(/^floating$/i, '') ||
+          undefined
+        : undefined;
+    const value = allDay
+      ? dateTime.toISODate()
+      : dateTime.toISO({ suppressMilliseconds: true, includeOffset: true });
+    if (!value) return undefined;
+
+    return { value, allDay, ...(timezone ? { timezone } : {}) };
+  } catch {
+    return undefined;
+  }
+}
+
+function readTimestamp(component: ical.Component, name: string): string | undefined {
+  const property = component.getFirstProperty(name);
+  if (!property) return undefined;
+
+  try {
+    const value = property.getFirstValue();
+    if (!(value instanceof ical.Time)) return undefined;
+    const parsed = parseTimezoneAwareString(value);
+    return parsed.isValid
+      ? parsed.toISO({ suppressMilliseconds: true, includeOffset: true }) || undefined
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getDatePart(value: VTodoDateValue): string | null {
+  return DateTime.fromISO(value.value, {
+    setZone: true,
+    ...(value.timezone ? { zone: value.timezone } : {})
+  }).toISODate();
+}
+
+function getTimePart(value: VTodoDateValue): string | null {
+  return DateTime.fromISO(value.value, {
+    setZone: true,
+    ...(value.timezone ? { zone: value.timezone } : {})
+  }).toFormat('HH:mm');
+}
+
+function buildEvent(task: Omit<ParsedVTodo, 'event'>): OFCEvent | null {
+  const placement = task.start || task.due;
+  if (!placement) return null;
+
+  const date = getDatePart(placement);
+  if (!date) return null;
+
+  const icalTask = {
+    status: task.status || undefined,
+    start: task.start,
+    due: task.due,
+    completedAt: task.completedAt,
+    percentComplete: task.percentComplete,
+    priority: task.priority,
+    created: task.created,
+    lastModified: task.lastModified
+  };
+  const timing = placement.allDay
+    ? ({ allDay: true } as const)
+    : (() => {
+        const time = getTimePart(placement);
+        return time ? ({ allDay: false, startTime: time, endTime: time } as const) : null;
+      })();
+  if (!timing) return null;
+
+  const common = {
+    uid: task.uid,
+    title: task.title,
+    description: task.description || undefined,
+    timezone: placement.allDay ? undefined : placement.timezone,
+    icalTask,
+    ...timing
+  };
+
+  if (task.rrule) {
+    return validateEvent({
+      ...common,
+      type: 'rrule',
+      id: `ics::${task.uid}::${date}::recurring`,
+      startDate: date,
+      endDate: null,
+      rrule: task.rrule,
+      skipDates: [],
+      isTask: true
+    });
+  }
+
+  return validateEvent({
+    ...common,
+    type: 'single',
+    date,
+    endDate: null,
+    completed: task.completed ? task.completedAt || true : false
+  });
+}
+
+export function parseVTodoCalendar(ics: string): ParsedVTodo[] {
+  if (!ics.trim() || !/BEGIN:VCALENDAR/i.test(ics)) {
+    throw new Error(t('settings.calendars.caldavTasks.errors.malformedMissingCalendar'));
+  }
+
+  let calendar: ical.Component;
+  try {
+    calendar = new ical.Component(ical.parse(ics));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(t('settings.calendars.caldavTasks.errors.malformedData', { message }), {
+      cause: error
+    });
+  }
+
+  const tasks: (ParsedVTodo | null)[] = calendar.getAllSubcomponents('vtodo').map(todo => {
+    const uid = textValue(todo, 'uid').trim();
+    if (!uid) return null;
+
+    const status = textValue(todo, 'status').trim().toUpperCase();
+    const completedAt = readTimestamp(todo, 'completed');
+    const percentComplete = readPercentComplete(todo);
+    const priorityValue = Number(textValue(todo, 'priority'));
+    const priority =
+      Number.isInteger(priorityValue) && priorityValue >= 0 && priorityValue <= 9
+        ? priorityValue
+        : undefined;
+    const rrule = textValue(todo, 'rrule').trim() || undefined;
+    const taskWithoutEvent = {
+      uid,
+      title: textValue(todo, 'summary') || t('settings.calendars.caldavTasks.untitledTask'),
+      description: textValue(todo, 'description'),
+      status,
+      completed: status === 'COMPLETED' || Boolean(completedAt) || percentComplete === 100,
+      cancelled: status === 'CANCELLED',
+      percentComplete,
+      priority,
+      rrule,
+      created: readTimestamp(todo, 'created'),
+      lastModified: readTimestamp(todo, 'last-modified'),
+      completedAt,
+      start: readDateValue(todo, 'dtstart'),
+      due: readDateValue(todo, 'due')
+    } satisfies Omit<ParsedVTodo, 'event'>;
+
+    return { ...taskWithoutEvent, event: buildEvent(taskWithoutEvent) };
+  });
+  return tasks.filter((task): task is ParsedVTodo => task !== null);
+}
+
+function eventPlacement(event: OFCEvent): VTodoDateValue | null {
+  const date =
+    event.type === 'single' ? event.date : event.type === 'rrule' ? event.startDate : null;
+  if (!date) return null;
+  if (event.allDay) return { value: date, allDay: true };
+
+  const startTime = 'startTime' in event ? event.startTime : null;
+  if (!startTime) return null;
+  const parsed = DateTime.fromISO(`${date}T${startTime}`, {
+    ...(event.timezone ? { zone: event.timezone } : {})
+  });
+  const value = parsed.toISO({ suppressMilliseconds: true, includeOffset: true });
+  return value
+    ? { value, allDay: false, ...(event.timezone ? { timezone: event.timezone } : {}) }
+    : null;
+}
+
+function toIcalTime(value: VTodoDateValue): ical.Time {
+  const parsed = DateTime.fromISO(value.value, {
+    setZone: true,
+    ...(value.timezone ? { zone: value.timezone } : {})
+  });
+  const utc = value.timezone === 'UTC' || value.timezone === 'Z';
+  const normalized = utc ? parsed.toUTC() : parsed;
+  return new ical.Time({
+    year: normalized.year,
+    month: normalized.month,
+    day: normalized.day,
+    hour: value.allDay ? 0 : normalized.hour,
+    minute: value.allDay ? 0 : normalized.minute,
+    second: value.allDay ? 0 : normalized.second,
+    isDate: value.allDay,
+    ...(!value.allDay && utc ? { timezone: 'Z' } : {})
+  });
+}
+
+function replaceDateProperty(
+  component: ical.Component,
+  name: 'dtstart' | 'due',
+  value: VTodoDateValue | undefined
+): void {
+  component.removeAllProperties(name);
+  if (!value) return;
+
+  const property = new ical.Property(name);
+  if (!value.allDay && value.timezone && value.timezone !== 'UTC' && value.timezone !== 'Z') {
+    property.setParameter('TZID', value.timezone);
+  }
+  property.setValue(toIcalTime(value));
+  component.addProperty(property);
+}
+
+function replaceTextProperty(component: ical.Component, name: string, value?: string): void {
+  component.removeAllProperties(name);
+  if (value) component.addPropertyWithValue(name, value);
+}
+
+function addRecurrence(component: ical.Component, rule?: string): void {
+  if (!rule) return;
+  try {
+    const recur = (ical.Recur as unknown as { fromString(value: string): unknown }).fromString(
+      rule.replace(/^RRULE:/i, '')
+    ) as string;
+    component.addPropertyWithValue('rrule', recur);
+  } catch {
+    const property = new ical.Property('rrule');
+    property.setValue(rule.replace(/^RRULE:/i, ''));
+    component.addProperty(property);
+  }
+}
+
+function completionTimestamp(event: OFCEvent): ical.Time {
+  const completed = event.type === 'single' ? event.completed : false;
+  const parsed =
+    typeof completed === 'string' ? DateTime.fromISO(completed, { setZone: true }) : DateTime.utc();
+  return ical.Time.fromJSDate((parsed.isValid ? parsed : DateTime.utc()).toJSDate(), true);
+}
+
+function applyCompletion(component: ical.Component, event: OFCEvent): void {
+  const completed = event.type === 'single' ? Boolean(event.completed) : false;
+  const currentStatus = textValue(component, 'status').toUpperCase();
+  const currentPercentComplete = readPercentComplete(component);
+  const wasCompleted =
+    currentStatus === 'COMPLETED' ||
+    Boolean(component.getFirstProperty('completed')) ||
+    currentPercentComplete === 100;
+  const preferredStatus = event.icalTask?.status?.toUpperCase();
+  const activeStatus =
+    currentStatus === 'IN-PROCESS' || preferredStatus === 'IN-PROCESS'
+      ? 'IN-PROCESS'
+      : 'NEEDS-ACTION';
+  component.updatePropertyWithValue('status', completed ? 'COMPLETED' : activeStatus);
+  component.removeAllProperties('completed');
+  if (completed) {
+    component.addPropertyWithValue('completed', completionTimestamp(event));
+    component.updatePropertyWithValue('percent-complete', 100);
+  } else if (wasCompleted || currentPercentComplete === undefined) {
+    component.updatePropertyWithValue('percent-complete', 0);
+  }
+}
+
+function durationBetween(start: VTodoDateValue, due: VTodoDateValue): number | null {
+  const startDate = DateTime.fromISO(start.value, { setZone: true });
+  const dueDate = DateTime.fromISO(due.value, { setZone: true });
+  return startDate.isValid && dueDate.isValid ? dueDate.toMillis() - startDate.toMillis() : null;
+}
+
+function addDuration(value: VTodoDateValue, milliseconds: number, allDay: boolean): VTodoDateValue {
+  const parsed = DateTime.fromISO(value.value, {
+    setZone: true,
+    ...(value.timezone ? { zone: value.timezone } : {})
+  }).plus({ milliseconds });
+  const nextValue = allDay
+    ? parsed.toISODate()
+    : parsed.toISO({ suppressMilliseconds: true, includeOffset: true });
+  return {
+    value: nextValue || value.value,
+    allDay,
+    ...(!allDay && value.timezone ? { timezone: value.timezone } : {})
+  };
+}
+
+function placementChanged(oldEvent: OFCEvent, newEvent: OFCEvent): boolean {
+  return JSON.stringify(eventPlacement(oldEvent)) !== JSON.stringify(eventPlacement(newEvent));
+}
+
+function updateTaskDates(todo: ical.Component, oldEvent: OFCEvent, newEvent: OFCEvent): void {
+  if (!placementChanged(oldEvent, newEvent)) return;
+  const nextPlacement = eventPlacement(newEvent);
+  if (!nextPlacement) return;
+
+  const currentStart = readDateValue(todo, 'dtstart');
+  const currentDue = readDateValue(todo, 'due');
+  if (currentStart) {
+    replaceDateProperty(todo, 'dtstart', nextPlacement);
+    if (currentDue) {
+      const duration = durationBetween(currentStart, currentDue);
+      replaceDateProperty(
+        todo,
+        'due',
+        duration === null
+          ? currentDue
+          : addDuration(nextPlacement, duration, nextPlacement.allDay && currentDue.allDay)
+      );
+    }
+    return;
+  }
+
+  replaceDateProperty(todo, 'due', nextPlacement);
+}
+
+export function createVTodoCalendar(event: OFCEvent, uid: string): string {
+  const calendar = new ical.Component(['vcalendar', [], []]);
+  calendar.addPropertyWithValue('version', '2.0');
+  calendar.addPropertyWithValue('prodid', PRODID);
+
+  const todo = new ical.Component('vtodo');
+  todo.addPropertyWithValue('uid', uid);
+  todo.addPropertyWithValue('dtstamp', ical.Time.now());
+  todo.addPropertyWithValue('created', ical.Time.now());
+  todo.addPropertyWithValue('last-modified', ical.Time.now());
+  todo.addPropertyWithValue(
+    'summary',
+    event.title || t('settings.calendars.caldavTasks.untitledTask')
+  );
+  if (event.description) todo.addPropertyWithValue('description', event.description);
+
+  const placement = eventPlacement(event);
+  const taskMetadata = event.icalTask;
+  replaceDateProperty(todo, 'dtstart', taskMetadata?.start);
+  replaceDateProperty(
+    todo,
+    'due',
+    taskMetadata?.due || (!taskMetadata?.start ? placement || undefined : undefined)
+  );
+  if (taskMetadata?.priority !== undefined) {
+    todo.addPropertyWithValue('priority', taskMetadata.priority);
+  }
+  if (event.type === 'rrule') addRecurrence(todo, event.rrule);
+  applyCompletion(todo, event);
+  calendar.addSubcomponent(todo);
+
+  return (calendar as unknown as { toString(): string }).toString();
+}
+
+export function updateVTodoCalendar(
+  ics: string,
+  uid: string,
+  oldEvent: OFCEvent,
+  newEvent: OFCEvent
+): string {
+  const calendar = new ical.Component(ical.parse(ics));
+  const todo = calendar
+    .getAllSubcomponents('vtodo')
+    .find(component => textValue(component, 'uid').trim() === uid);
+  if (!todo) {
+    throw new Error(t('settings.calendars.caldavTasks.errors.vtodoNotFound', { uid }));
+  }
+
+  replaceTextProperty(
+    todo,
+    'summary',
+    newEvent.title || t('settings.calendars.caldavTasks.untitledTask')
+  );
+  replaceTextProperty(todo, 'description', newEvent.description);
+  updateTaskDates(todo, oldEvent, newEvent);
+  applyCompletion(todo, newEvent);
+  todo.updatePropertyWithValue('last-modified', ical.Time.now());
+
+  return (calendar as unknown as { toString(): string }).toString();
+}

--- a/src/types/calendar_settings.ts
+++ b/src/types/calendar_settings.ts
@@ -60,6 +60,15 @@ const calendarOptionsSchema = z.discriminatedUnion('type', [
     password: z.string()
   }),
   z.object({
+    type: z.literal('caldavtasks'),
+    id: z.string(),
+    name: z.string(),
+    url: z.string().url(),
+    homeUrl: z.string().url(),
+    username: z.string(),
+    password: z.string()
+  }),
+  z.object({
     type: z.literal('google'),
     id: z.string(),
     name: z.string(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,3 +38,4 @@ export type Authentication = {
 };
 
 export type CalDAVSource = Extract<CalendarInfo, { type: 'caldav' }>;
+export type CalDAVTaskSource = Extract<CalendarInfo, { type: 'caldavtasks' }>;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -68,6 +68,30 @@ export const CommonSchema = z.object({
   recurrenceId: z.string().optional(),
   timezone: z.string().optional(),
   etag: z.string().optional(),
+  icalTask: z
+    .object({
+      status: z.string().optional(),
+      start: z
+        .object({
+          value: z.string(),
+          allDay: z.boolean(),
+          timezone: z.string().optional()
+        })
+        .optional(),
+      due: z
+        .object({
+          value: z.string(),
+          allDay: z.boolean(),
+          timezone: z.string().optional()
+        })
+        .optional(),
+      completedAt: z.string().optional(),
+      percentComplete: z.number().int().min(0).max(100).optional(),
+      priority: z.number().int().min(0).max(9).optional(),
+      created: z.string().optional(),
+      lastModified: z.string().optional()
+    })
+    .optional(),
   category: z.string().optional(), // This will store the parsed category.
   subCategory: z.string().optional(),
   recurringEventId: z.string().optional(), // The ID of the parent recurring event.

--- a/src/ui/modals/EditEvent.tsx
+++ b/src/ui/modals/EditEvent.tsx
@@ -246,6 +246,7 @@ export const EditEvent = ({
   const selectedCalendar = calendars[calendarIndex];
   const isDailyNoteCalendar =
     selectedCalendar.type === 'dailynote' || selectedCalendar.type === 'journals';
+  const isCalDAVTaskCalendar = selectedCalendar.type === 'caldavtasks';
   const provider = PluginState.getProviderRegistry().getInstance(selectedCalendar.id);
   const useBooleanTaskCompletion = Boolean(
     provider &&
@@ -266,6 +267,13 @@ export const EditEvent = ({
       setRecurrenceType('none');
     }
   }, [isDailyNoteCalendar]);
+
+  useEffect(() => {
+    if (isCalDAVTaskCalendar) {
+      setIsTask(true);
+      if (mode === 'create') setRecurrenceType('none');
+    }
+  }, [isCalDAVTaskCalendar, mode]);
 
   const handleSubmit = async (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -510,7 +518,12 @@ export const EditEvent = ({
           </div>
           <div className="setting-item-control options-group">
             <label>
-              <input type="checkbox" checked={isTask} onChange={e => setIsTask(e.target.checked)} />
+              <input
+                type="checkbox"
+                checked={isTask}
+                onChange={e => setIsTask(e.target.checked)}
+                disabled={isCalDAVTaskCalendar}
+              />
               <span> {t('modals.editEvent.fields.options.isTask')}</span>
             </label>
             {isTask && (
@@ -650,8 +663,12 @@ export const EditEvent = ({
                 <select
                   value={recurrenceType}
                   onChange={e => setRecurrenceType(e.target.value as RecurrenceType)}
-                  disabled={isDailyNoteCalendar}
-                  title={recurringTooltip}
+                  disabled={isDailyNoteCalendar || isCalDAVTaskCalendar}
+                  title={
+                    isCalDAVTaskCalendar
+                      ? t('modals.editEvent.tooltips.caldavTaskRecurrence')
+                      : recurringTooltip
+                  }
                 >
                   <option value="none">{t('modals.editEvent.fields.repeats.options.none')}</option>
                   <option value="daily">

--- a/src/ui/settings/SettingsTab.tsx
+++ b/src/ui/settings/SettingsTab.tsx
@@ -129,6 +129,7 @@ export function addCalendarButton(
           journals: t('settings.calendars.types.journals'),
           icloud: t('settings.calendars.types.icloud'),
           caldav: t('settings.calendars.types.caldav'),
+          caldavtasks: t('settings.calendars.types.caldavTasks'),
           ical: t('settings.calendars.types.ical'),
           google: t('settings.calendars.types.google'),
           googletasks: 'Google Tasks',

--- a/src/ui/settings/sections/renderCalendars.ts
+++ b/src/ui/settings/sections/renderCalendars.ts
@@ -196,6 +196,10 @@ export function renderCalendarManagement(
         { text: t('settings.calendars.docs.journals'), path: 'user/calendars/journals' },
         { text: t('settings.calendars.docs.ics'), path: 'user/calendars/ics' },
         { text: t('settings.calendars.docs.caldav'), path: 'user/calendars/caldav' },
+        {
+          text: t('settings.calendars.docs.caldavTasks'),
+          path: 'user/calendars/caldav-tasks'
+        },
         { text: t('settings.calendars.docs.google'), path: 'user/calendars/gcal' },
         { text: t('settings.calendars.docs.outlook'), path: 'user/calendars/outlook' },
         {

--- a/src/ui/settings/utilsSettings.ts
+++ b/src/ui/settings/utilsSettings.ts
@@ -325,7 +325,7 @@ export function migrateAndSanitizeSettings(settings: unknown): {
       // CalDAV Passwords
       if (newSettings.calendarSources) {
         newSettings.calendarSources.forEach(source => {
-          if (source.type === 'caldav') {
+          if (source.type === 'caldav' || source.type === 'caldavtasks') {
             if (source.password) {
               secretStorage.setSecret(getSecretKey.caldavPassword(source.id), source.password);
               source.password = '';
@@ -384,7 +384,7 @@ export function migrateAndSanitizeSettings(settings: unknown): {
       // CalDAV Passwords
       if (newSettings.calendarSources) {
         newSettings.calendarSources.forEach(source => {
-          if (source.type === 'caldav') {
+          if (source.type === 'caldav' || source.type === 'caldavtasks') {
             const storedPwd = secretStorage.getSecret(getSecretKey.caldavPassword(source.id));
             if (storedPwd && storedPwd !== '') {
               source.password = storedPwd;


### PR DESCRIPTION
## Summary

Adds first-class CalDAV `VTODO` support through a new **CalDAV Tasks** source.

This extends the existing CalDAV integration beyond `VEVENT` calendars, allowing Full Calendar Remastered to connect to CalDAV task/reminder collections.

The implementation has been manually tested end-to-end with Apple iCloud Reminders.

## What changed

- Added a new **CalDAV Tasks** source with localized configuration UI
- Added parsing and serialization of `VTODO` resources
- Added support for dated and undated tasks
- Added create, edit, complete/reopen, and delete synchronization
- Added `DTSTART`, `DUE`, `STATUS`, `PERCENT-COMPLETE`, `COMPLETED`, priority, and recurrence handling
- Added timezone / `VTIMEZONE` and nested `VALARM` support
- Added ETag-aware writes and stable resource identity
- Added namespace-aware CalDAV `207 Multi-Status` handling
- Preserves unknown properties such as provider-specific extensions
- Reuses the existing CalDAV authentication, SecretStorage, networking, fallback, and synchronization infrastructure
- Added dedicated VTODO tests, sanitized Apple-style CalDAV fixtures, VEVENT regression coverage, and documentation

## Apple Reminders

The implementation was manually tested against iCloud Reminders using a direct CalDAV VTODO collection, an Apple Account email, and an app-specific password.

No private Apple APIs are used. The integration communicates through CalDAV/iCalendar VTODO resources.

No account-specific URLs, identifiers, credentials, or personal reminder data are included in this PR.

## Validation

- `pnpm run ra` 
  - TypeScript passed
  - Prettier passed
  - ESLint: 0 errors
  - CSS lint: 0 errors
  - i18n validation passed
  - 87/87 Jest suites passed
  - 886 tests passed, 1 todo
  - 43/43 snapshots passed
- Focused CalDAV suite: 9 suites / 70 tests passed
- `pnpm run prod` 

## Current limitations

- A direct VTODO collection URL is currently required; account-root discovery is not included.
- Existing recurrence rules are parsed, displayed, and preserved, but creating/changing recurrence or editing individual recurring instances is not yet supported.
- Cancelled VTODO tasks are not rendered because the shared task model does not currently expose a separate cancelled state.
- Synchronization currently queries the collection rather than using CalDAV sync tokens.