### PR TITLE
fix(journals): support the Journals 3.2 official API

### DIFF
--- a/__mocks__/obsidianJournalsApi.js
+++ b/__mocks__/obsidianJournalsApi.js
@@ -1,0 +1,7 @@
+/* global module */
+
+module.exports = {
+  getJournalsApi(app) {
+    return app?.plugins?.plugins?.journals?.api ?? null;
+  }
+};

--- a/docs/architecture/calendars/provider-implementations.md
+++ b/docs/architecture/calendars/provider-implementations.md
@@ -40,9 +40,13 @@ Parses list items under configured heading and performs line-targeted updates. I
 Note lookup and creation are delegated through a source adapter:
 
 - `ObsidianDailyNoteSourceAdapter` preserves the existing `obsidian-daily-notes-interface` integration for core Daily Notes and Periodic Notes.
-- `JournalsDailyNoteSourceAdapter` validates the optional Journals runtime API, selects a configured Day journal, and delegates resolution/creation to that journal. Journals remains optional and owns its folder, naming, template, and frontmatter initialization.
+- `JournalsDailyNoteSourceAdapter` consumes a `JournalsBridge`, selects a configured Day journal, and delegates resolution/creation to that exact journal. Journals remains optional and owns its folder, naming, template, and frontmatter initialization.
 
-Both adapters feed the same heading parser, serializer, UID allocator, and CRUD implementation. The Journals adapter is intentionally narrow because Journals does not currently publish a documented third-party API; runtime shape checks contain that compatibility boundary.
+`JournalsBridge` is the only compatibility boundary. It prefers Journals 3.2+'s `obsidian-journals-api` locator and documented asynchronous surface, then falls back to the capability-checked Journals 2.x runtime. Provider and UI code do not branch on plugin version strings or private 3.x fields. The official adapter uses `listJournals({ writeType: "day" })`, `notesFor`, `journalOf`, and `ensureNote`; exact journal-name selectors preserve multiple-Day-journal isolation. The legacy adapter retains `journals`, `getJournal`, `index`, and `journal.open` behavior for 2.x.
+
+Both adapters feed the same heading parser, serializer, UID allocator, and CRUD implementation. The 3.2 API makes note operations asynchronous, so CRUD awaits bridge results. FCR's synchronous event-handle and file-relevance contracts use only a selected-journal path/date cache hydrated by authoritative API reads and maintained by `noteAdded`/`noteRemoved` subscriptions. Provider teardown disposes those subscriptions during source reload and plugin unload. `journalRenamed` migrates every matching persisted `journalId`; Journals defines the journal name itself as identity.
+
+Journals 3.2 does not expose journal templates through its public API. Heading suggestions therefore come from headings in existing selected-journal notes, while manual heading entry remains available. The 2.x adapter continues to inspect its public-at-runtime template settings for the legacy UX.
 
 Daily Notes and Journals have independent persisted source discriminators (`dailynote` and `journals`). `JournalsProvider` reuses `DailyNoteProvider` as its date-note CRUD base, while remaining separately registered so multiple selected Day journals can coexist without participating in the single Daily Note source limit. Legacy Journals sources saved as `type: dailynote` plus `provider: journals` are migrated to `type: journals`.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ Corresponds to
 -   **For Dev**: `git tags` of the `main` branch
 
 
+## Unreleased
+
+### Fixed
+
+-   Restored Journals calendar compatibility with Journals 3.2+ through its official plugin API while retaining legacy Journals 2.x support.
+
+
 ## v0.13.5
 
 <video controls playsinline preload="metadata" width="100%" src="https://raw.githubusercontent.com/obsidian-full-calendar-remastered/plugin-full-calendar/main/docs/assets/changlogs/v0.13.5.mp4">

--- a/docs/user/calendars/journals.md
+++ b/docs/user/calendars/journals.md
@@ -8,6 +8,8 @@ Use a **Journals** calendar to store Full Calendar events inside entries managed
 - Configure at least one **Day** journal in Journals.
 - Obsidian's core Daily Notes plugin is not required when you use this calendar source.
 
+Full Calendar supports Journals 3.2 and later through the official Journals API. Journals 2.x remains supported through a legacy compatibility adapter. Journals may label this cadence **DAILY** in its interface; its integration write type is still `day`.
+
 ## Add a Journals calendar
 
 1. Open **Full Calendar settings**.
@@ -17,7 +19,7 @@ Use a **Journals** calendar to store Full Calendar events inside entries managed
 5. Choose or enter the **Heading** where events should be written.
 6. Select the timed-event **Format**, then add the calendar.
 
-When the selected journal's templates contain headings, Full Calendar offers them in the Heading dropdown. You can also enter a heading manually and change it later from the configured calendar row.
+Full Calendar offers heading suggestions when it can discover them. With Journals 3.2+, suggestions come from existing notes in the selected journal because the public API does not expose template configuration. With Journals 2.x, suggestions come from the journal's configured templates. You can always enter a heading manually and change it later from the configured calendar row.
 
 ## How entries and events are stored
 
@@ -42,6 +44,7 @@ You can add multiple Journals calendars and connect each one to a different Day 
 - `Journals: PHD`
 
 Each calendar keeps its own selected journal, heading, color, and other calendar settings.
+Note lookup and creation are always scoped to that exact journal, so Full Calendar does not show Journals' generic journal picker or silently switch to another Day journal.
 
 ## Journals or Daily Note?
 
@@ -56,8 +59,10 @@ The two source types may coexist. Journals calendars do not count against the on
 
 - Journals must remain installed and enabled.
 - Only Journals **Day** journals can be selected.
-- If the selected Day journal is renamed or deleted, remove or reconfigure the affected Full Calendar source.
+- **Loading Day journals** is temporary; wait for Journals to finish responding.
+- **No Day journals configured** means Journals is enabled, but it has no selectable Day journal. Add one in Journals settings.
+- **Unsupported API** means Journals is enabled, but it is neither a compatible 2.x runtime nor Journals 3.2+ with the public API.
+- Full Calendar follows Journals 3.2+ rename notifications and updates saved source references. If a journal was renamed while Full Calendar was disabled, or if it was deleted, reselect the journal.
 - Recurring events and multi-day single events are not supported by date-note calendars; use a [Full Note calendar](local.md) for those events.
-- Duplicate event titles on the same date are not supported within one Journals calendar.
 
 [Daily Note Calendar](dailynote.md) · [Working with Events](../events/index.md) · [Troubleshooting](../guides/troubleshooting.md)

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,6 @@ module.exports = {
 	moduleNameMapper: {
 		"\\.css$": "<rootDir>/__mocks__/styleMock.js",
 		"\\.md$": "<rootDir>/__mocks__/mdMock.js",
+		"^obsidian-journals-api$": "<rootDir>/__mocks__/obsidianJournalsApi.js",
 	},
 };

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
         "ical.js": "^2.2.1",
         "luxon": "^3.7.2",
         "obsidian-daily-notes-interface": "^0.9.5",
+        "obsidian-journals-api": "^1.0.0",
         "plotly.js": "^3.7.0",
         "preact": "^10.29.8",
         "rrule": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       obsidian-daily-notes-interface:
         specifier: ^0.9.5
         version: 0.9.5(obsidian@1.13.1(@codemirror/state@6.7.1)(@codemirror/view@6.43.8))
+      obsidian-journals-api:
+        specifier: ^1.0.0
+        version: 1.0.0(obsidian@1.13.1(@codemirror/state@6.7.1)(@codemirror/view@6.43.8))
       plotly.js:
         specifier: ^3.7.0
         version: 3.7.0(mapbox-gl@1.13.3)
@@ -4331,6 +4334,11 @@ packages:
   obsidian-daily-notes-interface@0.9.5:
     resolution: {integrity: sha512-Jk1hFagCcMAC1B/LGHCeSLRWIvNCX4qJ6a5HDpUZqs8ckmdszzDKNTdnJZgCVzsUEQKdATJmoNW2kjMzk7+qhw==}
     engines: {node: '>=22.9.0'}
+    peerDependencies:
+      obsidian: '>=1.0.0'
+
+  obsidian-journals-api@1.0.0:
+    resolution: {integrity: sha512-MnEz6cZUE3lIjrEhsoGMUWLTcxfNZ2aJj7FFxpLShp2T4ZWL3kGEUQ0HQEG8yNzPPCQq7xy6u4dMvlHCxTDiaQ==}
     peerDependencies:
       obsidian: '>=1.0.0'
 
