### PR TITLE
fix(cache): read bulk update state dynamically

### DIFF
--- a/src/core/EventCache.ts
+++ b/src/core/EventCache.ts
@@ -73,7 +73,7 @@ export default class EventCache {
       store: this._store,
       enhancer: this.enhancer,
       timeEngine: this.timeEngine,
-      isBulkUpdating: this.isBulkUpdating,
+      isBulkUpdating: () => this.isBulkUpdating,
       setBulkUpdating: (val: boolean) => (this.isBulkUpdating = val),
       flushUpdateQueue: this.flushUpdateQueue.bind(this),
       generateId: this.generateId.bind(this),

--- a/src/core/cache/CacheSyncHandler.ts
+++ b/src/core/cache/CacheSyncHandler.ts
@@ -11,7 +11,7 @@ export interface CacheContext {
   store: EventStore;
   enhancer: EventEnhancer;
   timeEngine: TimeEngine;
-  isBulkUpdating: boolean;
+  isBulkUpdating: () => boolean;
   setBulkUpdating: (val: boolean) => void;
   flushUpdateQueue: (toRemove: string[], toAdd: CacheEntry[], affectedCalendars?: string[]) => void;
   generateId: () => string;
@@ -27,7 +27,7 @@ export class CacheSyncHandler {
     calendarId: string,
     newRawEvents: [OFCEvent, EventLocation | null][]
   ): Promise<void> {
-    if (this.ctx.isBulkUpdating) {
+    if (this.ctx.isBulkUpdating()) {
       return;
     }
     LoadDebugProfiler.startPhase('Cache Delta Sync & Indexing');
@@ -253,7 +253,7 @@ export class CacheSyncHandler {
     file: { path: string },
     newEventsWithDetails: { event: OFCEvent; location: EventLocation | null; calendarId: string }[]
   ): Promise<void> {
-    if (this.ctx.isBulkUpdating) {
+    if (this.ctx.isBulkUpdating()) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
## Description

Changing the category of a Full Note event renames its Markdown file and can temporarily display the event twice. The duplicate remains visible until Obsidian is restarted.

This change passes `isBulkUpdating` as a function.

Related Issue: #399

## Type of Change

- [x] Bug fix (Related Issue #399)

## Code Quality Checklist (MANDATORY)

- **SOLID, DRY**:
  - [x] Reused the existing bulk-update guard instead of introducing another synchronization mechanism.
- **Internationalization (i18n)**:
  - [x] No user-facing strings were added or changed.
- **Documentation Sync**:
  - [x] Not applicable — this restores the intended behavior of an existing internal guard; no user-facing behavior or configuration was added.
- **Code Integrity & Type Safety**:
  - [x] Ran pnpm run ra locally; pass with 0 errors.
- **Test Integrity**:
  - [x] Kept all existing `.test` files untouched.
