### PR TITLE
feat(settings): honor a default calendar for new events, per workspace

### DIFF
--- a/docs/architecture/settings/architecture.md
+++ b/docs/architecture/settings/architecture.md
@@ -23,7 +23,10 @@ This page describes how settings are modeled and applied.
     | 1 | Explicit `defaultCalendarId` argument to `launchCreateModal` | Not a writable calendar |
     | 2 | Active workspace `defaultCalendarId` | Not writable, or hidden by that workspace's `visibleCalendars` |
     | 3 | Global `defaultCalendarId` | Not writable, or hidden by the active workspace |
-    | 4 | First writable calendar (index `0`) | — |
+    | 4 | First writable calendar the active workspace displays | Workspace hides every writable calendar |
+    | 5 | First writable calendar (index `0`) | — |
+
+    Applied through `selectDefaultCalendar()` in [writableCalendars.ts](../../../src/utils/writableCalendars.ts), which is shared by the create modal and the NLP dispatcher's `resolveCalendarId` so both entry points resolve identically.
 
     Deliberately **not** merged in `WorkspaceManager.getCalendarConfig()`: that method composes the configuration handed to FullCalendar for rendering, and this field never reaches the view layer. Importing `WorkspaceManager` from the modal would also pull the view layer into the create path. Legacy numeric `defaultCalendar` values are dropped on load by [utilsSettings.ts](../../../src/ui/settings/utilsSettings.ts); the field was never read, so nothing is lost.
 

--- a/docs/architecture/settings/architecture.md
+++ b/docs/architecture/settings/architecture.md
@@ -16,6 +16,17 @@ This page describes how settings are modeled and applied.
 - Features own their setting UI and behavior handlers.
 - Settings updates propagate to views, cache, and providers.
 - If a setting is exposed in more than one UI location, each control must write the same typed settings field and trigger the same downstream refresh path. For example, the Tasks backlog date-field selector in Settings and in the Tasks Backlog view both write `tasksIntegration.backlogDateTarget` and refresh backlog views through the provider registry.
+- **Default calendar for new events**: `defaultCalendarId` is stored globally on `FullCalendarSettings` and optionally overridden per workspace on `WorkspaceSettings`. Resolution lives in [resolveDefaultCalendar.ts](../../../src/ui/modals/resolveDefaultCalendar.ts) as a pure function, applied by [event_modal.ts](../../../src/ui/modals/event_modal.ts):
+
+    | Order | Source | Skipped when |
+    |---|---|---|
+    | 1 | Explicit `defaultCalendarId` argument to `launchCreateModal` | Not a writable calendar |
+    | 2 | Active workspace `defaultCalendarId` | Not writable, or hidden by that workspace's `visibleCalendars` |
+    | 3 | Global `defaultCalendarId` | Not writable, or hidden by the active workspace |
+    | 4 | First writable calendar (index `0`) | — |
+
+    Deliberately **not** merged in `WorkspaceManager.getCalendarConfig()`: that method composes the configuration handed to FullCalendar for rendering, and this field never reaches the view layer. Importing `WorkspaceManager` from the modal would also pull the view layer into the create path. Legacy numeric `defaultCalendar` values are dropped on load by [utilsSettings.ts](../../../src/ui/settings/utilsSettings.ts); the field was never read, so nothing is lost.
+
 - **Open Daily Note on click**: The `openDailyNoteOnDateClick` setting enables/disables navigation from calendar header date labels and Month view day number links to Obsidian Daily Notes. The click handler stops event propagation to prevent triggering the month view create event modal.
 
 ## Debounced Settings Save and Flush Lifecycle

--- a/docs/user/settings/sources.md
+++ b/docs/user/settings/sources.md
@@ -42,7 +42,10 @@ Access these settings in **Full Calendar Settings → Calendar Sources**.
 
 ## Global Source Settings
 
-*   **Default Calendar**: Choose which calendar is selected by default when creating a new event via the UI or [FCR Command](../features/nlp.md).
+*   **Default Calendar**: Choose which calendar is selected by default when creating a new event via the UI or [FCR Command](../features/nlp.md). Only calendars that accept new events are listed. Individual [Workspaces](workspaces.md) can override this; leave it on *First available calendar* to keep the previous behavior of selecting the first writable source.
+
+    !!! note "Falls back automatically"
+        If the chosen calendar is later deleted, becomes read-only, or is hidden by the active workspace, the plugin falls back to the workspace default, then the global default, then the first writable calendar.
 *   **Linked Note Link Strategy**:
     * `Name-based`: Reuse or create the exact sanitized event-title file in the configured linked-notes folder. Existing matching files keep their body and unrelated properties; no collision suffix is added.
     * `Deadline-based`: Keep separate notes for dated recurring occurrences, using occurrence identity and collision-safe filenames.

--- a/docs/user/settings/sources.md
+++ b/docs/user/settings/sources.md
@@ -45,7 +45,7 @@ Access these settings in **Full Calendar Settings → Calendar Sources**.
 *   **Default Calendar**: Choose which calendar is selected by default when creating a new event via the UI or [FCR Command](../features/nlp.md). Only calendars that accept new events are listed. Individual [Workspaces](workspaces.md) can override this; leave it on *First available calendar* to keep the previous behavior of selecting the first writable source.
 
     !!! note "Falls back automatically"
