### PR TITLE
docs(copilot): correct stale developer guidance in copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,81 +1,99 @@
 
 # Full Calendar Plugin for Obsidian
 
-This plugin integrates FullCalendar.js into Obsidian, supporting local (Full Note, Daily Note) and remote (ICS, CalDAV, Google) calendars. It is TypeScript-based, modular, and designed for robust event management and calendar views.
+This plugin integrates FullCalendar.io into Obsidian. It reads and writes events from local sources (note frontmatter, daily notes, journals) and remote ones (ICS, CalDAV, Google, Outlook), plus several task providers. It is TypeScript-based, modular, and designed for robust event management and calendar views.
+
+> **Package manager: pnpm, not npm.** `preinstall` runs `npx only-allow pnpm`, so `npm install` hard-fails. Every command below uses `pnpm`.
 
 ## Essential Architecture
 
-- **UI Layer**: React components (`src/ui/`), FullCalendar.js integration (`src/ui/view.ts`), and view models (e.g., `ViewEnhancer`).
-- **Core Layer**: Central event management via `EventCache` (single source of truth) and `EventStore` (in-memory DB, indexes).
-- **Calendar Layer**: Pluggable sources (`src/calendars/`): Full Note, Daily Note, ICS, CalDAV.
-- **Abstraction Layer**: `ObsidianAdapter` for testable Obsidian API interactions.
-- **ChronoAnalyser**: Data visualization (see `src/chrono_analyser/`), consumes `EventCache` via pub/sub for real-time updates.
+- **UI Layer**: React-style components (`src/ui/`) and FullCalendar.io integration (`src/ui/view.ts`), with `ViewEnhancer` (`src/core/ViewEnhancer.ts`) applying workspace filters. Note that `react`/`react-dom` are aliased to `preact/compat` at build time in `esbuild.config.mjs`.
+- **Core Layer**: `EventCache` (`src/core/EventCache.ts`) is the single source of truth, with optimistic writes and rollback on provider failure. It wraps `EventStore` (`src/core/EventStore.ts`), an in-memory DB with secondary indexes.
+- **Normalization Layer**: `EventEnhancer` (`src/core/EventEnhancer.ts`) is the chokepoint between raw provider data and canonical events. `enhance()` converts raw → canonical (category split, source timezone → display timezone); `prepareForStorage()` reverses it.
+- **Provider Layer**: Pluggable sources under `src/providers/`, contract defined in `src/providers/Provider.ts`, all I/O routed through `ProviderRegistry` (`src/providers/ProviderRegistry.ts`).
+- **Abstraction Layer**: `ObsidianAdapter` (`src/ObsidianAdapter.ts`) for testable Obsidian API interactions.
+- **ChronoAnalyser**: Data visualization (`src/chrono_analyser/`), consumes `EventCache` via pub/sub for real-time updates.
 
-**Data Flow Example**:
-- User actions → EventCache → Calendar implementations → Obsidian vault
-- File changes/remote sync → EventCache → UI updates (pub/sub)
+**Data Flow**: strictly one-way through the cache.
+- User actions → `EventCache` → `EventEnhancer` → `ProviderRegistry` → provider → vault or network
+- File changes / remote sync → provider → `EventEnhancer` → `EventCache` → UI updates (pub/sub)
+
+### Providers
+
+Thirteen providers are registered in `ProviderRegistry.registerBuiltInProviders()`, all as lazy dynamic imports: `local` (full note), `dailynote`, `journals`, `ical`, `caldav`, `caldavtasks`, `google`, `googletasks`, `outlook`, `tasks`, `tasknotes`, `bases`, `holidays`.
+
+Adding a provider means touching the registry, the settings dropdown in `src/ui/settings/SettingsTab.tsx`, and the docs. Follow `docs/architecture/calendars/provider-blueprint.md`.
 
 ## Developer Workflows
 