@@ -10639,6 +10647,10 @@ snapshots:
     dependencies:
       obsidian: 1.13.1(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
       tslib: 2.5.0
+
+  obsidian-journals-api@1.0.0(obsidian@1.13.1(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)):
+    dependencies:
+      obsidian: 1.13.1(@codemirror/state@6.7.1)(@codemirror/view@6.43.8)
 
   obsidian@1.13.1(@codemirror/state@6.7.1)(@codemirror/view@6.43.8):
     dependencies:

--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -847,8 +847,11 @@
           "label": "Day journal",
           "description": "Select the Journals Day journal to use.",
           "select": "Select a Day journal",
+          "loading": "Loading Day journals from Journals…",
           "unavailable": "Install and enable the Journals plugin to use this provider.",
-          "none": "Configure a Day journal in Journals before adding this calendar."
+          "unsupported": "Journals is enabled, but this version does not expose a supported integration API.",
+          "error": "Journals is enabled, but Full Calendar could not load its Day journals. Check the developer console for details.",
+          "none": "Journals is enabled, but no Day journals are configured."
         },
         "heading": {
           "label": "Heading",

--- a/src/providers/dailynote/DailyNoteConfigComponent.tsx
+++ b/src/providers/dailynote/DailyNoteConfigComponent.tsx
@@ -11,10 +11,10 @@ import { ProviderConfigContext } from '../typesProvider';
 import { t } from '../../features/i18n/i18n';
 import type FullCalendarPlugin from '../../main';
 import {
-  getJournalsDayJournals,
-  getJournalsPlugin,
-  getJournalsTemplateHeadings
-} from './DailyNoteSourceAdapter';
+  loadJournalsCatalog,
+  type JournalsBridge,
+  type JournalsJournalDescriptor
+} from '../journals/JournalsBridge';
 
 interface DailyNoteConfigComponentProps {
   plugin: FullCalendarPlugin;
@@ -24,6 +24,15 @@ interface DailyNoteConfigComponentProps {
   onSave: (finalConfig: DailyNoteProviderConfig) => void;
   onClose: () => void; // Required prop
 }
+
+type JournalsCatalogState =
+  | { state: 'loading'; journals: readonly JournalsJournalDescriptor[] }
+  | { state: 'missing' | 'unsupported' | 'error'; journals: readonly [] }
+  | {
+      state: 'ready';
+      journals: readonly JournalsJournalDescriptor[];
+      bridge: JournalsBridge;
+    };
 
 export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> = ({
   plugin,
@@ -36,17 +45,82 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
   const [heading, setHeading] = React.useState(config.heading || '');
   const [format, setFormat] = React.useState<DailyNoteEventFormat>(getDailyNoteEventFormat(config));
   const provider: DailyNoteSourceProvider = getDailyNoteSourceProvider(config);
-  const journalsPlugin = getJournalsPlugin(plugin.app);
-  const dayJournals = getJournalsDayJournals(plugin.app);
-  const initialJournalId =
-    config.journalId ||
-    (provider === 'journals' && dayJournals.length === 1 ? dayJournals[0].name : '');
-  const [journalId, setJournalId] = React.useState(initialJournalId);
-  const availableHeadings =
-    provider === 'journals' && journalId
-      ? getJournalsTemplateHeadings(plugin.app, journalId)
-      : context.headings;
+  const [journalId, setJournalId] = React.useState(config.journalId || '');
+  const [catalog, setCatalog] = React.useState<JournalsCatalogState>({
+    state: 'loading',
+    journals: []
+  });
+  const [journalHeadings, setJournalHeadings] = React.useState<readonly string[]>([]);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (provider !== 'journals') return;
+    let cancelled = false;
+    setCatalog({ state: 'loading', journals: [] });
+    void loadJournalsCatalog(plugin.app).then(result => {
+      if (cancelled) return;
+      if (result.state === 'error') {
+        console.warn('Full Calendar: Failed to list Journals Day journals.', result.error);
+        setCatalog({ state: 'error', journals: [] });
+        return;
+      }
+      if (result.state !== 'ready') {
+        setCatalog({ state: result.state, journals: [] });
+        return;
+      }
+      const { bridge, journals } = result;
+      setCatalog({ state: 'ready', journals, bridge });
+      const [onlyJournal] = journals;
+      if (journals.length === 1 && onlyJournal) {
+        setJournalId(current => current || onlyJournal.name);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [plugin.app, provider]);
+
+  React.useEffect(() => {
+    if (provider !== 'journals' || catalog.state !== 'ready' || !journalId) {
+      setJournalHeadings([]);
+      return;
+    }
+    let cancelled = false;
+    void Promise.resolve(catalog.bridge.getSuggestedHeadings(journalId)).then(
+      headings => {
+        if (!cancelled) setJournalHeadings(headings);
+      },
+      error => {
+        if (cancelled) return;
+        console.warn('Full Calendar: Failed to load Journals heading suggestions.', error);
+        setJournalHeadings([]);
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [catalog, journalId, provider]);
+
+  const dayJournals = catalog.journals;
+  const availableHeadings = provider === 'journals' ? journalHeadings : context.headings;
+
+  const journalDescription = (() => {
+    switch (catalog.state) {
+      case 'loading':
+        return t('settings.calendars.dailyNote.journal.loading');
+      case 'missing':
+        return t('settings.calendars.dailyNote.journal.unavailable');
+      case 'unsupported':
+        return t('settings.calendars.dailyNote.journal.unsupported');
+      case 'error':
+        return t('settings.calendars.dailyNote.journal.error');
+      case 'ready':
+        return dayJournals.length === 0
+          ? t('settings.calendars.dailyNote.journal.none')
+          : t('settings.calendars.dailyNote.journal.description');
+    }
+  })();
 
   const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -73,19 +147,13 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
             <div className="setting-item-name">
               {t('settings.calendars.dailyNote.journal.label')}
             </div>
-            <div className="setting-item-description">
-              {!journalsPlugin
-                ? t('settings.calendars.dailyNote.journal.unavailable')
-                : dayJournals.length === 0
-                  ? t('settings.calendars.dailyNote.journal.none')
-                  : t('settings.calendars.dailyNote.journal.description')}
-            </div>
+            <div className="setting-item-description">{journalDescription}</div>
           </div>
           <div className="setting-item-control">
             <select
               className="dropdown"
               value={journalId}
-              disabled={!journalsPlugin || dayJournals.length === 0}
+              disabled={catalog.state !== 'ready' || dayJournals.length === 0}
               onChange={e => {
                 setJournalId(e.target.value);
                 onConfigChange({ ...config, heading, format, provider, journalId: e.target.value });
@@ -115,7 +183,7 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
               setHeading(newValue);
               onConfigChange({ ...config, heading: newValue });
             }}
-            headings={availableHeadings}
+            headings={[...availableHeadings]}
           />
         </div>
       </div>
@@ -151,7 +219,11 @@ export const DailyNoteConfigComponent: React.FC<DailyNoteConfigComponentProps> =
           <button
             className="mod-cta"
             type="submit"
-            disabled={isSubmitting || !heading || (provider === 'journals' && !journalId)}
+            disabled={
+              isSubmitting ||
+              !heading ||
+              (provider === 'journals' && (catalog.state !== 'ready' || !journalId))
+            }
           >
             {t('ui.buttons.addCalendar')}
           </button>

--- a/src/providers/dailynote/DailyNoteProvider.ts
+++ b/src/providers/dailynote/DailyNoteProvider.ts
@@ -37,7 +37,6 @@ import {
 } from './typesDaily';
 import {
   DailyNoteSourceAdapter,
-  getJournalsTemplateHeadings,
   getObsidianDailyNoteTemplateHeadings,
   JournalsDailyNoteSourceAdapter,
   ObsidianDailyNoteSourceAdapter
@@ -46,12 +45,48 @@ import { DailyNoteConfigComponent } from './DailyNoteConfigComponent';
 import { DailyNoteDecorator } from './codemirror/DailyNoteDecorator';
 import { LivePreviewDecorator } from '../../features/livepreview/LivePreviewDecorator';
 import { HeadingInput } from '../../ui/components/forms/HeadingInput';
+import { PluginState } from '../../core/PluginState';
+import { resolveJournalsBridge } from '../journals/JournalsBridge';
+import { migrateJournalsSourceRename } from '../journals/JournalsSourceIdentity';
 
 type MomentFactory = typeof import('moment');
 const moment = obsidianMoment as unknown as MomentFactory;
 const METADATA_WAIT_TIMEOUT_MS = 1500;
 
 export type EditableEventResponse = [OFCEvent, EventLocation | null];
+
+const JournalsHeadingInput: React.FC<{
+  plugin: FullCalendarPlugin;
+  journalId: string;
+  value: string;
+  onChange: (heading: string) => void;
+}> = ({ plugin, journalId, value, onChange }) => {
+  const [headings, setHeadings] = React.useState<readonly string[]>([]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const resolution = resolveJournalsBridge(plugin.app);
+    if (resolution.state !== 'available') {
+      setHeadings([]);
+      return;
+    }
+    void Promise.resolve(resolution.bridge.getSuggestedHeadings(journalId)).then(
+      nextHeadings => {
+        if (!cancelled) setHeadings(nextHeadings);
+      },
+      error => {
+        if (cancelled) return;
+        console.warn('Full Calendar: Failed to load Journals heading suggestions.', error);
+        setHeadings([]);
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [journalId, plugin.app]);
+
+  return React.createElement(HeadingInput, { value, headings: [...headings], onChange });
+};
 
 const waitForMetadataWithTimeout = async (
   app: ObsidianInterface,
@@ -101,21 +136,25 @@ const DailyNoteHeadingSetting: React.FC<ProviderSettingsRowProps> = ({
     provider === 'journals'
       ? t('settings.calendars.dailyNote.heading.journalSummary')
       : t('settings.calendars.dailyNote.heading.summary');
-  const headings = plugin
-    ? provider === 'journals' && typeof journalId === 'string'
-      ? getJournalsTemplateHeadings(plugin.app, journalId)
-      : getObsidianDailyNoteTemplateHeadings(plugin.app)
-    : [];
+  const headingInput =
+    plugin && provider === 'journals' && typeof journalId === 'string'
+      ? React.createElement(JournalsHeadingInput, {
+          plugin,
+          journalId,
+          value: getHeading(),
+          onChange: heading => onSourceChange?.({ heading })
+        })
+      : React.createElement(HeadingInput, {
+          value: getHeading(),
+          headings: plugin ? getObsidianDailyNoteTemplateHeadings(plugin.app) : [],
+          onChange: heading => onSourceChange?.({ heading })
+        });
 
   return React.createElement(
     'div',
     { className: 'setting-item-control ofc-heading-setting-control' },
     React.createElement('span', {}, sourceLabel),
-    React.createElement(HeadingInput, {
-      value: getHeading(),
-      headings,
-      onChange: heading => onSourceChange?.({ heading })
-    }),
+    headingInput,
     React.createElement('span', { className: 'ofc-heading-setting-suffix' }, headingSummary)
   );
 };
@@ -233,6 +272,33 @@ export class DailyNoteProvider
     return this.noteSource.isFileRelevant(file);
   }
 
+  initialize(): void {
+    if (!(this.noteSource instanceof JournalsDailyNoteSourceAdapter)) return;
+    this.noteSource.initialize({
+      noteAdded: path => {
+        const file = this.plugin.app.vault.getFileByPath(path);
+        if (file instanceof TFile) {
+          void PluginState.getProviderRegistry().handleFileUpdate(file);
+        }
+      },
+      noteRemoved: path => {
+        void PluginState.getProviderRegistry().handleFileDelete(path);
+      },
+      journalRenamed: (from, to) => {
+        const settings = PluginState.getSettings();
+        if (migrateJournalsSourceRename(settings.calendarSources, from, to)) {
+          void PluginState.saveSettings();
+        }
+      }
+    });
+  }
+
+  teardown(): void {
+    if (this.noteSource instanceof JournalsDailyNoteSourceAdapter) {
+      this.noteSource.teardown();
+    }
+  }
+
   getCanonicalTitle(event: OFCEvent): string {
     return event.title;
   }
@@ -242,7 +308,7 @@ export class DailyNoteProvider
 
     const content = await this.app.read(file);
     const lines = content.split('\n');
-    const date = this.noteSource.getDateForFile(file);
+    const date = await this.noteSource.getDateForFile(file);
 
     const usedUids = new Set<number>();
 
@@ -269,7 +335,7 @@ export class DailyNoteProvider
   ): Promise<number> {
     const content = await this.app.read(file);
     const lines = content.split('\n');
-    const date = this.noteSource.getDateForFile(file);
+    const date = await this.noteSource.getDateForFile(file);
 
     // It's possible for a daily note file to not have a date in its title.
     // In that case, we cannot reliably parse events from it.
@@ -339,7 +405,7 @@ export class DailyNoteProvider
     }
 
     LoadDebugProfiler.recordDailyNotesStats({ readFromDisk: 1 });
-    const date = this.noteSource.getDateForFile(file) ?? undefined;
+    const date = (await this.noteSource.getDateForFile(file)) ?? undefined;
     const inlineEvents = await this.app.process(file, text =>
       getAllInlineEventsFromFile(text, listItems, { date })
     );
@@ -355,19 +421,24 @@ export class DailyNoteProvider
 
   async getEvents(range?: { start: Date; end: Date }): Promise<EditableEventResponse[]> {
     return LoadDebugProfiler.withContext('Daily Note Sync', async () => {
-      let files = this.noteSource.getAllFiles();
+      let files = await this.noteSource.getAllFiles(range);
 
       // OPTIMIZATION: If a range is provided, only process daily notes within that range.
       if (range) {
         const startMoment = moment(range.start);
         const endMoment = moment(range.end);
-        files = files.filter(file => {
-          const fileDate = this.noteSource.getDateForFile(file);
-          return fileDate
-            ? fileDate >= startMoment.format('YYYY-MM-DD') &&
-                fileDate <= endMoment.format('YYYY-MM-DD')
-            : false;
-        });
+        const filesInRange: TFile[] = [];
+        for (const file of files) {
+          const fileDate = await this.noteSource.getDateForFile(file);
+          if (
+            fileDate &&
+            fileDate >= startMoment.format('YYYY-MM-DD') &&
+            fileDate <= endMoment.format('YYYY-MM-DD')
+          ) {
+            filesInRange.push(file);
+          }
+        }
+        files = filesInRange;
       }
 
       LoadDebugProfiler.recordDailyNotesStats({ totalScanned: files.length });
@@ -395,7 +466,7 @@ export class DailyNoteProvider
     }
 
     const m = moment(event.date);
-    let file = this.noteSource.getExistingFileForDate(event.date, m);
+    let file = await this.noteSource.resolveExistingFileForDate(event.date, m);
     if (!file) {
       const createdFile = await this.noteSource.getFileForDate(event.date, m, true);
       if (!createdFile) {
@@ -443,12 +514,12 @@ export class DailyNoteProvider
       handle.location.lineNumber
     );
 
-    const oldDate = this.noteSource.getDateForFile(file);
+    const oldDate = await this.noteSource.getDateForFile(file);
     if (!oldDate) throw new Error(`Could not get date from file at path ${file.path}`);
 
     if (newEventData.date !== oldDate) {
       const m = moment(newEventData.date);
-      let newFile = this.noteSource.getExistingFileForDate(newEventData.date, m);
+      let newFile = await this.noteSource.resolveExistingFileForDate(newEventData.date, m);
       if (!newFile) {
         const createdFile = await this.noteSource.getFileForDate(newEventData.date, m, true);
         if (!createdFile) {

--- a/src/providers/dailynote/DailyNoteSourceAdapter.ts
+++ b/src/providers/dailynote/DailyNoteSourceAdapter.ts
@@ -10,89 +10,36 @@ import {
 
 import type { Moment } from 'moment';
 import type { DailyNoteProviderConfig } from './typesDaily';
+import {
+  getLegacyJournalsPlugin,
+  isLegacyDayJournal,
+  resolveJournalsBridge,
+  type JournalsBridge,
+  type JournalsDateRange,
+  type JournalsNoteDescriptor,
+  type LegacyDayJournal,
+  type LegacyJournalsPluginApi,
+  type MaybePromise
+} from '../journals/JournalsBridge';
 
-export const JOURNALS_PLUGIN_ID = 'journals';
-
-type JournalEntry = {
-  date: string;
-  journal: string;
-  path?: string;
-};
-
-export type JournalsDayJournal = {
-  name: string;
-  type: string;
-  get(date: string): JournalEntry | null;
-  getNotePath(entry: JournalEntry): string;
-  open(entry: JournalEntry): Promise<void>;
-};
-
-type JournalsIndex = {
-  getAllPaths(journalId: string): string[];
-  getForPath(path: string): JournalEntry | null;
-};
-
-export type JournalsPluginApi = {
-  journals: JournalsDayJournal[];
-  getJournal(name: string): JournalsDayJournal | undefined;
-  getJournalConfig?(name: string): { templates?: string[] } | undefined;
-  index: JournalsIndex;
-};
-
-type AppWithPlugins = App & {
-  plugins?: {
-    getPlugin?(id: string): unknown;
-    plugins?: Record<string, unknown>;
-  };
-};
+export type JournalsDayJournal = LegacyDayJournal;
+export type JournalsPluginApi = LegacyJournalsPluginApi;
 
 export type DailyNoteSourceAdapter = {
-  getAllFiles(): TFile[];
+  getAllFiles(range?: JournalsDateRange): MaybePromise<TFile[]>;
   getExistingFileForDate(date: string, dateMoment: Moment): TFile | null;
+  resolveExistingFileForDate(date: string, dateMoment: Moment): MaybePromise<TFile | null>;
   getFileForDate(date: string, dateMoment: Moment, create: boolean): Promise<TFile | null>;
-  getDateForFile(file: TFile): string | null;
+  getDateForFile(file: TFile): MaybePromise<string | null>;
   isFileRelevant(file: TFile): boolean;
 };
 
-function isJournalEntry(value: unknown): value is JournalEntry {
-  if (!value || typeof value !== 'object') return false;
-  const entry = value as Record<string, unknown>;
-  return typeof entry.date === 'string' && typeof entry.journal === 'string';
-}
-
-function isDayJournal(value: unknown): value is JournalsDayJournal {
-  if (!value || typeof value !== 'object') return false;
-  const journal = value as Record<string, unknown>;
-  return (
-    journal.type === 'day' &&
-    typeof journal.name === 'string' &&
-    typeof journal.get === 'function' &&
-    typeof journal.getNotePath === 'function' &&
-    typeof journal.open === 'function'
-  );
-}
-
-function isJournalsPluginApi(value: unknown): value is JournalsPluginApi {
-  if (!value || typeof value !== 'object') return false;
-  const plugin = value as Record<string, unknown>;
-  if (!Array.isArray(plugin.journals) || typeof plugin.getJournal !== 'function') return false;
-  if (plugin.getJournalConfig !== undefined && typeof plugin.getJournalConfig !== 'function') {
-    return false;
-  }
-  if (!plugin.index || typeof plugin.index !== 'object') return false;
-  const index = plugin.index as Record<string, unknown>;
-  return typeof index.getAllPaths === 'function' && typeof index.getForPath === 'function';
-}
-
 export function getJournalsPlugin(app: App): JournalsPluginApi | null {
-  const plugins = (app as AppWithPlugins).plugins;
-  const candidate =
-    plugins?.getPlugin?.(JOURNALS_PLUGIN_ID) ?? plugins?.plugins?.[JOURNALS_PLUGIN_ID];
-  return isJournalsPluginApi(candidate) ? candidate : null;
+  return getLegacyJournalsPlugin(app);
 }
 
 export function getJournalsDayJournals(app: App): JournalsDayJournal[] {
-  return getJournalsPlugin(app)?.journals.filter(isDayJournal) ?? [];
+  return getJournalsPlugin(app)?.journals.filter(isLegacyDayJournal) ?? [];
 }
 
 const getHeadingsFromTemplates = (app: App, templates: string[]): string[] => {
@@ -129,6 +76,10 @@ export class ObsidianDailyNoteSourceAdapter implements DailyNoteSourceAdapter {
     return getDailyNote(dateMoment, getAllDailyNotes()) ?? null;
   }
 
+  resolveExistingFileForDate(date: string, dateMoment: Moment): TFile | null {
+    return this.getExistingFileForDate(date, dateMoment);
+  }
+
   async getFileForDate(_date: string, dateMoment: Moment, create: boolean): Promise<TFile | null> {
     const existing = this.getExistingFileForDate(_date, dateMoment);
     if (existing instanceof TFile || !create) return existing ?? null;
@@ -153,80 +104,136 @@ export class ObsidianDailyNoteSourceAdapter implements DailyNoteSourceAdapter {
 }
 
 export class JournalsDailyNoteSourceAdapter implements DailyNoteSourceAdapter {
-  private readonly plugin: JournalsPluginApi | null;
-  private readonly journalId: string | undefined;
+  private journalId: string | undefined;
+  private readonly filesByDate = new Map<string, TFile>();
+  private readonly datesByPath = new Map<string, string>();
+  private unsubscribe: (() => void) | null = null;
 
   constructor(
     private readonly app: App,
     config: DailyNoteProviderConfig
   ) {
-    this.plugin = getJournalsPlugin(app);
     this.journalId = config.journalId;
   }
 
-  private getJournal(): JournalsDayJournal {
-    if (!this.plugin) {
-      throw new Error('Journals is not installed/enabled, or its runtime API is incompatible.');
-    }
+  private getJournalId(): string {
     if (!this.journalId) {
       throw new Error('No Journals Day journal is selected.');
     }
-    const journal = this.plugin.getJournal(this.journalId);
-    if (!isDayJournal(journal)) {
-      throw new Error(
-        `The selected Journals Day journal "${this.journalId}" is unavailable. It may have been renamed or deleted.`
-      );
-    }
-    return journal;
+    return this.journalId;
   }
 
-  getAllFiles(): TFile[] {
-    const journal = this.getJournal();
-    const plugin = this.plugin;
-    if (!plugin) return [];
-    return plugin.index
-      .getAllPaths(journal.name)
-      .map(path => this.app.vault.getFileByPath(path))
-      .filter((file): file is TFile => file instanceof TFile);
+  private getBridge(): JournalsBridge {
+    const resolution = resolveJournalsBridge(this.app);
+    if (resolution.state === 'available') return resolution.bridge;
+    if (resolution.state === 'missing') {
+      throw new Error('Journals is not installed/enabled.');
+    }
+    throw new Error('Journals is enabled, but its API is unsupported by Full Calendar.');
+  }
+
+  private remember(note: JournalsNoteDescriptor): TFile | null {
+    if (note.journal !== this.getJournalId() || !note.file) return null;
+    this.filesByDate.set(note.date, note.file);
+    this.datesByPath.set(note.file.path, note.date);
+    return note.file;
+  }
+
+  private forget(path: string, date?: string): void {
+    const knownDate = date ?? this.datesByPath.get(path);
+    this.datesByPath.delete(path);
+    if (knownDate && this.filesByDate.get(knownDate)?.path === path) {
+      this.filesByDate.delete(knownDate);
+    }
+  }
+
+  private rememberNotes(notes: readonly JournalsNoteDescriptor[]): TFile[] {
+    return notes.flatMap(note => {
+      const file = this.remember(note);
+      return file ? [file] : [];
+    });
+  }
+
+  private mapMaybePromise<T, U>(value: MaybePromise<T>, map: (item: T) => U): MaybePromise<U> {
+    return value instanceof Promise ? value.then(map) : map(value);
+  }
+
+  initialize(events: {
+    noteAdded?: (path: string) => void;
+    noteRemoved?: (path: string) => void;
+    journalRenamed?: (from: string, to: string) => void;
+  }): void {
+    this.teardown();
+    const resolution = resolveJournalsBridge(this.app);
+    if (resolution.state !== 'available' || resolution.bridge.kind !== 'official') return;
+    this.unsubscribe = resolution.bridge.subscribe({
+      noteAdded: note => {
+        if (note.journal !== this.journalId) return;
+        const file = this.app.vault.getFileByPath(note.path);
+        if (file instanceof TFile) this.remember({ ...note, file });
+        events.noteAdded?.(note.path);
+      },
+      noteRemoved: note => {
+        if (note.journal !== this.journalId) return;
+        this.forget(note.path, note.date);
+        events.noteRemoved?.(note.path);
+      },
+      journalRenamed: ({ from, to }) => {
+        if (from !== this.journalId) return;
+        this.journalId = to;
+        events.journalRenamed?.(from, to);
+      }
+    });
+  }
+
+  teardown(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+
+  getAllFiles(range?: JournalsDateRange): MaybePromise<TFile[]> {
+    const notes = this.getBridge().getNotes(this.getJournalId(), range);
+    return this.mapMaybePromise(notes, value => this.rememberNotes(value));
+  }
+
+  resolveExistingFileForDate(date: string, _dateMoment: Moment): MaybePromise<TFile | null> {
+    const note = this.getBridge().getNoteForDate(this.getJournalId(), date);
+    return this.mapMaybePromise(note, value => (value ? this.remember(value) : null));
   }
 
   getExistingFileForDate(date: string, _dateMoment: Moment): TFile | null {
-    if (!this.plugin) return null;
-    const journal = this.getJournal();
-    const entry = journal.get(date);
-    if (!isJournalEntry(entry) || !entry.path) return null;
-    return this.app.vault.getFileByPath(entry.path);
+    const bridge = this.getBridge();
+    if (bridge.kind === 'legacy') {
+      const note = bridge.getNoteForDate(this.getJournalId(), date);
+      if (!(note instanceof Promise)) return note ? this.remember(note) : null;
+    }
+    return this.filesByDate.get(date) ?? null;
   }
 
   async getFileForDate(date: string, _dateMoment: Moment, create: boolean): Promise<TFile | null> {
-    const journal = this.getJournal();
-    const entry = journal.get(date);
-    if (!isJournalEntry(entry)) {
-      throw new Error(`Journals could not resolve an entry for ${date}.`);
-    }
+    const existing = await this.resolveExistingFileForDate(date, _dateMoment);
+    if (existing || !create) return existing;
 
-    if (entry.path) {
-      const existing = this.app.vault.getFileByPath(entry.path);
-      if (existing) return existing;
-      throw new Error(`Journals resolved ${date} to a missing file: ${entry.path}.`);
-    }
-    if (!create) return null;
-
-    await journal.open(entry);
-    const path = journal.getNotePath(entry);
-    const created = this.app.vault.getFileByPath(path);
+    const note = await this.getBridge().ensureNote(this.getJournalId(), date);
+    const created = this.remember(note);
     if (!created) {
-      throw new Error(`Journals did not create the expected entry for ${date} at ${path}.`);
+      throw new Error(`Journals did not create the expected entry for ${date}.`);
     }
     return created;
   }
 
-  getDateForFile(file: TFile): string | null {
-    return this.plugin?.index.getForPath(file.path)?.date ?? null;
+  getDateForFile(file: TFile): MaybePromise<string | null> {
+    const known = this.datesByPath.get(file.path);
+    if (known) return known;
+    const note = this.getBridge().journalOf(file);
+    return this.mapMaybePromise(note, value => {
+      if (!value || value.journal !== this.getJournalId()) return null;
+      this.remember(value);
+      return value.date;
+    });
   }
 
   isFileRelevant(file: TFile): boolean {
-    if (!this.plugin) return false;
-    return this.plugin.index.getForPath(file.path)?.journal === this.getJournal().name;
+    return this.datesByPath.has(file.path);
   }
 }

--- a/src/providers/journals/JournalsBridge.test.ts
+++ b/src/providers/journals/JournalsBridge.test.ts
@@ -1,0 +1,310 @@
+import { App, TFile } from 'obsidian';
+import type { JournalsApi, JournalsApiEvents } from 'obsidian-journals-api';
+
+import {
+  loadJournalsCatalog,
+  resolveJournalsBridge,
+  type LegacyDayJournal,
+  type LegacyJournalEntry,
+  type LegacyJournalsPluginApi
+} from './JournalsBridge';
+
+jest.mock('obsidian', () => ({
+  TFile: class TFile {
+    path = '';
+  },
+  App: class App {}
+}));
+
+const makeFile = (path: string): TFile => {
+  const file = new TFile();
+  file.path = path;
+  return file;
+};
+
+type TestApp = App & {
+  vault: {
+    getFileByPath(path: string): TFile | null;
+    getMarkdownFiles(): TFile[];
+  };
+  metadataCache: {
+    getFileCache(file: TFile): { headings?: { heading: string }[] } | null;
+  };
+  plugins: {
+    getPlugin(id: string): unknown;
+    plugins: Record<string, unknown>;
+  };
+};
+
+const makeApp = (
+  journalsPlugin: unknown,
+  files: TFile[] = [],
+  headings = new Map<string, string[]>()
+): TestApp =>
+  ({
+    vault: {
+      getFileByPath: (path: string) => files.find(file => file.path === path) ?? null,
+      getMarkdownFiles: () => files
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => ({
+        headings: (headings.get(file.path) ?? []).map(heading => ({ heading }))
+      })
+    },
+    plugins: {
+      getPlugin: (id: string) => (id === 'journals' ? journalsPlugin : null),
+      plugins: journalsPlugin ? { journals: journalsPlugin } : {}
+    }
+  }) as TestApp;
+
+const existingNote = (journal: string, date: string, file: TFile) => ({
+  journal,
+  date,
+  displayDate: date,
+  endDate: date,
+  path: file.path,
+  file
+});
+
+type ApiMocks = {
+  api: JournalsApi;
+  listJournals: jest.Mock;
+  notesFor: jest.Mock;
+  journalOf: jest.Mock;
+  ensureNote: jest.Mock;
+  on: jest.Mock;
+  handlers: Partial<{ [K in keyof JournalsApiEvents]: JournalsApiEvents[K] }>;
+  disposers: jest.Mock[];
+};
+
+const makeOfficialApi = (): ApiMocks => {
+  const handlers: ApiMocks['handlers'] = {};
+  const disposers: jest.Mock[] = [];
+  const listJournals = jest.fn().mockResolvedValue([]);
+  const notesFor = jest.fn().mockResolvedValue([]);
+  const journalOf = jest.fn().mockResolvedValue(null);
+  const ensureNote = jest.fn();
+  const on = jest.fn((event: keyof JournalsApiEvents, handler: JournalsApiEvents[typeof event]) => {
+    handlers[event] = handler as never;
+    const dispose = jest.fn();
+    disposers.push(dispose);
+    return dispose;
+  });
+  const api = {
+    apiVersion: 1,
+    listJournals,
+    notesFor,
+    journalOf,
+    ensureNote,
+    on
+  } as unknown as JournalsApi;
+  return {
+    api,
+    listJournals,
+    notesFor,
+    journalOf,
+    ensureNote,
+    on,
+    handlers,
+    disposers
+  };
+};
+
+const makeLegacyJournal = (name: string, type = 'day'): LegacyDayJournal => ({
+  name,
+  type,
+  get: jest.fn((date: string): LegacyJournalEntry => ({ date, journal: name })),
+  getNotePath: jest.fn(entry => `${name}/${entry.date}.md`),
+  open: jest.fn().mockResolvedValue(undefined)
+});
+
+const makeLegacyPlugin = (journals: LegacyDayJournal[]): LegacyJournalsPluginApi => ({
+  journals,
+  getJournal: name => journals.find(journal => journal.name === name),
+  index: {
+    getAllPaths: () => [],
+    getForPath: () => null
+  }
+});
+
+describe('Journals compatibility bridge', () => {
+  it('reports Journals as missing without crashing when the plugin is absent', () => {
+    expect(resolveJournalsBridge(makeApp(null))).toEqual({ state: 'missing' });
+  });
+
+  it('detects the Journals 2.x runtime and returns only Day journals', async () => {
+    const legacy = makeLegacyPlugin([
+      makeLegacyJournal('Work'),
+      makeLegacyJournal('Personal'),
+      makeLegacyJournal('Weekly', 'week')
+    ]);
+    const resolution = resolveJournalsBridge(makeApp(legacy));
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    expect(resolution.bridge.kind).toBe('legacy');
+    await expect(Promise.resolve(resolution.bridge.listDayJournals())).resolves.toEqual([
+      { name: 'Work' },
+      { name: 'Personal' }
+    ]);
+  });
+
+  it('prefers the Journals 3.2 official API and uses the documented day filter', async () => {
+    const mocks = makeOfficialApi();
+    mocks.listJournals.mockResolvedValue([
+      { name: 'Work', shelf: null, write: { type: 'day' } },
+      { name: 'Personal', shelf: 'Home', write: { type: 'day' } }
+    ]);
+    const resolution = resolveJournalsBridge(makeApp({ api: mocks.api }));
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    expect(resolution.bridge.kind).toBe('official');
+    await expect(Promise.resolve(resolution.bridge.listDayJournals())).resolves.toEqual([
+      { name: 'Work' },
+      { name: 'Personal' }
+    ]);
+    expect(mocks.listJournals).toHaveBeenCalledWith({ writeType: 'day' });
+  });
+
+  it('distinguishes an enabled plugin with no supported API from a missing plugin', () => {
+    expect(resolveJournalsBridge(makeApp({ api: null }))).toEqual({ state: 'unsupported' });
+  });
+
+  it('returns the unsupported catalog state instead of the plugin-missing UI state', async () => {
+    await expect(loadJournalsCatalog(makeApp({ api: null }))).resolves.toEqual({
+      state: 'unsupported'
+    });
+  });
+
+  it('keeps an available provider distinct from an empty Day journal list', async () => {
+    const mocks = makeOfficialApi();
+    const resolution = resolveJournalsBridge(makeApp({ api: mocks.api }));
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    await expect(Promise.resolve(resolution.bridge.listDayJournals())).resolves.toEqual([]);
+  });
+
+  it('surfaces listJournals failures as a handled rejection', async () => {
+    const mocks = makeOfficialApi();
+    mocks.listJournals.mockRejectedValue(new Error('index unavailable'));
+    const resolution = resolveJournalsBridge(makeApp({ api: mocks.api }));
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    await expect(Promise.resolve(resolution.bridge.listDayJournals())).rejects.toThrow(
+      'index unavailable'
+    );
+    await expect(loadJournalsCatalog(makeApp({ api: mocks.api }))).resolves.toEqual(
+      expect.objectContaining({ state: 'error' })
+    );
+  });
+
+  it('scopes note lookup and creation to the persisted selected journal name', async () => {
+    const work = makeFile('Work/2026-08-30.md');
+    const mocks = makeOfficialApi();
+    mocks.notesFor.mockResolvedValue([existingNote('Work', '2026-08-30', work)]);
+    mocks.ensureNote.mockResolvedValue({
+      note: existingNote('Work', '2026-08-31', makeFile('Work/2026-08-31.md')),
+      created: true
+    });
+    const resolution = resolveJournalsBridge(makeApp({ api: mocks.api }, [work]));
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    await expect(
+      Promise.resolve(resolution.bridge.getNoteForDate('Work', '2026-08-30'))
+    ).resolves.toEqual(expect.objectContaining({ journal: 'Work', file: work }));
+    await expect(resolution.bridge.ensureNote('Work', '2026-08-31')).resolves.toEqual(
+      expect.objectContaining({ journal: 'Work', path: 'Work/2026-08-31.md' })
+    );
+    expect(mocks.notesFor).toHaveBeenCalledWith('Work', '2026-08-30');
+    expect(mocks.ensureNote).toHaveBeenCalledWith('Work', '2026-08-31');
+  });
+
+  it('loads an event date range through exact selected-journal note lookups', async () => {
+    const work = makeFile('Work/2026-08-30.md');
+    const mocks = makeOfficialApi();
+    mocks.notesFor.mockImplementation(async (selector: string, date: string) => {
+      if (selector !== 'Work') return [];
+      if (date === '2026-08-30') return [existingNote('Work', date, work)];
+      return [
+        {
+          journal: 'Work',
+          date,
+          displayDate: date,
+          endDate: date,
+          path: `Work/${date}.md`,
+          file: null
+        }
+      ];
+    });
+    const resolution = resolveJournalsBridge(makeApp({ api: mocks.api }, [work]));
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    await expect(
+      Promise.resolve(
+        resolution.bridge.getNotes('Work', {
+          start: new Date(2026, 7, 30),
+          end: new Date(2026, 7, 31)
+        })
+      )
+    ).resolves.toEqual([expect.objectContaining({ journal: 'Work', date: '2026-08-30' })]);
+    expect(mocks.notesFor.mock.calls).toEqual([
+      ['Work', '2026-08-30'],
+      ['Work', '2026-08-31']
+    ]);
+  });
+
+  it('enumerates selected-journal files and derives headings through public journalOf', async () => {
+    const work = makeFile('Work/2026-08-30.md');
+    const personal = makeFile('Personal/2026-08-30.md');
+    const mocks = makeOfficialApi();
+    mocks.journalOf.mockImplementation(async (file: TFile) =>
+      file === work
+        ? existingNote('Work', '2026-08-30', work)
+        : existingNote('Personal', '2026-08-30', personal)
+    );
+    const app = makeApp(
+      { api: mocks.api },
+      [work, personal],
+      new Map([[work.path, ['Schedule', 'Notes', 'Schedule']]])
+    );
+    const resolution = resolveJournalsBridge(app);
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    await expect(Promise.resolve(resolution.bridge.getNotes('Work'))).resolves.toEqual([
+      expect.objectContaining({ journal: 'Work', file: work })
+    ]);
+    await expect(Promise.resolve(resolution.bridge.getSuggestedHeadings('Work'))).resolves.toEqual([
+      'Schedule',
+      'Notes'
+    ]);
+  });
+
+  it('subscribes to official note and rename events and disposes every listener', () => {
+    const mocks = makeOfficialApi();
+    const resolution = resolveJournalsBridge(makeApp({ api: mocks.api }));
+
+    expect(resolution.state).toBe('available');
+    if (resolution.state !== 'available') return;
+    const noteAdded = jest.fn();
+    const noteRemoved = jest.fn();
+    const journalRenamed = jest.fn();
+    const dispose = resolution.bridge.subscribe({ noteAdded, noteRemoved, journalRenamed });
+
+    mocks.handlers.noteAdded?.({ journal: 'Work', date: '2026-08-30', path: 'Work.md' });
+    mocks.handlers.noteRemoved?.({ journal: 'Work', date: '2026-08-30', path: 'Work.md' });
+    mocks.handlers.journalRenamed?.({ from: 'Work', to: 'Office' });
+    expect(noteAdded).toHaveBeenCalledTimes(1);
+    expect(noteRemoved).toHaveBeenCalledTimes(1);
+    expect(journalRenamed).toHaveBeenCalledWith({ from: 'Work', to: 'Office' });
+
+    dispose();
+    expect(mocks.disposers).toHaveLength(3);
+    mocks.disposers.forEach(unsubscribe => expect(unsubscribe).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/providers/journals/JournalsBridge.ts
+++ b/src/providers/journals/JournalsBridge.ts
@@ -1,0 +1,407 @@
+import { App, TFile } from 'obsidian';
+import { getJournalsApi, type ExistingJournalNote, type JournalsApi } from 'obsidian-journals-api';
+
+export const JOURNALS_PLUGIN_ID = 'journals';
+
+export type MaybePromise<T> = T | Promise<T>;
+
+export type JournalsJournalDescriptor = {
+  name: string;
+};
+
+export type JournalsNoteDescriptor = {
+  journal: string;
+  date: string;
+  path: string | null;
+  file: TFile | null;
+};
+
+export type JournalsDateRange = {
+  start: Date;
+  end: Date;
+};
+
+export type JournalsBridgeEvents = {
+  noteAdded?: (note: { journal: string; date: string; path: string }) => void;
+  noteRemoved?: (note: { journal: string; date: string; path: string }) => void;
+  journalRenamed?: (event: { from: string; to: string }) => void;
+};
+
+export interface JournalsBridge {
+  readonly kind: 'official' | 'legacy';
+
+  listDayJournals(): MaybePromise<readonly JournalsJournalDescriptor[]>;
+  getNotes(
+    journalName: string,
+    range?: JournalsDateRange
+  ): MaybePromise<readonly JournalsNoteDescriptor[]>;
+  getNoteForDate(journalName: string, date: string): MaybePromise<JournalsNoteDescriptor | null>;
+  ensureNote(journalName: string, date: string): Promise<JournalsNoteDescriptor>;
+  journalOf(file: TFile): MaybePromise<JournalsNoteDescriptor | null>;
+  getSuggestedHeadings(journalName: string): MaybePromise<readonly string[]>;
+  subscribe(events: JournalsBridgeEvents): () => void;
+}
+
+export type JournalsBridgeResolution =
+  { state: 'available'; bridge: JournalsBridge } | { state: 'missing' | 'unsupported' };
+
+export type JournalsCatalogResult =
+  | { state: 'missing' | 'unsupported' }
+  | {
+      state: 'ready';
+      bridge: JournalsBridge;
+      journals: readonly JournalsJournalDescriptor[];
+    }
+  | { state: 'error'; error: unknown };
+
+export type LegacyJournalEntry = {
+  date: string;
+  journal: string;
+  path?: string;
+};
+
+export type LegacyDayJournal = {
+  name: string;
+  type: string;
+  get(date: string): LegacyJournalEntry | null;
+  getNotePath(entry: LegacyJournalEntry): string;
+  open(entry: LegacyJournalEntry): Promise<void>;
+};
+
+type LegacyJournalsIndex = {
+  getAllPaths(journalName: string): string[];
+  getForPath(path: string): LegacyJournalEntry | null;
+};
+
+export type LegacyJournalsPluginApi = {
+  journals: LegacyDayJournal[];
+  getJournal(name: string): LegacyDayJournal | undefined;
+  getJournalConfig?(name: string): { templates?: string[] } | undefined;
+  index: LegacyJournalsIndex;
+};
+
+type AppWithPlugins = App & {
+  plugins?: {
+    getPlugin?(id: string): unknown;
+    plugins?: Record<string, unknown>;
+  };
+};
+
+type SupportedJournalsApi = Pick<
+  JournalsApi,
+  'apiVersion' | 'listJournals' | 'notesFor' | 'journalOf' | 'ensureNote' | 'on'
+>;
+
+const isLegacyJournalEntry = (value: unknown): value is LegacyJournalEntry => {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.date === 'string' && typeof entry.journal === 'string';
+};
+
+export const isLegacyDayJournal = (value: unknown): value is LegacyDayJournal => {
+  if (!value || typeof value !== 'object') return false;
+  const journal = value as Record<string, unknown>;
+  return (
+    journal.type === 'day' &&
+    typeof journal.name === 'string' &&
+    typeof journal.get === 'function' &&
+    typeof journal.getNotePath === 'function' &&
+    typeof journal.open === 'function'
+  );
+};
+
+const isLegacyJournalsPluginApi = (value: unknown): value is LegacyJournalsPluginApi => {
+  if (!value || typeof value !== 'object') return false;
+  const plugin = value as Record<string, unknown>;
+  if (!Array.isArray(plugin.journals) || typeof plugin.getJournal !== 'function') return false;
+  if (plugin.getJournalConfig !== undefined && typeof plugin.getJournalConfig !== 'function') {
+    return false;
+  }
+  if (!plugin.index || typeof plugin.index !== 'object') return false;
+  const index = plugin.index as Record<string, unknown>;
+  return typeof index.getAllPaths === 'function' && typeof index.getForPath === 'function';
+};
+
+const getPluginCandidate = (app: App): unknown => {
+  const plugins = (app as AppWithPlugins).plugins;
+  return plugins?.getPlugin?.(JOURNALS_PLUGIN_ID) ?? plugins?.plugins?.[JOURNALS_PLUGIN_ID];
+};
+
+export const getLegacyJournalsPlugin = (app: App): LegacyJournalsPluginApi | null => {
+  const candidate = getPluginCandidate(app);
+  return isLegacyJournalsPluginApi(candidate) ? candidate : null;
+};
+
+const isOfficialJournalsApi = (value: unknown): value is SupportedJournalsApi => {
+  if (!value || typeof value !== 'object') return false;
+  const api = value as Record<string, unknown>;
+  return (
+    typeof api.apiVersion === 'number' &&
+    typeof api.listJournals === 'function' &&
+    typeof api.notesFor === 'function' &&
+    typeof api.journalOf === 'function' &&
+    typeof api.ensureNote === 'function' &&
+    typeof api.on === 'function'
+  );
+};
+
+const getOfficialJournalsApi = (app: App): SupportedJournalsApi | null => {
+  const api = getJournalsApi(app);
+  return isOfficialJournalsApi(api) ? api : null;
+};
+
+const headingsFromFiles = (app: App, files: readonly TFile[]): string[] => {
+  const headings = files.flatMap(
+    file => app.metadataCache.getFileCache(file)?.headings?.map(item => item.heading) ?? []
+  );
+  return [...new Set(headings)];
+};
+
+const headingsFromTemplates = (app: App, templates: readonly string[]): string[] => {
+  const files = templates
+    .map(template => (template.endsWith('.md') ? template : `${template}.md`))
+    .map(path => app.vault.getFileByPath(path))
+    .filter((file): file is TFile => file instanceof TFile);
+  return headingsFromFiles(app, files);
+};
+
+const toIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const datesInRange = ({ start, end }: JournalsDateRange): string[] => {
+  const cursor = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+  const last = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+  const dates: string[] = [];
+  while (cursor <= last) {
+    dates.push(toIsoDate(cursor));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return dates;
+};
+
+const inRange = (date: string, range?: JournalsDateRange): boolean => {
+  if (!range) return true;
+  return date >= toIsoDate(range.start) && date <= toIsoDate(range.end);
+};
+
+const officialNote = (note: ExistingJournalNote): JournalsNoteDescriptor => ({
+  journal: note.journal,
+  date: note.date,
+  path: note.path,
+  file: note.file
+});
+
+class OfficialJournalsBridge implements JournalsBridge {
+  readonly kind = 'official' as const;
+
+  constructor(private readonly app: App) {}
+
+  private api(): SupportedJournalsApi {
+    const api = getOfficialJournalsApi(this.app);
+    if (!api) {
+      throw new Error('The Journals official API is no longer available.');
+    }
+    return api;
+  }
+
+  async listDayJournals(): Promise<readonly JournalsJournalDescriptor[]> {
+    const journals = await this.api().listJournals({ writeType: 'day' });
+    return journals.map(({ name }) => ({ name }));
+  }
+
+  async getNotes(
+    journalName: string,
+    range?: JournalsDateRange
+  ): Promise<readonly JournalsNoteDescriptor[]> {
+    const api = this.api();
+    if (range) {
+      const notes = await Promise.all(
+        datesInRange(range).map(date => api.notesFor(journalName, date))
+      );
+      const unique = new Map<string, JournalsNoteDescriptor>();
+      for (const note of notes.flat()) {
+        if (note.journal !== journalName || !note.file || !note.path) continue;
+        unique.set(note.path, officialNote(note as ExistingJournalNote));
+      }
+      return [...unique.values()];
+    }
+
+    const files = this.app.vault.getMarkdownFiles();
+    const notes: JournalsNoteDescriptor[] = [];
+    const batchSize = 50;
+    for (let index = 0; index < files.length; index += batchSize) {
+      const batch = files.slice(index, index + batchSize);
+      const matches = await Promise.all(batch.map(file => api.journalOf(file)));
+      for (const match of matches) {
+        if (match?.journal === journalName) notes.push(officialNote(match));
+      }
+    }
+    return notes;
+  }
+
+  async getNoteForDate(journalName: string, date: string): Promise<JournalsNoteDescriptor | null> {
+    const notes = await this.api().notesFor(journalName, date);
+    const note = notes.find(item => item.journal === journalName);
+    return note
+      ? {
+          journal: note.journal,
+          date: note.date,
+          path: note.path,
+          file: note.file
+        }
+      : null;
+  }
+
+  async ensureNote(journalName: string, date: string): Promise<JournalsNoteDescriptor> {
+    const { note } = await this.api().ensureNote(journalName, date);
+    return officialNote(note);
+  }
+
+  async journalOf(file: TFile): Promise<JournalsNoteDescriptor | null> {
+    const note = await this.api().journalOf(file);
+    return note ? officialNote(note) : null;
+  }
+
+  async getSuggestedHeadings(journalName: string): Promise<readonly string[]> {
+    const notes = await this.getNotes(journalName);
+    const files = notes.flatMap(note => (note.file ? [note.file] : []));
+    return headingsFromFiles(this.app, files);
+  }
+
+  subscribe(events: JournalsBridgeEvents): () => void {
+    const api = this.api();
+    const disposers = [
+      events.noteAdded ? api.on('noteAdded', events.noteAdded) : null,
+      events.noteRemoved ? api.on('noteRemoved', events.noteRemoved) : null,
+      events.journalRenamed ? api.on('journalRenamed', events.journalRenamed) : null
+    ].filter((dispose): dispose is () => void => dispose !== null);
+
+    return () => {
+      for (const dispose of disposers) dispose();
+    };
+  }
+}
+
+class LegacyJournalsBridge implements JournalsBridge {
+  readonly kind = 'legacy' as const;
+
+  constructor(private readonly app: App) {}
+
+  private plugin(): LegacyJournalsPluginApi {
+    const plugin = getLegacyJournalsPlugin(this.app);
+    if (!plugin) {
+      throw new Error('The Journals legacy runtime API is no longer available.');
+    }
+    return plugin;
+  }
+
+  private journal(journalName: string): LegacyDayJournal {
+    const journal = this.plugin().getJournal(journalName);
+    if (!isLegacyDayJournal(journal)) {
+      throw new Error(
+        `The selected Journals Day journal "${journalName}" is unavailable. It may have been renamed or deleted.`
+      );
+    }
+    return journal;
+  }
+
+  listDayJournals(): readonly JournalsJournalDescriptor[] {
+    return this.plugin()
+      .journals.filter(isLegacyDayJournal)
+      .map(({ name }) => ({ name }));
+  }
+
+  getNotes(journalName: string, range?: JournalsDateRange): readonly JournalsNoteDescriptor[] {
+    const plugin = this.plugin();
+    this.journal(journalName);
+    return plugin.index.getAllPaths(journalName).flatMap(path => {
+      const entry = plugin.index.getForPath(path);
+      const file = this.app.vault.getFileByPath(path);
+      if (
+        !isLegacyJournalEntry(entry) ||
+        entry.journal !== journalName ||
+        !inRange(entry.date, range) ||
+        !(file instanceof TFile)
+      ) {
+        return [];
+      }
+      return [{ journal: entry.journal, date: entry.date, path, file }];
+    });
+  }
+
+  getNoteForDate(journalName: string, date: string): JournalsNoteDescriptor | null {
+    const entry = this.journal(journalName).get(date);
+    if (!isLegacyJournalEntry(entry)) return null;
+    const file = entry.path ? this.app.vault.getFileByPath(entry.path) : null;
+    return {
+      journal: entry.journal,
+      date: entry.date,
+      path: entry.path ?? null,
+      file: file instanceof TFile ? file : null
+    };
+  }
+
+  async ensureNote(journalName: string, date: string): Promise<JournalsNoteDescriptor> {
+    const journal = this.journal(journalName);
+    const entry = journal.get(date);
+    if (!isLegacyJournalEntry(entry)) {
+      throw new Error(`Journals could not resolve an entry for ${date}.`);
+    }
+    if (!entry.path) await journal.open(entry);
+    const path = entry.path ?? journal.getNotePath(entry);
+    const file = this.app.vault.getFileByPath(path);
+    if (!(file instanceof TFile)) {
+      throw new Error(`Journals did not create the expected entry for ${date} at ${path}.`);
+    }
+    return { journal: entry.journal, date: entry.date, path, file };
+  }
+
+  journalOf(file: TFile): JournalsNoteDescriptor | null {
+    const entry = this.plugin().index.getForPath(file.path);
+    return isLegacyJournalEntry(entry)
+      ? { journal: entry.journal, date: entry.date, path: file.path, file }
+      : null;
+  }
+
+  getSuggestedHeadings(journalName: string): readonly string[] {
+    const templates = this.plugin().getJournalConfig?.(journalName)?.templates;
+    return Array.isArray(templates) ? headingsFromTemplates(this.app, templates) : [];
+  }
+
+  subscribe(_events: JournalsBridgeEvents): () => void {
+    return () => undefined;
+  }
+}
+
+/**
+ * Journals 3.2+ exposes a stable public API; Journals 2.x exposed only its plugin runtime.
+ * Keep both capability checks here so the rest of Full Calendar never depends on either
+ * plugin implementation shape.
+ */
+export const resolveJournalsBridge = (app: App): JournalsBridgeResolution => {
+  if (getOfficialJournalsApi(app)) {
+    return { state: 'available', bridge: new OfficialJournalsBridge(app) };
+  }
+  if (getLegacyJournalsPlugin(app)) {
+    return { state: 'available', bridge: new LegacyJournalsBridge(app) };
+  }
+  return getPluginCandidate(app) ? { state: 'unsupported' } : { state: 'missing' };
+};
+
+export const loadJournalsCatalog = async (app: App): Promise<JournalsCatalogResult> => {
+  const resolution = resolveJournalsBridge(app);
+  if (resolution.state !== 'available') return resolution;
+  try {
+    return {
+      state: 'ready',
+      bridge: resolution.bridge,
+      journals: await resolution.bridge.listDayJournals()
+    };
+  } catch (error) {
+    return { state: 'error', error };
+  }
+};

--- a/src/providers/journals/JournalsDailyNoteProvider.workflow.test.ts
+++ b/src/providers/journals/JournalsDailyNoteProvider.workflow.test.ts
@@ -1,0 +1,200 @@
+import { TFile } from 'obsidian';
+import type { CachedMetadata } from 'obsidian';
+import type { JournalsApi } from 'obsidian-journals-api';
+
+import { DailyNoteProvider } from '../dailynote/DailyNoteProvider';
+import type { ObsidianInterface } from '../../ObsidianAdapter';
+import type FullCalendarPlugin from '../../main';
+import { DEFAULT_SETTINGS } from '../../types/settings';
+import type { OFCEvent } from '../../types';
+import { PluginState } from '../../core/PluginState';
+
+jest.mock('obsidian', () => {
+  const toIsoDate = (input?: string | Date): string => {
+    if (!input) return '1970-01-01';
+    if (input instanceof Date) return input.toISOString().slice(0, 10);
+    return input.slice(0, 10);
+  };
+  const moment = (input?: string | Date) => ({
+    format: (_pattern?: string) => toIsoDate(input)
+  });
+
+  class TFile {
+    path = '';
+    name = '';
+  }
+
+  return {
+    moment,
+    TFile,
+    Notice: class {},
+    Modal: class {},
+    PluginSettingTab: class {},
+    Setting: class {},
+    Plugin: class {},
+    App: class {}
+  };
+});
+
+jest.mock('obsidian-daily-notes-interface', () => ({
+  appHasDailyNotesPluginLoaded: jest.fn(),
+  createDailyNote: jest.fn(),
+  getAllDailyNotes: jest.fn(),
+  getDailyNote: jest.fn(),
+  getDailyNoteSettings: jest.fn().mockReturnValue({ folder: '', template: '' }),
+  getDateFromFile: jest.fn()
+}));
+
+const makeFile = (path: string): TFile => {
+  const file = new TFile();
+  file.path = path;
+  file.name = path.split('/').pop() ?? '';
+  return file;
+};
+
+describe('Journals 3.2 Daily Note provider workflow', () => {
+  it('creates, edits, moves, and deletes through an exact selected-journal API selector', async () => {
+    const files = new Map<string, TFile>();
+    const datesByPath = new Map<string, string>();
+    const contents = new Map<string, string>();
+    const pathFor = (date: string) => `Work/${date}.md`;
+    const apiNote = (date: string, file: TFile | null) => ({
+      journal: 'Work',
+      date,
+      displayDate: date,
+      endDate: date,
+      path: pathFor(date),
+      file
+    });
+
+    const notesFor = jest.fn(async (selector: string, date: string) => {
+      if (selector !== 'Work') return [];
+      return [apiNote(date, files.get(pathFor(date)) ?? null)];
+    });
+    const ensureNote = jest.fn(async (selector: string, date: string) => {
+      if (selector !== 'Work') throw new Error('wrong journal');
+      const path = pathFor(date);
+      const file = files.get(path) ?? makeFile(path);
+      files.set(path, file);
+      datesByPath.set(path, date);
+      if (!contents.has(path)) contents.set(path, '');
+      return { note: apiNote(date, file), created: true };
+    });
+    const journalOf = jest.fn(async (file: TFile) => {
+      const date = datesByPath.get(file.path);
+      return date ? apiNote(date, file) : null;
+    });
+    const subscriptionDisposers: jest.Mock[] = [];
+    const on = jest.fn(() => {
+      const dispose = jest.fn();
+      subscriptionDisposers.push(dispose);
+      return dispose;
+    });
+    const api = {
+      apiVersion: 1,
+      listJournals: jest.fn().mockResolvedValue([
+        { name: 'Work', shelf: null, write: { type: 'day' } },
+        { name: 'Personal', shelf: null, write: { type: 'day' } }
+      ]),
+      notesFor,
+      journalOf,
+      ensureNote,
+      on
+    } as unknown as JournalsApi;
+
+    const obsidianApp = {
+      vault: {
+        getFileByPath: (path: string) => files.get(path) ?? null,
+        getMarkdownFiles: () => [...files.values()]
+      },
+      metadataCache: {
+        getFileCache: (_file: TFile) => ({ headings: [] })
+      },
+      plugins: {
+        getPlugin: (id: string) => (id === 'journals' ? { api } : null),
+        plugins: { journals: { api } }
+      }
+    };
+
+    const io: ObsidianInterface = {
+      getAbstractFileByPath: (path: string) => files.get(path) ?? null,
+      getFileByPath: (path: string) => files.get(path) ?? null,
+      getMetadata: (_file: TFile) => ({ headings: [] }),
+      waitForMetadata: (_file: TFile) => Promise.resolve({ headings: [] } as CachedMetadata),
+      read: (file: TFile) => Promise.resolve(contents.get(file.path) ?? ''),
+      process: <T>(file: TFile, func: (text: string) => T): Promise<T> =>
+        Promise.resolve(func(contents.get(file.path) ?? '')),
+      create: () => Promise.reject(new Error('Journals owns note creation')),
+      rewrite: async <T>(file: TFile, rewriteFunc: (text: string) => unknown) => {
+        const result = await rewriteFunc(contents.get(file.path) ?? '');
+        if (Array.isArray(result)) {
+          const [text, extra] = result as [string, T];
+          contents.set(file.path, text);
+          return extra;
+        }
+        contents.set(file.path, result as string);
+        return undefined;
+      },
+      rename: () => Promise.reject(new Error('Not used')),
+      delete: () => Promise.reject(new Error('Not used'))
+    };
+
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      calendarSources: [
+        {
+          type: 'journals' as const,
+          id: 'journals_1',
+          name: 'Journals: Work',
+          journalId: 'Work',
+          heading: 'Calendar',
+          format: 'default' as const,
+          color: '#123456'
+        }
+      ]
+    };
+    PluginState.setSettings(settings);
+    const plugin = { app: obsidianApp, settings } as unknown as FullCalendarPlugin;
+    const provider = new DailyNoteProvider(settings.calendarSources[0], plugin, io);
+    provider.initialize();
+    expect(on).toHaveBeenCalledTimes(3);
+
+    const event: OFCEvent = {
+      title: 'Official API lifecycle',
+      type: 'single',
+      allDay: false,
+      date: '2026-08-30',
+      startTime: '09:00',
+      endTime: '10:00',
+      endDate: null
+    };
+    const [created, createdLocation] = await provider.createEvent(event);
+    expect(createdLocation.file.path).toBe('Work/2026-08-30.md');
+    expect(contents.get(createdLocation.file.path)).toContain('Official API lifecycle');
+    expect(ensureNote).toHaveBeenCalledWith('Work', '2026-08-30');
+
+    const renamed: OFCEvent = { ...created, title: 'Official API renamed' };
+    const renameHandle = provider.getEventHandle(created);
+    expect(renameHandle?.location?.path).toBe('Work/2026-08-30.md');
+    await provider.updateEvent(renameHandle!, created, renamed);
+    expect(contents.get('Work/2026-08-30.md')).toContain('Official API renamed');
+
+    const moved = { ...renamed, date: '2026-08-31' } as OFCEvent;
+    const movedLocation = await provider.updateEvent(
+      provider.getEventHandle(renamed)!,
+      renamed,
+      moved
+    );
+    expect(movedLocation?.file.path).toBe('Work/2026-08-31.md');
+    expect(contents.get('Work/2026-08-30.md')).not.toContain('Official API renamed');
+    expect(contents.get('Work/2026-08-31.md')).toContain('Official API renamed');
+    expect(ensureNote).toHaveBeenCalledWith('Work', '2026-08-31');
+
+    await provider.deleteEvent(provider.getEventHandle(moved)!);
+    expect(contents.get('Work/2026-08-31.md')).not.toContain('Official API renamed');
+    expect(notesFor.mock.calls.every(([selector]) => selector === 'Work')).toBe(true);
+
+    provider.teardown();
+    subscriptionDisposers.forEach(dispose => expect(dispose).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/providers/journals/JournalsSourceIdentity.ts
+++ b/src/providers/journals/JournalsSourceIdentity.ts
@@ -1,0 +1,20 @@
+import type { CalendarInfo } from '../../types/calendar_settings';
+
+/**
+ * The Journals public API defines a journal name as its identity. Rename notifications are
+ * therefore the only supported opportunity to migrate persisted third-party references.
+ */
+export const migrateJournalsSourceRename = (
+  sources: CalendarInfo[],
+  from: string,
+  to: string
+): boolean => {
+  let changed = false;
+  for (const source of sources) {
+    if (source.type !== 'journals' || source.journalId !== from) continue;
+    source.journalId = to;
+    if (source.name === `Journals: ${from}`) source.name = `Journals: ${to}`;
+    changed = true;
+  }
+  return changed;
+};

--- a/src/providers/journals/JournalsSourceRename.test.ts
+++ b/src/providers/journals/JournalsSourceRename.test.ts
@@ -1,0 +1,37 @@
+import { parseCalendarInfo, type CalendarInfo } from '../../types/calendar_settings';
+import { migrateJournalsSourceRename } from './JournalsSourceIdentity';
+
+const source = (id: string, journalId: string, name: string): CalendarInfo =>
+  parseCalendarInfo({
+    type: 'journals',
+    id,
+    journalId,
+    name,
+    heading: 'Calendar',
+    color: '#123456'
+  });
+
+describe('Journals source rename migration', () => {
+  it('updates every matching persisted journal name while preserving custom calendar names', () => {
+    const sources = [
+      source('journals_1', 'Work', 'Journals: Work'),
+      source('journals_2', 'Work', 'Office schedule'),
+      source('journals_3', 'Personal', 'Journals: Personal')
+    ];
+
+    expect(migrateJournalsSourceRename(sources, 'Work', 'Office')).toBe(true);
+    expect(sources).toEqual([
+      expect.objectContaining({ journalId: 'Office', name: 'Journals: Office' }),
+      expect.objectContaining({ journalId: 'Office', name: 'Office schedule' }),
+      expect.objectContaining({ journalId: 'Personal', name: 'Journals: Personal' })
+    ]);
+  });
+
+  it('is idempotent after the rename has been applied', () => {
+    const sources = [source('journals_1', 'Office', 'Journals: Office')];
+    expect(migrateJournalsSourceRename(sources, 'Work', 'Office')).toBe(false);
+    expect(sources[0]).toEqual(
+      expect.objectContaining({ journalId: 'Office', name: 'Journals: Office' })
+    );
+  });
+});


### PR DESCRIPTION
 ## Description

  Restores Journals 3.2+ compatibility using its official obsidian-journals-api while retaining legacy Journals 2.x support. Adds capability-based API
  detection, asynchronous journal CRUD, multiple Daily journal support, accurate UI states, subscription cleanup, tests, and documentation.

  ## Type of Change

  - [x] Bug fix
  - [x] Documentation