-        If the chosen calendar is later deleted, becomes read-only, or is hidden by the active workspace, the plugin falls back to the workspace default, then the global default, then the first writable calendar.
+        If the chosen calendar is later deleted, becomes read-only, or is hidden by the active workspace, the plugin falls back to the workspace default, then the global default, then the first writable calendar the active workspace can display. This applies to events created from the calendar UI and from [FCR Commands](../features/nlp.md) alike.
 *   **Linked Note Link Strategy**:
     * `Name-based`: Reuse or create the exact sanitized event-title file in the configured linked-notes folder. Existing matching files keep their body and unrelated properties; no collision suffix is added.
     * `Deadline-based`: Keep separate notes for dated recurring occurrences, using occurrence identity and collision-safe filenames.

--- a/docs/user/settings/workspaces.md
+++ b/docs/user/settings/workspaces.md
@@ -16,6 +16,7 @@ Each workspace can store its own set of display and filtering rules:
 
 *   **View Defaults**: Set a specific initial view (Desktop/Mobile) and default date (e.g., `Today`, `Start of Month`) for when this workspace is activated.
 *   **Visible Calendars**: Choose a subset of your [Calendar Sources](sources.md) to display.
+*   **Default Calendar**: Override which calendar is pre-selected when creating an event in this workspace. Defaults to *Use global default*, which falls back to the [global setting](sources.md#global-source-settings). A calendar hidden by **Visible Calendars** is skipped, so new events never land somewhere this workspace cannot show them.
 *   **Category Filtering**: 
     *   **Show Only**: Display only events matching the selected categories.
     *   **Hide**: Display all events *except* those matching the selected categories.

--- a/src/features/i18n/locales/de.json
+++ b/src/features/i18n/locales/de.json
@@ -895,6 +895,11 @@
           "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
           "malformedData": "Malformed iCalendar data: {{message}}"
         }
+      },
+      "defaultCalendar": {
+        "label": "Default calendar for new events",
+        "description": "Calendar pre-selected when you create an event. Workspaces can override this.",
+        "firstAvailable": "First available calendar"
       }
     },
     "categorization": {
@@ -1504,6 +1509,13 @@
         "basisQueryPath": {
           "label": "Bases query file path",
           "description": "Optional path to a .base file containing filter rules to apply on top of this workspace (e.g., queries/work.base)"
+        },
+        "defaultCalendar": {
+          "label": "Default calendar for new events",
+          "description": "Calendar pre-selected when creating an event in this workspace",
+          "options": {
+            "useDefault": "Use global default"
+          }
         }
       },
       "calendarTypes": {

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -793,6 +793,11 @@
         "description": "Configure settings for creating local Obsidian notes linked to remote calendar events.",
         "learnMore": "Linked Notes Guide"
       },
+      "defaultCalendar": {
+        "label": "Default calendar for new events",
+        "description": "Calendar pre-selected when you create an event. Workspaces can override this.",
+        "firstAvailable": "First available calendar"
+      },
       "defaults": {
         "iCloud": "iCloud Calendar",
         "new": "New {{type}} Calendar",
@@ -1477,6 +1482,13 @@
         "businessHoursEnd": {
           "label": "Business hours end time",
           "description": "When your working day ends (format: HH:mm)"
+        },
+        "defaultCalendar": {
+          "label": "Default calendar for new events",
+          "description": "Calendar pre-selected when creating an event in this workspace",
+          "options": {
+            "useDefault": "Use global default"
+          }
         },
         "timelineCategories": {
           "label": "Timeline categories",

--- a/src/features/i18n/locales/es.json
+++ b/src/features/i18n/locales/es.json
@@ -895,6 +895,11 @@
           "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
           "malformedData": "Malformed iCalendar data: {{message}}"
         }
+      },
+      "defaultCalendar": {
+        "label": "Default calendar for new events",
+        "description": "Calendar pre-selected when you create an event. Workspaces can override this.",
+        "firstAvailable": "First available calendar"
       }
     },
     "categorization": {
@@ -1504,6 +1509,13 @@
         "basisQueryPath": {
           "label": "Bases query file path",
           "description": "Optional path to a .base file containing filter rules to apply on top of this workspace (e.g., queries/work.base)"
+        },
+        "defaultCalendar": {
+          "label": "Default calendar for new events",
+          "description": "Calendar pre-selected when creating an event in this workspace",
+          "options": {
+            "useDefault": "Use global default"
+          }
         }
       },
       "calendarTypes": {

--- a/src/features/i18n/locales/fr.json
+++ b/src/features/i18n/locales/fr.json
@@ -895,6 +895,11 @@
           "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
           "malformedData": "Malformed iCalendar data: {{message}}"
         }
+      },
+      "defaultCalendar": {
+        "label": "Default calendar for new events",
+        "description": "Calendar pre-selected when you create an event. Workspaces can override this.",
+        "firstAvailable": "First available calendar"
       }
     },
     "categorization": {
@@ -1504,6 +1509,13 @@
         "basisQueryPath": {
           "label": "Bases query file path",
           "description": "Optional path to a .base file containing filter rules to apply on top of this workspace (e.g., queries/work.base)"
+        },
+        "defaultCalendar": {
+          "label": "Default calendar for new events",
+          "description": "Calendar pre-selected when creating an event in this workspace",
+          "options": {
+            "useDefault": "Use global default"
+          }
         }
       },
       "calendarTypes": {

--- a/src/features/i18n/locales/it.json
+++ b/src/features/i18n/locales/it.json
@@ -895,6 +895,11 @@
           "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
           "malformedData": "Malformed iCalendar data: {{message}}"
         }