-- **Bootstrap**:  
-	- `npm install` (45s, never cancel)
-- **Build/Test**:  
-	- `npm run compile` (type check)  
-	- `npm run lint` (Prettier)  
-	- `npm run test` (Jest, 154 tests)  
-	- `npm run build` (esbuild)  
-	- `npm run prod` (type check + build)
-- **Development**:  
-	- `npm run dev` (esbuild watch)  
-	- `npm run fix-lint` (auto-format)  
-	- `npm run coverage` (test coverage)  
-	- `npm run test-update` (update Jest snapshots)
-- **Validation**:  
-	- Always run `npm run lint && npm run compile && npm run test` before commit
-	- Test in `obsidian-dev-vault/` (pre-configured dev vault)
-	- Copy `manifest.json` to plugin build directory for Obsidian testing
+- **Bootstrap**:
+	- `pnpm install`
+- **Build/Test**:
+	- `pnpm run compile` (type check, `tsc --noEmit`)
+	- `pnpm run lint` (ESLint: one TypeScript pass, one CSS pass)
+	- `pnpm test` (Jest, 89 suites / 894 tests / 43 snapshots)
+	- `pnpm run build` (esbuild, production)
+	- `pnpm run prod` (type check + production build)
+- **Development**:
+	- `pnpm run dev` (esbuild watch, writes into the dev vault)
+	- `pnpm run lint:fix` (ESLint autofix)
+	- `pnpm run format` (Prettier write) / `pnpm run format:check`
+	- `pnpm run test-dev` (Jest watch mode)
+	- `pnpm run coverage` (test coverage)
+- **Validation**:
+	- While iterating: `pnpm run compile && pnpm test && pnpm run lint`
+	- Before opening a PR: `pnpm run ra` must exit with **0 errors**. It runs Prettier `--write`, compile, ESLint (to `lint_report.txt`), CSS lint (to `css_report.txt`), the i18n sync check, and Jest. It **rewrites source files**, so run it deliberately rather than mid-investigation.
+	- Test in `obsidian-dev-vault/`. The dev vault is created automatically by `esbuild.config.mjs` on first build; it is gitignored, so its absence is normal.
+
+> **Snapshot warning**: CI runs `pnpm run test-update` (`.github/workflows/check.yml`), i.e. Jest with `--updateSnapshot`. **Snapshot drift cannot fail CI.** Verify snapshots locally with plain `pnpm test`.
 
 ## Project Conventions
 
-- **Event Storage**:  
-	- Full Note: events as separate notes with frontmatter  
+- **Event Storage**:
+	- Full Note: events as separate notes with frontmatter
 	- Daily Note: events as list items with inline metadata
-- **Category System**:  
+- **Category System**:
 	- Format: `Category - Title` or `Category - Subcategory - Title`
-	- Color coding and parsing logic in core
-- **Recurring Events**:  
-	- Recurrence logic and instance modification supported
-- **Internationalization**:  
-	- Uses i18next, translation files in `src/features/i18n/locales/`, type-safe keys
+	- Parsing and color logic live in `EventEnhancer` / `src/features/category/`
+- **Recurring Events**:
+	- Editing a single instance is "skip and override": the date is pushed into the parent's `skipDates[]` **and** a new `single` event is created carrying `recurringEventId` back to the parent. That is two writes, not one. Providers with native recurrence set `ownsRecurringInstanceOverrides` and bypass this. See `src/features/recur_events/RecurringEventManager.ts`.
+- **Timezones**: three are always live — SourceTZ (stored on the event), DisplayTZ (user setting), SystemTZ. `src/features/timezone/Timezone.ts` is a bespoke, luxon-free implementation; luxon remains a dependency for FullCalendar.io but should not be used for core conversion logic.
+- **Internationalization**:
+	- Uses i18next, translation files in `src/features/i18n/locales/`, type-safe keys.
+	- **Zero hardcoded user-facing strings.** Add to `en.json` and render via `t('key.path')`. Do not hand-edit the other locale JSONs; `pnpm run ra` syncs them.
+- **Tests**: never modify existing `.test` files. Add new ones freely. See `CONTRIBUTING.md`.
 
 ## Key Files & Directories
 
 - `src/main.ts` — Plugin entry
-- `src/core/EventCache.ts` — Event management
+- `src/core/PluginState.ts` — Global singleton wiring
+- `src/core/EventCache.ts` — Event management (single source of truth)
 - `src/core/EventStore.ts` — In-memory DB
