### PR TITLE
Preview daily notes from date links

### DIFF
--- a/docs/architecture/system/features/daily-note-date-navigation.md
+++ b/docs/architecture/system/features/daily-note-date-navigation.md
@@ -1,0 +1,39 @@
+# Daily-note Date Navigation
+
+Calendar date labels are adapters between FullCalendar's rendered DOM and Obsidian's Daily
+Notes and Page Preview APIs. The implementation intentionally separates read-only note
+resolution from note creation so pointer movement cannot mutate the vault.
+
+## Data flow
+
+1. FullCalendar calls `dayHeaderDidMount` for time-grid and list headers and
+   `dayCellDidMount` for month-grid cells.
+2. `renderCalendar` selects only `.fc-col-header-cell-cushion` or
+   `.fc-daygrid-day-number`. It marks the element as bound so repeated renders cannot attach
+   duplicate listeners.
+3. A left click stops FullCalendar's selection handler and calls `openDailyNoteForDate`.
+4. `openDailyNoteForDate` resolves the note through `obsidian-daily-notes-interface`. If no
+   file exists, it calls `createDailyNote`, then opens the resulting `TFile` in the current
+   workspace leaf.
+5. A mouseover calls `getDailyNoteForDate`, which only searches the daily-note index. When a
+   file exists, the calendar emits Obsidian's `hover-link` workspace event with the date
+   element as `targetEl` and the calendar container as `hoverParent`.
+
+## Behavioral invariants
+
+- Hover resolution must never call `createDailyNote`.
+- Creation must be delegated to `obsidian-daily-notes-interface`; constructing paths in the
+  calendar would bypass folder, format, template, and Periodic Notes compatibility.
+- A missing or unloaded Daily Notes integration is a no-op, not an event-creation fallback.
+- Only date-label cushions are bound. Month cell bodies remain available to create events,
+  and right clicks remain available to date navigation.
+- Binding follows the existing opt-in `openDailyNoteOnDateClick` setting. Its default remains
+  disabled, while an explicit user choice survives settings migration.
+- Page Preview is optional. Errors from the `hover-link` integration are isolated from the
+  calendar renderer.
+
+## Test coverage
+
+`openDailyNote.test.ts` verifies existing-note opening, missing-note creation, unavailable
+plugin handling, and the non-creating resolver used by hover. Settings migration tests verify
+that the established opt-in default and an explicit enabled preference are preserved.

--- a/docs/user/calendars/dailynote.md
+++ b/docs/user/calendars/dailynote.md
@@ -75,6 +75,43 @@ In both modes, events are rendered in the Display Timezone you choose for the ca
 
 ## Navigation to Daily Notes
 
-If the **Open daily note on date click** option is enabled in **Settings → General**, you can left-click directly on date headers in Week/Day views and the day number cushion in Month view to open (or create) the corresponding daily note file.
+Enable **Open daily note on date click** in **Settings → General** to make Full Calendar's
+visible date labels act as daily-note links. This remains opt-in for compatibility with
+existing click and selection workflows.
+
+### Click behavior
+
+- In **Month** view, click the day number in the corner of a day cell.
+- In **Week**, **Day**, and **3-day** views, click the formatted column header (for example,
+  `Mon 7/9`).
+- In **List** view, click either part of a day's heading; both represent the same daily note.
+- If the daily note already exists, Full Calendar opens it in the current Obsidian leaf.
+- If it does not exist, Full Calendar asks the active Daily Notes integration to create it,
+  including the configured folder, date format, and template, and then opens the new file.
+- The date is resolved in local calendar time, so the label you click is the date that opens.
+
+This navigation uses Obsidian's **Daily Notes** core plugin or the supported **Periodic
+Notes** plugin. Enable and configure one of those prerequisites first. A Daily Note calendar
+source is not required merely to navigate from a date, although it is required if you want
+Full Calendar events stored inside the notes.
+
+### Hover preview
+
+Hovering over the same date label displays Obsidian's standard Page Preview popover when the
+daily note already exists. The popover renders the note's current contents just like links in
+Markdown and linked calendar-event notes.
+
+Hover is read-only: it never creates a file, runs a template, or modifies the vault. A date
+whose note does not exist has nothing to preview. Click it to create the note, then hover the
+date again to preview it. Obsidian's **Page Preview** core plugin must be enabled for the
+popover to appear.
+
+### Interaction boundaries
 
 Left-clicking on the main day cell body in Month view will continue to open the "Create Event" modal.
