### PR TITLE
docs(contributing): fix setup instructions that cannot be followed as written

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To maintain a premium, state-of-the-art codebase, all contributions must strictl
 - **Don't Repeat Yourself (DRY)**: Re-use selectors, normalizers, and formatting helpers. Avoid copy-pasted layout rules or logic.
 
 ### 2. Internationalization (i18n)
-- **Zero Hardcoded UI Strings**: All user-facing strings, headers, placeholders, helper text, and tooltips **MUST** be defined in [en.json](file:///d:/Codes/plugin-full-calendar/src/features/i18n/locales/en.json) and rendered via `t('key.path')`. (Do not modify other locale JSONs directly; maintainers or localized workflows will sync them later).
+- **Zero Hardcoded UI Strings**: All user-facing strings, headers, placeholders, helper text, and tooltips **MUST** be defined in [`src/features/i18n/locales/en.json`](src/features/i18n/locales/en.json) and rendered via `t('key.path')`. (Do not modify other locale JSONs directly; maintainers or localized workflows will sync them later).
 
 ### 3. Documentation Sync & Formatting
 - **Technical & User Docs**: Synchronize architecture docs (under `docs/architecture/`) and user guides (under `docs/user/`) in the same PR. As the name suggests, one is the single source of implementation logic, while the other is for ease of access of users.
@@ -30,26 +30,12 @@ To maintain a premium, state-of-the-art codebase, all contributions must strictl
 
 ## 🚀 Getting Started
 
-### 1. Create the Obsidian Vault
+### 1. Build the Plugin
 
-To develop locally, set up your development vault and plugin directory:
+There is no manual directory setup. `esbuild.config.mjs` creates the development vault and the
+plugin folder inside it on the first build, then keeps them up to date on every rebuild.
 
-```bash
-mkdir -p .obsidian/.plugins/full-calendar-remastered/
-cp manifest.json .obsidian/.plugins/full-calendar-remastered/manifest.json
-````
-
-*Currently this folder already exists and will contain the minimified builds accordingly the latest tags (this is done to simplify the obsidian community plugin release process).
-
-> 💡 **Note:** Obsidian expects a CSS file named `styles.css`, but **esbuild** will output one named `main.css`.
-
----
-
-### 2. Build the Plugin
-
-You can build the plugin in two ways:
-
-* For development:
+* For development (watch mode, unminified, inline sourcemaps):
 
   ```bash
   pnpm run dev
@@ -61,15 +47,53 @@ You can build the plugin in two ways:
   pnpm run prod
   ```
 
-All build output will appear in the plugin directory created above.
+> ⚠️ **Use pnpm, not npm.** `preinstall` runs `npx only-allow pnpm`, so `npm install` fails.
+
+Each build writes to:
+
+```
+obsidian-dev-vault/.obsidian/plugins/full-calendar-remastered/
+├── main.js
+├── styles.css     # esbuild emits main.css; the build renames it for you
+└── manifest.json  # copied from manifest-beta.json
+```
+
+`obsidian-dev-vault/` is gitignored, so it will not exist until your first build. That is normal.
 
 ---
 
-### 3. Open the Vault in Obsidian
+### 2. Open the Vault in Obsidian
 
 1. Open **Obsidian**
 2. Go to **Vaults** → **Open Folder as Vault**
 3. Select the `obsidian-dev-vault` directory
+4. Turn off **Restricted Mode**, then enable **Full Calendar Remastered** in Community Plugins
+
+---
+
+### 3. Verify Your Changes
+
+While iterating (all read-only, none of them write to your tree):
+
+```bash
+pnpm run compile   # tsc --noEmit
+pnpm test          # jest
+pnpm run lint      # eslint, TypeScript pass + CSS pass
+```
+
+Before opening a PR, run the full gate. It must exit with **0 errors**:
+
+```bash
+pnpm run ra
+```
+
+> ⚠️ **`pnpm run ra` rewrites files.** It runs Prettier `--write` over `src/`, regenerates
+> `lint_report.txt` and `css_report.txt`, and syncs the non-English locale JSONs. Run it
+> deliberately just before committing, not while you are still investigating.
+
+> ⚠️ **Check snapshots locally.** CI runs `pnpm run test-update` (Jest with
+> `--updateSnapshot`), so snapshot drift cannot fail CI. Plain `pnpm test` is the only thing
+> that catches it.
 
 ---
 
@@ -77,7 +101,7 @@ All build output will appear in the plugin directory created above.
 
 > 💡 **Recommended:** Use the [Hot Reload plugin](https://github.com/pjeby/hot-reload) to make development smoother — it auto-reloads your plugin changes.
 
-> 📘 **Start Here:** To understand the architecture and get familiar with the codebase, read our [Architecture Guide](https://github.com/obsidian-full-calendar-remastered/plugin-full-calendar/blob/main/src/README.md).
+> 📘 **Start Here:** To understand the architecture and get familiar with the codebase, read our [Architecture Docs](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/architecture/system/). (`src/README.md` is the older version of this and is marked deprecated.)
 
 > 📱 **Android Testing** For testing Android devices use `adb` together with `chrome://inspect/#devices` to see the console on the PC.
 


### PR DESCRIPTION
## Description

Follow-up to my comment on #375. The same documentation drift affects `CONTRIBUTING.md`, and it matters more here because this is the doc new contributors actually onboard from.

The §1 setup snippet cannot be followed to a working result. What makes it costly is that it fails *silently*: `mkdir -p` cheerfully creates a stray directory at the repo root, `cp` succeeds, and the contributor only discovers something is wrong later when the build output never appears where they were told to look.

All corrections verified against `main` @ `c19bfa6`.

| Line | Was | Now |
|---|---|---|
| 38–39 | `mkdir -p .obsidian/.plugins/full-calendar-remastered/` | Removed. Path was wrong twice over — stray dot before `plugins`, and not under `obsidian-dev-vault/`. It also contradicted step 3 of the same section, which says to open `obsidian-dev-vault` as the vault. |
| 38–39 | Manual directory creation | Removed as unnecessary: `esbuild.config.mjs` creates `obsidian-dev-vault/.obsidian/plugins/full-calendar-remastered/` itself on every build. |
| 39 | `cp manifest.json …` | Removed. The build copies `manifest-beta.json` into the dev vault as `manifest.json`, overwriting whatever was placed there. |
| 40 | ` ```` ` closing a ` ``` ` block | Fixed. The mismatched fence broke rendering for the rest of the section. |
| 44 | "esbuild will output one named `main.css`" | Removed. The `rename-css-plugin` `onEnd` hook already renames it to `styles.css`, so the note implied manual work that doesn't exist. |
| 64 | "All build output will appear in the plugin directory created above" | Replaced with a tree of what the build actually writes, and where. |
| 80 | "Start Here" → `src/README.md` | Repointed to the published [architecture docs](https://obsidian-full-calendar-remastered.github.io/plugin-full-calendar/architecture/system/) (verified HTTP 200). `src/README.md` self-marks as deprecated and is badged v0.12.7 against a current 0.13.5. |
| 17 | `[en.json](file:///d:/Codes/plugin-full-calendar/…)` | Replaced with a repo-relative link. This was a `file://` path from a maintainer's local machine, so it resolved for nobody. |

I also added a short **Verify Your Changes** subsection. §4 of the standards already mandates `pnpm run ra`, but nothing in the guide said what to run while iterating, warned that `ra` rewrites source files and locale JSONs, or mentioned that CI runs `test-update` and therefore cannot fail on snapshot drift. That last one seemed worth stating explicitly, since green CI currently reads as stronger evidence than it is.

Kept the existing voice, emoji headers, and admonition style throughout.

Nothing outside `CONTRIBUTING.md` is touched.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation — follows from #375
- [ ] Chore / maintenance

## Code Quality Checklist (MANDATORY)

- **SOLID, DRY**:
  - [x] N/A — documentation only, no code changes.
- **Internationalization (i18n)**:
  - [x] N/A — contributor-facing doc, no user-facing strings.
- **Documentation Sync**:
  - [x] N/A for `docs/architecture/` and `docs/user/` — this PR documents the build and verification workflow, not user or runtime behavior.
  - [x] Adhered to the compact, table-based, admonition style.
- **Code Integrity & Type Safety**:
  - [ ] `pnpm run ra` — **not run, deliberately.** See note below.
- **Test Integrity**:
  - [x] No `.test` files touched.
  - [x] No new tests — documentation-only change.

### Note on `pnpm run ra`

Same as in #378, and I'd rather flag it than tick the box.

This branch changes one Markdown file. `ra`'s Prettier step globs `src/**/*.ts*`, and my working tree has unrelated in-progress work in `src/`; running `ra` would have rewritten those files while changing nothing in this diff. Compile, ESLint, and Jest never read `CONTRIBUTING.md`.

Verified instead with this commit checked out into a clean isolated worktree:

```
Test Suites: 89 passed, 89 total
Tests:       1 todo, 894 passed, 895 total
Snapshots:   43 passed, 43 total
```

`pnpm run compile` exits 0; `pnpm run lint` reports 0 errors and 1 pre-existing warning in `AvailabilityService.ts` that this PR does not touch. I also confirmed the instructions in the new version by following them from scratch: `pnpm run dev` creates the dev vault and populates it with `main.js`, `styles.css`, and `manifest.json` with no manual setup.