-- `src/calendars/` — Calendar sources
+- `src/core/EventEnhancer.ts` — Raw ↔ canonical normalization
+- `src/providers/` — Provider implementations
+- `src/providers/Provider.ts` — Provider contract
 - `src/ui/view.ts` — Calendar view integration
-- `src/types/schema.ts` — Zod schemas
-- `test_helpers/MockVault.ts` — Obsidian API mocking
-- `docs/` — MkDocs documentation
+- `src/types/schema.ts` — Zod schemas (`OFCEvent`)
+- `test_helpers/` — `MockVault.ts`, `AppBuilder.ts`, `FileBuilder.ts` for Obsidian API mocking
+- `docs/architecture/` — Implementation documentation (MkDocs)
 
 ## Integration & Extensibility
 
-- **External dependencies**: FullCalendar.js, React, Luxon (bundled), Obsidian APIs (external)
+- **External dependencies**: FullCalendar.io, Preact (aliased from React), Luxon, Zod, i18next (bundled); Obsidian APIs marked external
 - **ChronoAnalyser**: Extensible charting via Strategy Pattern; subscribes to EventCache for real-time data
-- **Testing**: Unit/integration tests, snapshot updates, coverage enforcement
+- **Testing**: Unit and integration tests against a mock vault, snapshot tests, coverage available
 
 ## Troubleshooting
 
 - Build failures: check TypeScript errors, esbuild config, CSS renaming
-- Test failures: run `npm run test-update` for snapshots, check date/timezone issues
-- Plugin loading: verify build output, copy manifest, check Obsidian console
+- Test failures: check date/timezone assumptions first; see the snapshot warning above before reaching for `test-update`
+- Plugin loading: verify build output in the dev vault, check the Obsidian console
 
 ## Best Practices
 
 - Minimal, modular changes; follow SOLID/DRY
-- Strict formatting (Prettier, Husky hooks)
-- Always validate in dev vault before commit
+- ESLint for correctness, Prettier for formatting; Husky pre-commit runs a type check
+- Always validate in the dev vault before commit
 - Reference [Obsidian plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines)
 
 