+Right-clicking a date continues to open Full Calendar's date navigation context menu. On
+mobile Month view, tapping outside the day number continues to select the day and update the
+agenda. Disabling **Open daily note on date click** removes both the click and hover behavior
+from date labels without changing those other interactions.
+
+For a complete input reference, see [Interactions and Gestures](../features/interactions.md#date-links-and-daily-notes).

--- a/docs/user/features/interactions.md
+++ b/docs/user/features/interactions.md
@@ -5,7 +5,8 @@ This page documents direct interactions in the calendar UI.
 ## Mouse and Trackpad
 
 - Click empty date/time slot: create event.
-- Click a date label or day number: open or create that day's Obsidian daily note. (Can be toggled via the **Open daily note on date click** setting under General Settings; Month view uses the day number link, and Week/Day views use the column header).
+- With **Settings → General → Open daily note on date click** enabled, click a date label or day number to open that day's Obsidian daily note, creating it from your configured daily-note template when necessary.
+- With the same option enabled, hover a date label or day number to preview an existing daily note with Obsidian's Page Preview popover. Hovering never creates a missing note.
 - Drag event: move event to a new day or time.
 - Resize event edge: change event duration.
 - Right-click event: open context actions.
@@ -34,6 +35,30 @@ This page documents direct interactions in the calendar UI.
 - Ctrl/Cmd + click event: open the associated note directly. For remote events (Google, CalDAV, Outlook, ICS) this also **creates** the linked note when none exists yet, then opens it.
 - Ctrl/Cmd + hover event: trigger note preview (requires Obsidian Page Preview support).
 - Ctrl/Cmd + mouse wheel: zoom the time axis for supported views.
+
+## Date Links and Daily Notes
+
+Calendar date links use the same Daily Notes integration as Obsidian. The filename, folder,
+date format, and template therefore come from the active **Daily Notes** core plugin or the
+supported **Periodic Notes** configuration; Full Calendar does not guess a path of its own.
+
+| Calendar surface | Interactive target | Left click | Hover |
+| --- | --- | --- | --- |
+| Month | Day number, such as `9` | Open/create the daily note | Preview it when it exists |
+| Week | Column date, such as `Mon 7/9` | Open/create the daily note | Preview it when it exists |
+| Day | Date column header | Open/create the daily note | Preview it when it exists |
+| 3-day | Each date column header | Open/create the daily note | Preview it when it exists |
+| List | Either date in each day heading | Open/create the daily note | Preview it when it exists |
+
+Only the visible date label is a daily-note link. The rest of a Month-view day cell retains
+its normal event-creation or mobile-selection behavior. Right-click also retains Full
+Calendar's date navigation menu.
+
+First enable **Open daily note on date click** in Full Calendar's General settings. Page
+Preview must also be enabled in Obsidian for hover popovers to appear. If the note does not
+exist yet, there is no content to preview and hover deliberately does nothing. Click once to
+create the note; subsequent hovers can then preview its contents. Turning off **Open daily
+note on date click** disables both navigation and preview behavior on these date labels.
 
 ## Zoom Levels
 

--- a/src/features/daily-notes/openDailyNote.test.ts
+++ b/src/features/daily-notes/openDailyNote.test.ts
@@ -8,7 +8,7 @@ import {
   getAllDailyNotes,
   getDailyNote
 } from 'obsidian-daily-notes-interface';
-import { openDailyNoteForDate } from './openDailyNote';
+import { getDailyNoteForDate, openDailyNoteForDate } from './openDailyNote';
 
 jest.mock('obsidian', () => {
   const obsidianMock: typeof import('obsidian') = jest.requireActual('../../../__mocks__/obsidian');
@@ -76,5 +76,35 @@ describe('openDailyNoteForDate', () => {
 
     expect(getDailyNoteMock).not.toHaveBeenCalled();
     expect(openFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('getDailyNoteForDate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hasDailyNotes.mockReturnValue(true);
+    getAllDailyNotesMock.mockReturnValue({});
+  });
+
+  it('returns an existing note without creating one', () => {
+    const file = new TFile();
+    getDailyNoteMock.mockReturnValue(file);
+
+    expect(getDailyNoteForDate(new Date(2026, 2, 21))).toBe(file);
+    expect(createDailyNoteMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the note does not exist', () => {
+    getDailyNoteMock.mockImplementation(() => null!);
+
+    expect(getDailyNoteForDate(new Date(2026, 2, 21))).toBeNull();
+    expect(createDailyNoteMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when Daily Notes is unavailable', () => {
+    hasDailyNotes.mockReturnValue(false);
+
+    expect(getDailyNoteForDate(new Date(2026, 2, 21))).toBeNull();
+    expect(getAllDailyNotesMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/daily-notes/openDailyNote.ts
+++ b/src/features/daily-notes/openDailyNote.ts
@@ -1,4 +1,4 @@
-import { App, moment as obsidianMoment } from 'obsidian';
+import { App, moment as obsidianMoment, TFile } from 'obsidian';
 import {
   appHasDailyNotesPluginLoaded,
   createDailyNote,
@@ -9,13 +9,27 @@ import {
 type MomentFactory = typeof import('moment');
 const moment = obsidianMoment as unknown as MomentFactory;
 
+/**
+ * Resolve an existing daily note without creating one.
+ *
+ * Keeping this separate from {@link openDailyNoteForDate} is important for hover previews:
+ * moving the pointer over a calendar date must never create a note as a side effect.
+ */
+export function getDailyNoteForDate(date: Date): TFile | null {
+  if (!appHasDailyNotesPluginLoaded()) {
+    return null;
+  }
+
+  return getDailyNote(moment(date), getAllDailyNotes()) ?? null;
+}
+
 export async function openDailyNoteForDate(app: App, date: Date): Promise<void> {
   if (!appHasDailyNotesPluginLoaded()) {
     return;
   }
 
   const day = moment(date);
-  const file = getDailyNote(day, getAllDailyNotes()) || (await createDailyNote(day));
+  const file = getDailyNote(day, getAllDailyNotes()) ?? (await createDailyNote(day));
   if (file) {
     await app.workspace.getLeaf(false).openFile(file);
   }

--- a/src/ui/settings/sections/calendars/calendar.ts
+++ b/src/ui/settings/sections/calendars/calendar.ts
@@ -32,13 +32,17 @@ import {
   type RRulePluginLike
 } from '../../../../features/timezone/Timezone';
 import { PluginState } from '../../../../core/PluginState';
+import { PLUGIN_SLUG } from '../../../../types';
 import {
   fetchWeatherForecast,
   type WeatherInfo,
   formatTempRange
 } from '../../../../features/weather/Weather';
 import { WeatherDetailModal } from '../../../../features/weather/WeatherDetailModal';
-import { openDailyNoteForDate } from '../../../../features/daily-notes/openDailyNote';
+import {
+  getDailyNoteForDate,
+  openDailyNoteForDate
+} from '../../../../features/daily-notes/openDailyNote';
 import { i18n } from '../../../../features/i18n/i18n';
 
 export interface ExtraRenderProps {
@@ -833,7 +837,7 @@ export async function renderCalendar(
     });
   };
 
-  const bindDailyNoteClick = (el: HTMLElement, date: Date, selector: string): void => {
+  const bindDailyNoteLink = (el: HTMLElement, date: Date, selector: string): void => {
     if (!PluginState.getSettings().openDailyNoteOnDateClick) {
       return;
     }
@@ -848,6 +852,25 @@ export async function renderCalendar(
       event.preventDefault();
       event.stopPropagation();
       void openDailyNoteForDate(PluginState.getPlugin().app, date);
+    });
+    dateLabel.addEventListener('mouseover', event => {
+      const file = getDailyNoteForDate(date);
+      if (!file) {
+        return;
+      }
+
+      try {
+        PluginState.getPlugin().app.workspace.trigger('hover-link', {
+          event,
+          source: PLUGIN_SLUG,
+          hoverParent: containerEl,
+          targetEl: dateLabel,
+          linktext: file.path,
+          sourcePath: file.path
+        });
+      } catch {
+        // Page Preview is optional; a preview failure must not affect date navigation.
+      }
     });
   };
 
@@ -915,7 +938,11 @@ export async function renderCalendar(
   cal = new CalendarCtor(containerEl, {
     dayHeaderDidMount: arg => {
       if (arg.view.type.startsWith('timeGrid')) {
-        bindDailyNoteClick(arg.el, arg.date, '.fc-col-header-cell-cushion');
+        bindDailyNoteLink(arg.el, arg.date, '.fc-col-header-cell-cushion');
+      } else if (arg.view.type.startsWith('list')) {
+        // List headers render the weekday and full date as separate anchors for the same day.
+        bindDailyNoteLink(arg.el, arg.date, '.fc-list-day-text');
+        bindDailyNoteLink(arg.el, arg.date, '.fc-list-day-side-text');
       }
       const pluginSettings = PluginState.getSettings();
       if (settings?.weatherHide || pluginSettings.weatherHide) {
@@ -937,7 +964,7 @@ export async function renderCalendar(
       }
     },
     dayCellDidMount: arg => {
-      bindDailyNoteClick(arg.el, arg.date, '.fc-daygrid-day-number');
+      bindDailyNoteLink(arg.el, arg.date, '.fc-daygrid-day-number');
       const pluginSettings = PluginState.getSettings();
       if (
         settings?.weatherHide ||


### PR DESCRIPTION
## Description

Adds Obsidian Page Preview support to calendar date links while preserving the existing opt-in behavior controlled by **Open daily note on date click**.

When that option is enabled:

- Hovering a date label previews the corresponding daily note if it already exists.
- Hovering never creates a note, runs a template, or modifies the vault.
- Clicking retains the existing open-or-create behavior.
- Month, Week, Day, 3-day, and List views are supported.
- Every date resolves to the corresponding daily note; no weekly or monthly notes are created.

The implementation separates read-only daily-note resolution from the existing creation path. It continues to delegate path, filename, date-format, template, Daily Notes, and Periodic Notes compatibility to `obsidian-daily-notes-interface`.

User-facing and architectural documentation has been updated with supported views, prerequisites, interaction boundaries, and compatibility guarantees.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore / maintenance

## Code Quality Checklist (MANDATORY)

*Please read and verify you have adhered to all guidelines outlined in https://github.com/obsidian-full-calendar-remastered/plugin-full-calendar/blob/main/CONTRIBUTING.md.*

- **[SOLID](https://en.wikipedia.org/wiki/SOLID), [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)**:
  - [x] Designed polymorphically where appropriate.
  - [x] Kept classes and UI views decoupled by separating read-only daily-note resolution from calendar DOM behavior.
  - [x] Shared reusable helpers instead of copying/pasting daily-note lookup logic.
- **Internationalization (i18n)**:
  - [x] No new user-facing UI strings, headers, labels, or placeholders were introduced.
- **Documentation Sync**:
  - [x] Updated corresponding architectural documentation under `docs/architecture/`.
  - [x] Updated corresponding user-facing documentation under `docs/user/`.
  - [x] Adhered to the hyperlinked, compact, table-based concise formatting style.
- **Code Integrity & Type Safety**:
  - [ ] Ran `pnpm run ra` locally and confirmed that compilation, ESLint, i18n checks, and all Jest tests pass with 0 errors.
- **Test Integrity**:
  - [ ] Kept all existing `.test` files completely untouched.
  - [x] Added unit tests covering read-only resolution, missing notes, and unavailable Daily Notes integrations.

## Validation Performed

- TypeScript compilation passed.
- ESLint passed for all changed TypeScript files.
- Prettier and whitespace checks passed.
- Focused daily-note and settings regression tests passed: 11/11.

The full `pnpm run ra` suite has not been run, so its checklist item is intentionally left unchecked. The existing daily-note test file was extended with regression coverage, so the “existing test files untouched” item is also intentionally left unchecked.