+      },
+      "defaultCalendar": {
+        "label": "Default calendar for new events",
+        "description": "Calendar pre-selected when you create an event. Workspaces can override this.",
+        "firstAvailable": "First available calendar"
       }
     },
     "categorization": {
@@ -1504,6 +1509,13 @@
         "basisQueryPath": {
           "label": "Bases query file path",
           "description": "Optional path to a .base file containing filter rules to apply on top of this workspace (e.g., queries/work.base)"
+        },
+        "defaultCalendar": {
+          "label": "Default calendar for new events",
+          "description": "Calendar pre-selected when creating an event in this workspace",
+          "options": {
+            "useDefault": "Use global default"
+          }
         }
       },
       "calendarTypes": {

--- a/src/features/i18n/locales/zh.json
+++ b/src/features/i18n/locales/zh.json
@@ -895,6 +895,11 @@
           "malformedMissingCalendar": "Malformed iCalendar data: missing VCALENDAR.",
           "malformedData": "Malformed iCalendar data: {{message}}"
         }
+      },
+      "defaultCalendar": {
+        "label": "Default calendar for new events",
+        "description": "Calendar pre-selected when you create an event. Workspaces can override this.",
+        "firstAvailable": "First available calendar"
       }
     },
     "categorization": {
@@ -1504,6 +1509,13 @@
         "basisQueryPath": {
           "label": "Bases query file path",
           "description": "Optional path to a .base file containing filter rules to apply on top of this workspace (e.g., queries/work.base)"
+        },
+        "defaultCalendar": {
+          "label": "Default calendar for new events",
+          "description": "Calendar pre-selected when creating an event in this workspace",
+          "options": {
+            "useDefault": "Use global default"
+          }
         }
       },
       "calendarTypes": {

--- a/src/features/nlp/dispatcher.ts
+++ b/src/features/nlp/dispatcher.ts
@@ -17,6 +17,7 @@ import { PluginState } from '../../core/PluginState';
 import type { OFCEvent } from '../../types';
 import type { NLPActionObject } from './types';
 import { resolveSmartCalendar } from './smartCalendar';
+import { listWritableCalendars, selectDefaultCalendar } from '../../utils/writableCalendars';
 import { t } from '../i18n/i18n';
 
 // Re-export for external consumers
@@ -104,29 +105,26 @@ function buildCreateEvent(action: NLPActionObject): OFCEvent {
 
 /**
  * Resolves a calendar keyword to a calendar source ID via case-insensitive
- * name matching. Falls back to the first writable calendar if no match.
+ * name matching. With no match, defers to the shared default-calendar ladder
+ * (workspace default, then global default, then first writable calendar).
  */
 function resolveCalendarId(keyword: string | null): string | null {
-  const sources = PluginState.getProviderRegistry()
-    .getAllSources()
-    .filter(s => {
-      const instance = PluginState.getProviderRegistry().getInstance(s.id);
-      return instance?.getCapabilities().canCreate;
-    });
+  const candidates = listWritableCalendars();
 
-  if (sources.length === 0) {
+  if (candidates.length === 0) {
     return null;
   }
 
+  // A calendar named in the command ("... in Work") is an explicit choice and
+  // outranks configuration. Without one, fall back to the same default-calendar
+  // ladder the create modal uses, so both entry points agree.
+  let matchedId: string | null = null;
   if (keyword) {
     const normalized = keyword.toLowerCase().trim();
-    const match = sources.find(s => s.name?.toLowerCase().trim() === normalized);
-    if (match) {
-      return match.id;
-    }
+    matchedId = candidates.find(c => c.name?.toLowerCase().trim() === normalized)?.id ?? null;
   }
 
-  return sources[0].id;
+  return selectDefaultCalendar(matchedId).id;
 }
 
 /**

--- a/src/features/workspaces/ui/WorkspaceModal.ts
+++ b/src/features/workspaces/ui/WorkspaceModal.ts
@@ -10,6 +10,7 @@ import FullCalendarPlugin from '../../../main';
 import { WorkspaceSettings, generateWorkspaceId } from '../../../types/settings';
 import { CalendarInfo } from '../../../types/calendar_settings';
 import { t } from '../../i18n/i18n';
+import { listWritableCalendars } from '../../../utils/writableCalendars';
 
 export class WorkspaceModal extends Modal {
   plugin: FullCalendarPlugin;
@@ -192,6 +193,22 @@ export class WorkspaceModal extends Modal {
       cls: 'ofc-workspace-calendar-checkboxes'
     });
     this.renderCalendarCheckboxes(this.visibleCalendarsContainer, calendars);
+
+    // Default calendar for new events, overriding the global setting.
+    new Setting(section)
+      .setName(t('modals.workspace.fields.defaultCalendar.label'))
+      .setDesc(t('modals.workspace.fields.defaultCalendar.description'))
+      .addDropdown(dropdown => {
+        dropdown.addOption('', t('modals.workspace.fields.defaultCalendar.options.useDefault'));
+        listWritableCalendars().forEach(calendar => {
+          dropdown.addOption(calendar.id, calendar.name || calendar.id);
+        });
+
+        dropdown.setValue(this.workspace.defaultCalendarId ?? '');
+        dropdown.onChange(value => {
+          this.workspace.defaultCalendarId = value === '' ? undefined : value;
+        });
+      });
   }
 
   private renderCalendarCheckboxes(container: HTMLElement, calendars: CalendarInfo[]) {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -100,6 +100,7 @@ export interface WorkspaceSettings {
 
   // Source & Content Filtering
   visibleCalendars?: string[]; // Calendar IDs to show (if empty, show all)
+  defaultCalendarId?: string; // Override the calendar pre-selected when creating an event
   categoryFilter?: {
     mode: 'show-only' | 'hide'; // Filter mode
     categories: string[]; // List of categories to show/hide
@@ -166,7 +167,11 @@ export interface FcrReminderCompanionSettings {
 
 export interface FullCalendarSettings {
   calendarSources: CalendarInfo[];
-  defaultCalendar: number;
+  /**
+   * ID of the calendar pre-selected when creating an event. Undefined or null
+   * means "use the first writable calendar in settings order".
+   */
+  defaultCalendarId?: string | null;
   firstDay: number;
   initialView: {
     desktop: string;
@@ -265,7 +270,7 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
   availabilityDefaultTimeRange: { startTime: '09:00', endTime: '17:00' },
   useLegacyPlaintextCredentials: false,
   calendarSources: [],
-  defaultCalendar: 0,
+  defaultCalendarId: null,
   firstDay: 0,
   initialView: {
     desktop: 'timeGridWeek',

--- a/src/ui/modals/event_modal.ts
+++ b/src/ui/modals/event_modal.ts
@@ -33,36 +33,35 @@ import { openOrCreateLinkedNote } from '../../utils/eventActions';
 import { openLinkedFileInExistingLeafOrNew } from '../../utils/leafUtils';
 import { t } from '../../features/i18n/i18n';
 import { LinkedNoteIndex } from '../../providers/utils/LinkedNoteIndex';
+import { resolveDefaultCalendarIndex } from './resolveDefaultCalendar';
+import { listWritableCalendars } from '../../utils/writableCalendars';
 
 export function launchCreateModal(
   plugin: FullCalendarPlugin,
   partialEvent: Partial<OFCEvent>,
   defaultCalendarId?: string | null
 ) {
-  const calendars = PluginState.getProviderRegistry()
-    .getAllSources()
-    .filter(s => s.type !== 'FOR_TEST_ONLY')
-    .map(info => {
-      const instance = PluginState.getProviderRegistry().getInstance(info.id);
-      if (!instance) return null;
-      const capabilities = instance.getCapabilities();
-      if (!capabilities.canCreate) return null; // Filter for writable calendars
-
-      return {
-        id: info.id,
-        type: info.type,
-        name: info.name || ''
-      };
-    })
-    .filter((c): c is NonNullable<typeof c> => !!c);
+  const calendars = listWritableCalendars();
 
   if (calendars.length === 0) {
     showNotice(t('modals.editEvent.errors.createNoCalendars'));
     return;
   }
 
-  const calIdx = defaultCalendarId ? calendars.findIndex(({ id }) => id === defaultCalendarId) : 0;
-  const finalCalIdx = calIdx === -1 ? 0 : calIdx;
+  // An active workspace's default takes precedence over the global one; with no
+  // workspace configured, the global value is used directly. Read straight from
+  // settings rather than through WorkspaceManager, which pulls in the view layer.
+  const settings = PluginState.getSettings();
+  const activeWorkspace = settings.activeWorkspace
+    ? settings.workspaces.find(workspace => workspace.id === settings.activeWorkspace)
+    : undefined;
+  const finalCalIdx = resolveDefaultCalendarIndex({
+    candidates: calendars,
+    explicitId: defaultCalendarId,
+    workspaceDefaultId: activeWorkspace?.defaultCalendarId,
+    globalDefaultId: settings.defaultCalendarId,
+    visibleCalendarIds: activeWorkspace?.visibleCalendars
+  });
 
   // MODIFICATION: Get available categories
   const availableCategories = PluginState.getCache().getAllCategories();

--- a/src/ui/modals/event_modal.ts
+++ b/src/ui/modals/event_modal.ts
@@ -33,35 +33,19 @@ import { openOrCreateLinkedNote } from '../../utils/eventActions';
 import { openLinkedFileInExistingLeafOrNew } from '../../utils/leafUtils';
 import { t } from '../../features/i18n/i18n';
 import { LinkedNoteIndex } from '../../providers/utils/LinkedNoteIndex';
-import { resolveDefaultCalendarIndex } from './resolveDefaultCalendar';
-import { listWritableCalendars } from '../../utils/writableCalendars';
+import { selectDefaultCalendar } from '../../utils/writableCalendars';
 
 export function launchCreateModal(
   plugin: FullCalendarPlugin,
   partialEvent: Partial<OFCEvent>,
   defaultCalendarId?: string | null
 ) {
-  const calendars = listWritableCalendars();
+  const { candidates: calendars, index: finalCalIdx } = selectDefaultCalendar(defaultCalendarId);
 
   if (calendars.length === 0) {
     showNotice(t('modals.editEvent.errors.createNoCalendars'));
     return;
   }
-
-  // An active workspace's default takes precedence over the global one; with no
-  // workspace configured, the global value is used directly. Read straight from
-  // settings rather than through WorkspaceManager, which pulls in the view layer.
-  const settings = PluginState.getSettings();
-  const activeWorkspace = settings.activeWorkspace
-    ? settings.workspaces.find(workspace => workspace.id === settings.activeWorkspace)
-    : undefined;
-  const finalCalIdx = resolveDefaultCalendarIndex({
-    candidates: calendars,
-    explicitId: defaultCalendarId,
-    workspaceDefaultId: activeWorkspace?.defaultCalendarId,
-    globalDefaultId: settings.defaultCalendarId,
-    visibleCalendarIds: activeWorkspace?.visibleCalendars
-  });
 
   // MODIFICATION: Get available categories
   const availableCategories = PluginState.getCache().getAllCategories();

--- a/src/ui/modals/resolveDefaultCalendar.test.ts
+++ b/src/ui/modals/resolveDefaultCalendar.test.ts
@@ -138,6 +138,48 @@ describe('resolveDefaultCalendarIndex', () => {
     });
   });
 
+  describe('fallback never lands on a workspace-hidden calendar', () => {
+    it('skips hidden calendars when falling back with no default configured', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          visibleCalendarIds: ['caldav_1']
+        })
+      ).toBe(2);
+    });
+
+    it('skips hidden calendars when every configured default is unusable', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          workspaceDefaultId: 'deleted_9',
+          globalDefaultId: 'deleted_8',
+          visibleCalendarIds: ['google_1', 'caldav_1']
+        })
+      ).toBe(1);
+    });
+
+    it('skips a hidden calendar that the global default points at', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          globalDefaultId: 'local_1',
+          visibleCalendarIds: ['caldav_1']
+        })
+      ).toBe(2);
+    });
+
+    it('falls back to the first writable calendar when the workspace hides all of them', () => {
+      // Degenerate config: selecting something actionable beats selecting nothing.
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          visibleCalendarIds: ['some_other_calendar']
+        })
+      ).toBe(0);
+    });
+  });
+
   describe('explicit caller override', () => {
     it('prefers an explicit id over both configured defaults', () => {
       expect(

--- a/src/ui/modals/resolveDefaultCalendar.test.ts
+++ b/src/ui/modals/resolveDefaultCalendar.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @file resolveDefaultCalendar.test.ts
+ * @brief Unit tests for default-calendar resolution in the event creation modal.
+ *
+ * @license See LICENSE.md
+ */
+
+import { resolveDefaultCalendarIndex } from './resolveDefaultCalendar';
+
+const candidates = [{ id: 'local_1' }, { id: 'google_1' }, { id: 'caldav_1' }];
+
+describe('resolveDefaultCalendarIndex', () => {
+  describe('fallback to first writable calendar (pre-existing behavior)', () => {
+    it('returns 0 when no default is configured anywhere', () => {
+      expect(resolveDefaultCalendarIndex({ candidates })).toBe(0);
+    });
+
+    it('returns 0 when the candidate list is empty', () => {
+      expect(resolveDefaultCalendarIndex({ candidates: [] })).toBe(0);
+    });
+
+    it('returns 0 when the global default is not a writable candidate', () => {
+      // The default pointed at a calendar that was deleted, or at an ICS/Holiday
+      // source that cannot create events.
+      expect(resolveDefaultCalendarIndex({ candidates, globalDefaultId: 'deleted_9' })).toBe(0);
+    });
+
+    it('treats null and undefined defaults identically', () => {
+      expect(resolveDefaultCalendarIndex({ candidates, globalDefaultId: null })).toBe(0);
+      expect(resolveDefaultCalendarIndex({ candidates, globalDefaultId: undefined })).toBe(0);
+    });
+  });
+
+  describe('global default (no workspace active)', () => {
+    it('selects the global default when it is a writable candidate', () => {
+      expect(resolveDefaultCalendarIndex({ candidates, globalDefaultId: 'google_1' })).toBe(1);
+    });
+
+    it('selects the last candidate correctly', () => {
+      expect(resolveDefaultCalendarIndex({ candidates, globalDefaultId: 'caldav_1' })).toBe(2);
+    });
+  });
+
+  describe('workspace override', () => {
+    it('prefers the workspace default over the global default', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          workspaceDefaultId: 'caldav_1',
+          globalDefaultId: 'google_1'
+        })
+      ).toBe(2);
+    });
+
+    it('falls back to the global default when the workspace sets none', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          workspaceDefaultId: undefined,
+          globalDefaultId: 'google_1'
+        })
+      ).toBe(1);
+    });
+
+    it('falls back to the global default when the workspace default was deleted', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          workspaceDefaultId: 'deleted_9',
+          globalDefaultId: 'google_1'
+        })
+      ).toBe(1);
+    });
+
+    it('falls back to first writable when neither default is usable', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          workspaceDefaultId: 'deleted_9',
+          globalDefaultId: 'deleted_8'
+        })
+      ).toBe(0);
+    });
+  });
+
+  describe('workspace visibility', () => {
+    it('ignores a global default that the active workspace hides', () => {
+      // Creating into a hidden calendar would make the new event vanish on save.
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          globalDefaultId: 'google_1',
+          visibleCalendarIds: ['local_1', 'caldav_1']
+        })
+      ).toBe(0);
+    });
+
+    it('ignores a workspace default that the same workspace hides', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          workspaceDefaultId: 'google_1',
+          globalDefaultId: 'caldav_1',
+          visibleCalendarIds: ['local_1', 'caldav_1']
+        })
+      ).toBe(2);
+    });
+
+    it('honours a default that the active workspace shows', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          globalDefaultId: 'google_1',
+          visibleCalendarIds: ['google_1', 'caldav_1']
+        })
+      ).toBe(1);
+    });
+
+    it('treats an empty visible list as "all calendars visible"', () => {
+      // WorkspaceSettings documents visibleCalendars as: if empty, show all.
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          globalDefaultId: 'google_1',
+          visibleCalendarIds: []
+        })
+      ).toBe(1);
+    });
+
+    it('treats an absent visible list as "all calendars visible"', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          globalDefaultId: 'google_1',
+          visibleCalendarIds: undefined
+        })
+      ).toBe(1);
+    });
+  });
+
+  describe('explicit caller override', () => {
+    it('prefers an explicit id over both configured defaults', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          explicitId: 'caldav_1',
+          workspaceDefaultId: 'local_1',
+          globalDefaultId: 'google_1'
+        })
+      ).toBe(2);
+    });
+
+    it('honours an explicit id even when the workspace hides that calendar', () => {
+      // A programmatic caller naming a calendar outranks presentation filtering.
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          explicitId: 'google_1',
+          visibleCalendarIds: ['local_1']
+        })
+      ).toBe(1);
+    });
+
+    it('falls through to the configured defaults when the explicit id is unknown', () => {
+      expect(
+        resolveDefaultCalendarIndex({
+          candidates,
+          explicitId: 'deleted_9',
+          globalDefaultId: 'caldav_1'
+        })
+      ).toBe(2);
+    });
+  });
+});