@@ -83,103 +101,107 @@ This plugin integrates FullCalendar.js into Obsidian, supporting local (Full Not
 ```
 .
 ├── README.md
-├── CONTRIBUTING.md 
-├── package.json           # npm scripts and dependencies
-├── esbuild.config.mjs     # build configuration  
+├── CONTRIBUTING.md
+├── package.json           # pnpm scripts and dependencies
+├── esbuild.config.mjs     # build configuration
 ├── jest.config.js         # test configuration
 ├── manifest.json          # Obsidian plugin manifest
+├── manifest-beta.json     # manifest copied into the dev vault by the build
 ├── src/                   # TypeScript source code
-│   ├── main.ts           # plugin entry point
-│   ├── calendars/        # calendar source implementations
-│   ├── core/             # core logic (EventCache, EventStore)
-│   ├── ui/               # React components and views
-│   └── types/            # TypeScript types and schemas
-├── test_helpers/         # test utilities and mocks
-├── docs/                 # documentation (MkDocs)
-├── tools/                # Python development utilities
-└── obsidian-dev-vault/   # development Obsidian vault
+│   ├── main.ts            # plugin entry point
+│   ├── ObsidianAdapter.ts # Obsidian API abstraction
+│   ├── api/               # public and internal API surface
+│   ├── core/              # core logic (EventCache, EventStore, EventEnhancer)
+│   ├── providers/         # calendar and task source implementations
+│   ├── features/          # i18n, timezone, workspaces, recurrence, categories, …
+│   ├── ui/                # components, views, settings, modals
+│   ├── chrono_analyser/   # data visualization
+│   ├── types/             # TypeScript types and Zod schemas
+│   ├── utils/             # shared helpers
+│   ├── stubs/             # build-time module shims
+│   └── workers/           # web workers
+├── test_helpers/          # test utilities and mocks
+├── docs/                  # documentation (MkDocs)
+├── tools/                 # development utilities (i18n sync, generators, Android helpers)
+└── obsidian-dev-vault/    # development Obsidian vault (gitignored, created by the build)
 ```
 
 ### Key Source Files
 - `src/main.ts` -- Plugin entry point and initialization
 - `src/core/EventCache.ts` -- Central event management (single source of truth)
 - `src/core/EventStore.ts` -- In-memory event database with indexes
-- `src/calendars/FullNoteCalendar.ts` -- Full note calendar implementation
-- `src/calendars/DailyNoteCalendar.ts` -- Daily note calendar implementation
-- `src/ui/view.ts` -- Main calendar view integration with FullCalendar.js
+- `src/core/EventEnhancer.ts` -- Normalization chokepoint between raw and canonical events
+- `src/providers/Provider.ts` -- The provider contract every source implements
+- `src/providers/ProviderRegistry.ts` -- Provider registration, ID mapping, staged load
+- `src/providers/fullnote/FullNoteProvider.ts` -- Full note calendar implementation
+- `src/providers/dailynote/DailyNoteProvider.ts` -- Daily note calendar implementation
+- `src/ui/view.ts` -- Main calendar view integration with FullCalendar.io
 - `src/types/schema.ts` -- Zod schemas for data validation
 
 ### Build System Details
 - **Bundler**: esbuild with custom configuration
-- **CSS Handling**: Automatically renames main.css to styles.css for Obsidian compatibility
+- **CSS Handling**: Automatically renames `main.css` to `styles.css` for Obsidian compatibility, then copies `main.js`, `styles.css`, and `manifest-beta.json` (as `manifest.json`) into the dev vault
 - **TypeScript**: Strict type checking with `tsc --noEmit`
-- **External Dependencies**: FullCalendar.js, React, Luxon, and others bundled but Obsidian APIs marked as external
+- **Lean builds**: `pnpm run build:lean` stubs out `plotly.js` and `date-holidays` for a smaller bundle
+- **External Dependencies**: FullCalendar.io, Preact, Luxon and others bundled; Obsidian APIs marked as external
 
 ### Testing Framework
-- **Framework**: Jest with ts-jest preset
-- **Test Types**: Unit tests, integration tests with mock Obsidian vault
-- **Coverage**: Run `npm run coverage` for detailed coverage report
+- **Framework**: Jest with ts-jest preset, jsdom environment
+- **Test Types**: Unit tests, integration tests against a mock Obsidian vault
+- **Coverage**: Run `pnpm run coverage` for a detailed coverage report
 - **Test Files**: `*.test.ts` files alongside source code and in `test_helpers/`
-- **Mocking**: `test_helpers/MockVault.ts` provides Obsidian API mocking
+- **Mocking**: `test_helpers/MockVault.ts`, `AppBuilder.ts`, and `FileBuilder.ts` provide Obsidian API mocking; `__mocks__/obsidian.ts` mocks the module itself
+- **Property testing**: `fast-check` and `zod-fast-check` are available for schema-level tests
 
 ### Development Tools
-- **Linting**: Prettier for code formatting (strict enforcement)
-- **Git Hooks**: Husky for pre-commit formatting checks
-- **Python Tools**: Optional utilities in `tools/` for Android testing and event generation
-- **Documentation**: MkDocs setup for documentation site
+- **Linting**: ESLint (`pnpm run lint`), including a dedicated CSS pass via `eslint.css.config.mjs`
+- **Formatting**: Prettier (`pnpm run format`), separate from linting
+- **Git Hooks**: Husky pre-commit runs `npm run compile`, so a type error blocks the commit
+- **Utilities**: `tools/` holds the i18n sync script plus optional Python helpers for Android testing and event generation
+- **Documentation**: MkDocs setup for the documentation site
 
 ## Time Expectations and Timeouts
 
-CRITICAL: NEVER CANCEL builds or long-running commands:
-- `npm install`: 45 seconds (one-time setup)
-- `npm run test`: 3 seconds  
-- `npm run compile`: 5 seconds
-- `npm run build`: 0.5 seconds
-- `npm run prod`: 5.5 seconds
-- `npm run coverage`: 4.5 seconds
-- `npm run lint`: 1.5 seconds
-- Combined validation: `npm run lint && npm run compile && npm run test` takes 9 seconds
+CRITICAL: NEVER CANCEL builds or long-running commands.
 
-Set timeouts to at least 2x the expected time for safety.
+Approximate warm-cache timings, measured on one developer machine. Treat these as order-of-magnitude only; they vary substantially with hardware and cache state.
 
-## Architecture Overview
+| Command | Approx. |
+|---|---|
+| `pnpm run compile` | ~7s |
+| `pnpm test` | ~15s |
+| `pnpm run lint` | ~30s |
+| `pnpm run build` | ~10s |
+| `pnpm run prod` | ~10s |
+| `pnpm run coverage` | ~10s |
+| `pnpm run compile && pnpm test && pnpm run lint` | ~50s |
 
-The plugin follows a modular architecture:
-
-1. **UI Layer**: React components and FullCalendar.js integration
-2. **Core Layer**: EventCache (single source of truth) + EventStore (in-memory database)
-3. **Calendar Layer**: Pluggable calendar sources (Full Note, Daily Note, ICS, CalDAV)
-4. **Abstraction Layer**: ObsidianAdapter for testable Obsidian API interactions
-
-Key data flows:
-- User actions → EventCache → Calendar implementations → Obsidian vault
-- File changes → EventCache → UI updates via pub/sub pattern
-- Remote calendar sync → EventCache → UI updates
+`pnpm install` is network-bound and varies widely. Set timeouts to at least 2x the expected time.
 
 ## Common Issues and Solutions
 
 **Build Issues:**
-- If esbuild fails, check TypeScript errors with `npm run compile`
-- If styles missing, ensure CSS renaming plugin works in esbuild.config.mjs
+- If esbuild fails, check TypeScript errors with `pnpm run compile`
+- If styles are missing, ensure the CSS renaming plugin ran in `esbuild.config.mjs`
 
-**Test Issues:**  
-- Jest tests are fast and reliable - if failing, check recent code changes
-- Use `npm run test-dev` for watch mode during development
-- Snapshot test failures: Run `npm run test-update` to update snapshots when changes are expected
-- Some date/timezone related tests may fail due to environment differences - use test-update to fix these
+**Test Issues:**
+- Use `pnpm run test-dev` for watch mode during development
+- Snapshot failures: inspect the diff first. Only run `pnpm run test-update` once you have confirmed the new snapshot is correct — CI already updates snapshots, so it will not catch a wrong one for you
+- Date and timezone tests are sensitive to the three-timezone model; a failure there usually indicates a real bug rather than an environment quirk
 
 **Plugin Loading Issues:**
-- Ensure manifest.json is copied to build directory
-- Check Obsidian console for plugin loading errors
-- Verify all required files (main.js, styles.css, manifest.json) are present
+- Ensure the build wrote `main.js`, `styles.css`, and `manifest.json` into `obsidian-dev-vault/.obsidian/plugins/full-calendar-remastered/`
+- Check the Obsidian console for plugin loading errors
+- The [Hot Reload plugin](https://github.com/pjeby/hot-reload) reloads the plugin automatically on rebuild
 
 **Development Workflow:**
-- Use `npm run dev` for watch mode during active development
-- Run full validation suite before committing changes
-- Test plugin functionality in obsidian-dev-vault for real-world validation
+- Use `pnpm run dev` for watch mode during active development
+- Run the full validation suite before committing changes
+- Test plugin functionality in the dev vault for real-world validation
 
 ## Important Notes
 - Keep the codebase clean, lean, modular. Follow the SOLID and DRY principle.
-- Allows follow the Obsidian plugin development [guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines).
-- Try to Follow the minimal code changes principle - only modify what is necessary for the feature or fix, unless SOLID and DRY principles dictate otherwise.
-- Commit message should be precise and detailed and should contain what changes were made and why. 
+- Always follow the Obsidian plugin development [guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines).
+- Follow the minimal code changes principle - only modify what is necessary for the feature or fix, unless SOLID and DRY principles dictate otherwise.
+- Commit messages should be precise and detailed, stating what changed and why. The repo uses conventional-commit titles, e.g. `fix(caldav): …`, `feat(ui): …`, `docs(calendar): …`.
+- Documentation must be synchronized in the same PR: `docs/architecture/` for implementation truth and `docs/user/` for the user guide.


### PR DESCRIPTION
## Description

Fixes #375. The Copilot instructions file is auto-loaded as repo context by AI coding assistants, so its inaccuracies get amplified into contributor PRs rather than just sitting unread. It had drifted far enough that following it produced broken commands and references to deleted directories.

Every correction below was verified against `main` @ `c19bfa6`. Every file path referenced in the new version was checked to exist.

| It said | Reality |
|---|---|
| `npm install`, `npm run …` throughout | `preinstall` runs `npx only-allow pnpm`, so `npm install` hard-fails. All commands switched to `pnpm`, with a note at the top. |
| `src/calendars/`, `FullNoteCalendar.ts`, `DailyNoteCalendar.ts` | Removed in `ea81705`. It's `src/providers/` now, with the contract in `src/providers/Provider.ts`. |
| `npm run fix-lint` | No such script. It's `lint:fix`. |
| `lint` = Prettier | `lint` is ESLint (a TypeScript pass and a CSS pass). Prettier is `format` / `format:check`. |
| "154 tests" | 89 suites, 894 tests, 43 snapshots. |
| Husky = "pre-commit formatting checks" | `.husky/pre-commit` runs `compile`, so a type error blocks the commit. |
| "`npm run build`: 0.5 seconds" and similar | False precision, and stale. Replaced with rounded figures explicitly labelled as machine-dependent. |
| "use `test-update` to fix" failing snapshots | CI already runs `test-update`, so snapshot drift can never fail CI. Reframed as a warning, since the old advice tells contributors to paper over real failures. |
| "Copy `manifest.json` to plugin build directory" | `esbuild.config.mjs` creates the dev vault directory and copies `manifest-beta.json` in as `manifest.json`. |

I also filled in things a contributor gets wrong without them: the `EventEnhancer` normalization chokepoint, the 13 registered providers, the three-timezone model, the skip-and-override recurrence behavior, the i18n and test-integrity house rules, and the `pnpm run ra` pre-PR gate.

The `react` → `preact/compat` build alias is now stated too, since the old text described the UI as React and that misleads anyone debugging bundle or runtime behavior.

**One thing I deliberately left alone:** the file states its architecture, key-file list, and testing notes twice, in two separate sections. I corrected both copies consistently rather than consolidating, to keep this diff reviewable and scoped to accuracy. Happy to follow up with a structural pass if you want one.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation — Related Issue #375
- [ ] Chore / maintenance

## Code Quality Checklist (MANDATORY)

- **SOLID, DRY**:
  - [x] N/A — documentation only, no code changes.
- **Internationalization (i18n)**:
  - [x] N/A — no user-facing strings; this file is contributor-facing.
- **Documentation Sync**:
  - [x] N/A for `docs/architecture/` and `docs/user/` — this PR changes only `.github/copilot-instructions.md`, which documents no user or runtime behavior. The architecture facts I added were taken *from* `docs/architecture/`, not added to it.
  - [x] Adhered to compact, table-based formatting where it helped.
- **Code Integrity & Type Safety**:
  - [ ] `pnpm run ra` — **not run, deliberately.** See note below.
- **Test Integrity**:
  - [x] No `.test` files touched.
  - [x] No new tests — documentation-only change.

### Note on `pnpm run ra`

I did not run it for this PR, and I'd rather say so than tick the box.

This branch changes exactly one Markdown file. `ra`'s Prettier step globs `src/**/*.ts*`, and my working tree currently has unrelated in-progress work in `src/`; running `ra` would have rewritten those files without touching anything in this diff. Compile, ESLint, and Jest never read `.github/*.md`.

What I ran instead, with this commit checked out into a clean isolated worktree:

```
Test Suites: 89 passed, 89 total
Tests:       1 todo, 894 passed, 895 total
Snapshots:   43 passed, 43 total
```

`pnpm run compile` exits 0 and `pnpm run lint` reports 0 errors (1 pre-existing warning in `AvailabilityService.ts`, untouched by this PR). Happy to run the full gate if you'd like it on the record.