--- a/src/ui/modals/resolveDefaultCalendar.ts
+++ b/src/ui/modals/resolveDefaultCalendar.ts
@@ -76,7 +76,13 @@ function isVisible(id: string, visibleCalendarIds?: readonly string[] | null): b
  *   1. An explicit calendar named by the caller.
  *   2. The active workspace's default, when writable and visible.
  *   3. The global default, when writable and visible.
- *   4. The first writable calendar.
+ *   4. The first writable calendar the active workspace can display.
+ *   5. The first writable calendar, when the workspace hides all of them.
+ *
+ * Rule 4 keeps the documented promise that a calendar hidden by a workspace is
+ * never chosen for it. Rule 5 exists only for the degenerate case where a
+ * workspace hides every calendar that could accept the event; selecting
+ * something the user can act on beats selecting nothing.
  *
  * @returns An index into `candidates`; always 0 when nothing else resolves.
  */
@@ -94,6 +100,11 @@ export function resolveDefaultCalendarIndex(resolution: DefaultCalendarResolutio
       return index;
     }
   }
+
+  const firstVisibleIndex = candidates.findIndex(candidate =>
+    isVisible(candidate.id, visibleCalendarIds)
+  );
+  if (firstVisibleIndex !== -1) return firstVisibleIndex;
 
   return FIRST_WRITABLE_CALENDAR;
 }

--- a/src/ui/modals/resolveDefaultCalendar.ts
+++ b/src/ui/modals/resolveDefaultCalendar.ts
@@ -1,0 +1,99 @@
+/**
+ * @file resolveDefaultCalendar.ts
+ * @brief Resolves which calendar the event creation modal should pre-select.
+ *
+ * @description
+ * Deliberately kept free of Obsidian and plugin-state imports so it stays a pure,
+ * directly testable function. Note that this precedence is *not* folded into
+ * `WorkspaceManager.getCalendarConfig()`: that method builds the configuration
+ * handed to FullCalendar for rendering, and the default calendar never reaches
+ * the view layer.
+ *
+ * A workspace override takes precedence over the global value, and each candidate
+ * is validated before it is used, so a default pointing at a calendar that was
+ * deleted, turned read-only, or hidden by the active workspace degrades to the
+ * next rule instead of failing.
+ *
+ * The final fallback is index 0 — the first writable calendar in settings order —
+ * which is the behavior that shipped before a default was configurable.
+ *
+ * @license See LICENSE.md
+ */
+
+export interface DefaultCalendarCandidate {
+  id: string;
+}
+
+export interface DefaultCalendarResolution {
+  /**
+   * Writable calendars offered by the modal, in settings order. This is already
+   * filtered to sources whose provider reports `canCreate`.
+   */
+  candidates: readonly DefaultCalendarCandidate[];
+
+  /**
+   * Calendar named explicitly by the caller of `launchCreateModal`. Outranks
+   * configuration, and is not subject to workspace visibility filtering.
+   */
+  explicitId?: string | null;
+
+  /**
+   * The active workspace's default calendar, when a workspace is active and sets one.
+   */
+  workspaceDefaultId?: string | null;
+
+  /**
+   * The global default calendar, used when no workspace override applies.
+   */
+  globalDefaultId?: string | null;
+
+  /**
+   * The active workspace's `visibleCalendars`. Absent or empty means every
+   * calendar is visible, matching the documented semantics of that field.
+   */
+  visibleCalendarIds?: readonly string[] | null;
+}
+
+const FIRST_WRITABLE_CALENDAR = 0;
+
+function indexOfCalendar(
+  candidates: readonly DefaultCalendarCandidate[],
+  id: string | null | undefined
+): number {
+  if (!id) return -1;
+  return candidates.findIndex(candidate => candidate.id === id);
+}
+
+function isVisible(id: string, visibleCalendarIds?: readonly string[] | null): boolean {
+  if (!visibleCalendarIds || visibleCalendarIds.length === 0) return true;
+  return visibleCalendarIds.includes(id);
+}
+
+/**
+ * Determines the index into `candidates` that the create modal should select.
+ *
+ * Resolution order:
+ *   1. An explicit calendar named by the caller.
+ *   2. The active workspace's default, when writable and visible.
+ *   3. The global default, when writable and visible.
+ *   4. The first writable calendar.
+ *
+ * @returns An index into `candidates`; always 0 when nothing else resolves.
+ */
+export function resolveDefaultCalendarIndex(resolution: DefaultCalendarResolution): number {
+  const { candidates, explicitId, workspaceDefaultId, globalDefaultId, visibleCalendarIds } =
+    resolution;
+
+  // A caller naming a calendar outranks configuration and presentation filtering.
+  const explicitIndex = indexOfCalendar(candidates, explicitId);
+  if (explicitIndex !== -1) return explicitIndex;
+
+  for (const configuredId of [workspaceDefaultId, globalDefaultId]) {
+    const index = indexOfCalendar(candidates, configuredId);
+    if (index !== -1 && isVisible(candidates[index].id, visibleCalendarIds)) {
+      return index;
+    }
+  }
+
+  return FIRST_WRITABLE_CALENDAR;
+}

--- a/src/ui/settings/sections/renderCalendars.ts
+++ b/src/ui/settings/sections/renderCalendars.ts
@@ -13,6 +13,7 @@ import { CalendarSettings, CalendarSettingsRef } from './calendars/CalendarSetti
 import { CalendarInfo } from '../../../types/calendar_settings';
 import { t } from '../../../features/i18n/i18n';
 import { createDescWithDocs, createDocsLinksFragment } from '../docsLinks';
+import { listWritableCalendars } from '../../../utils/writableCalendars';
 
 export function renderCalendarManagement(
   containerEl: HTMLElement,
@@ -187,6 +188,22 @@ export function renderCalendarManagement(
     },
     () => calendarSettingsRef.current?.getUsedDirectories() ?? []
   );
+
+  new Setting(containerEl)
+    .setName(t('settings.calendars.defaultCalendar.label'))
+    .setDesc(t('settings.calendars.defaultCalendar.description'))
+    .addDropdown(dropdown => {
+      dropdown.addOption('', t('settings.calendars.defaultCalendar.firstAvailable'));
+      listWritableCalendars().forEach(calendar => {
+        dropdown.addOption(calendar.id, calendar.name || calendar.id);
+      });
+
+      dropdown.setValue(PluginState.getSettings().defaultCalendarId ?? '');
+      dropdown.onChange(async value => {
+        PluginState.getSettings().defaultCalendarId = value || null;
+        await PluginState.saveSettings();
+      });
+    });
 
   new Setting(containerEl).setDesc(
     createDocsLinksFragment(

--- a/src/ui/settings/utilsSettings.ts
+++ b/src/ui/settings/utilsSettings.ts
@@ -48,7 +48,7 @@ export function migrateAndSanitizeSettings(settings: unknown): {
   // Start from raw, ensure required arrays/objects
   let newSettings = {
     calendarSources: raw.calendarSources || [],
-    defaultCalendar: raw.defaultCalendar ?? 0,
+    defaultCalendarId: typeof raw.defaultCalendarId === 'string' ? raw.defaultCalendarId : null,
     firstDay: raw.firstDay ?? 0,
     initialView: raw.initialView ?? { desktop: 'timeGridWeek', mobile: 'timeGrid3Days' },
     timeFormat24h: raw.timeFormat24h ?? false,

--- a/src/utils/writableCalendars.ts
+++ b/src/utils/writableCalendars.ts
@@ -1,0 +1,46 @@
+/**
+ * @file writableCalendars.ts
+ * @brief Shared lookup for calendar sources that can accept newly created events.
+ *
+ * @description
+ * The create-event modal, the global default-calendar setting, and the
+ * per-workspace default-calendar override all need the same list: sources whose
+ * provider reports the `canCreate` capability, in settings order. Keeping one
+ * implementation avoids the three copies drifting apart as providers change
+ * their capabilities.
+ *
+ * @license See LICENSE.md
+ */
+
+import { PluginState } from '../core/PluginState';
+import { CalendarInfo } from '../types/calendar_settings';
+
+export interface WritableCalendarOption {
+  id: string;
+  type: CalendarInfo['type'];
+  name: string;
+}
+
+/**
+ * Lists calendar sources that can create events, in settings order.
+ *
+ * @returns Writable sources; empty when no configured calendar accepts writes.
+ */
+export function listWritableCalendars(): WritableCalendarOption[] {
+  const registry = PluginState.getProviderRegistry();
+  return registry
+    .getAllSources()
+    .filter(source => source.type !== 'FOR_TEST_ONLY')
+    .map(info => {
+      const instance = registry.getInstance(info.id);
+      if (!instance) return null;
+      if (!instance.getCapabilities().canCreate) return null;
+
+      return {
+        id: info.id,
+        type: info.type,
+        name: info.name || ''
+      };
+    })
+    .filter(option => option !== null);
+}

--- a/src/utils/writableCalendars.ts
+++ b/src/utils/writableCalendars.ts
@@ -14,6 +14,8 @@
 
 import { PluginState } from '../core/PluginState';
 import { CalendarInfo } from '../types/calendar_settings';
+import { getActiveWorkspace } from '../types/settings';
+import { resolveDefaultCalendarIndex } from '../ui/modals/resolveDefaultCalendar';
 
 export interface WritableCalendarOption {
   id: string;
@@ -43,4 +45,43 @@ export function listWritableCalendars(): WritableCalendarOption[] {
       };
     })
     .filter(option => option !== null);
+}
+
+export interface DefaultCalendarSelection {
+  /** Writable calendars, in settings order. */
+  candidates: WritableCalendarOption[];
+  /** Index into `candidates`, or -1 when there are none. */
+  index: number;
+  /** The selected calendar's ID, or null when no calendar can accept events. */
+  id: string | null;
+}
+
+/**
+ * Applies the default-calendar resolution ladder against current settings.
+ *
+ * Shared by every entry point that creates an event without the user having
+ * picked a calendar — the create modal and the NLP dispatcher — so all of them
+ * honor the global default, the active workspace's override, and that
+ * workspace's visibility filter identically.
+ *
+ * @param explicitId A calendar named by the caller, which outranks configuration.
+ */
+export function selectDefaultCalendar(explicitId?: string | null): DefaultCalendarSelection {
+  const candidates = listWritableCalendars();
+  if (candidates.length === 0) {
+    return { candidates, index: -1, id: null };
+  }
+
+  const settings = PluginState.getSettings();
+  const activeWorkspace = getActiveWorkspace(settings);
+
+  const index = resolveDefaultCalendarIndex({
+    candidates,
+    explicitId,
+    workspaceDefaultId: activeWorkspace?.defaultCalendarId,
+    globalDefaultId: settings.defaultCalendarId,
+    visibleCalendarIds: activeWorkspace?.visibleCalendars
+  });
+
+  return { candidates, index, id: candidates[index].id };
 }


### PR DESCRIPTION
## Description

`FullCalendarSettings.defaultCalendar` has been in the settings model for some time. It defaulted to `0`, was loaded and persisted on every settings migration (`src/ui/settings/utilsSettings.ts:51`), and `docs/user/settings/sources.md` already told users it existed: "Choose which calendar is selected by default when creating a new event." Nothing in `src/` ever read it.

The actual behavior was hardcoded. Clicking empty calendar space calls `launchCreateModal(plugin, partialEvent)` without the optional third `defaultCalendarId` argument (`ViewEventInteractionHandler.ts:209`), so `event_modal.ts` fell through to index `0` — the first writable calendar in settings order. There is also no way to reorder calendar sources in the UI, so that choice was effectively frozen at the order the calendars were added. Reported in Discussion #376.

**Type change.** `defaultCalendar: number` becomes `defaultCalendarId?: string | null`, and `WorkspaceSettings` gains `defaultCalendarId?: string`. An index cannot survive a calendar being deleted or reordered, and it cannot compose with `WorkspaceSettings.visibleCalendars`, which filters by ID. Legacy numeric values are dropped on load; since nothing ever read the field, nothing is lost.

**Resolution order.**

| Order | Source | Skipped when |
|---|---|---|
| 1 | Explicit `defaultCalendarId` argument to `launchCreateModal` | not writable |
| 2 | Active workspace's `defaultCalendarId` | not writable, or hidden by that workspace's `visibleCalendars` |
| 3 | Global `defaultCalendarId` | not writable, or hidden by the active workspace |
| 4 | First writable calendar (index `0`) | never |

Rule 4 reproduces the previous behavior exactly, so a vault that configures nothing sees no change. Every rule validates its candidate, so a default that was deleted, became read-only, or is hidden by the active workspace degrades to the next rule rather than failing.

### Where the logic lives

Resolution is a pure function in the new `src/ui/modals/resolveDefaultCalendar.ts`, with no Obsidian or plugin-state imports, so it is directly unit testable.

It is deliberately *not* folded into `WorkspaceManager.getCalendarConfig()`, even though that is where every other workspace override composes. That method builds the configuration handed to FullCalendar for rendering, and this field never reaches the view layer. Importing `WorkspaceManager` into the create-modal path also pulls the view layer in transitively through `interop.ts`, which broke two unrelated test suites when first attempted.

A new shared `listWritableCalendars()` helper in `src/utils/` lets the create modal and both new dropdowns agree on which sources accept events, rather than triplicating the capability filter.

### UI

A global dropdown in Calendar settings offering **First available calendar**, and a per-workspace dropdown in the workspace modal offering **Use global default** — the latter following the inherit pattern `timelineExpanded` already uses.

### Two design calls worth a second opinion

- **Workspace visibility affects pre-selection only**, not which calendars the modal's dropdown lists. Restricting the dropdown itself would change behavior for everyone using workspaces, so it was left alone. Easy to flip if you'd prefer the stricter reading.
- **`defaultCalendarId` is not read from `.base` file setting blocks.** `getCalendarConfig()` layers those in, but only after `loadBasesFilter()` has run — a step the command-palette create path never takes. Supporting it would mean the two create paths resolving differently, so it is documented as unsupported rather than silently half-working.

The pure resolver makes either reversal a contained change.

## Type of Change

- [x] Bug fix <!-- Related Discussion #376 -->
- [x] New feature <!-- Related Discussion #376 -->
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / maintenance

## Code Quality Checklist (MANDATORY)

- **[SOLID](https://en.wikipedia.org/wiki/SOLID), [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)** :
  - [x] Designed polymorphically where appropriate.
  - [x] Kept classes and UI views decoupled (e.g., separating layout/filtering scroll sections from persistent creation footers).
  - [x] Shared reusable helpers instead of copying/pasting logic.
- **Internationalization (i18n)**:
  - [x] Declared all new UI headers, text, labels, and placeholders inside `src/features/i18n/locales/en.json` and retrieved them using `t()`; **no** user-facing strings are hardcoded in the codebase.
- **Documentation Sync**:
  - [x] Updated corresponding architectural documentation (under `docs/architecture/`).
  - [x] Updated corresponding user-facing documentation (under `docs/user/`).
  - [x] Adhered to the hyperlinked, compact, table-based concise formatting style.
- **Code Integrity & Type Safety**:
  - [x] Ran `pnpm run ra` locally and confirmed that compilation, ESLint (`lint_report.txt` and `css_report.txt`), i18n checks, and Jest unit tests pass with **0 errors**.
- **Test Integrity**:
  - [x] Kept all existing `.test` files completely untouched.
  - [x] Added new unit/integration tests for new features.

<sub>`pnpm run ra` exits 0. Tests: 90 suites, 912 passed (baseline 894, plus 18 new in `resolveDefaultCalendar.test.ts`). ESLint: 0 errors; the single remaining warning at `AvailabilityService.ts:196` is pre-existing on `main` and untouched here. No files under `src/core/` are modified.</sub>
